### PR TITLE
feat: implement missing geometry/entity transforms and expand transform regression coverage

### DIFF
--- a/packages/data-model/__tests__/AcDbEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntity.spec.ts
@@ -1,16 +1,80 @@
-import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint2d,
+  AcGePoint3d,
+  AcGePolyline2d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
 
 import { AcDb2dPolyline, AcDbPoly2dType } from '../src/entity/AcDb2dPolyline'
 import { AcDb2dVertex } from '../src/entity/AcDb2dVertex'
+import { AcDbArc } from '../src/entity/AcDbArc'
+import { AcDbAttribute } from '../src/entity/AcDbAttribute'
+import { AcDbAttributeDefinition } from '../src/entity/AcDbAttributeDefinition'
 import { AcDb3PointAngularDimension } from '../src/entity/dimension/AcDb3PointAngularDimension'
+import { AcDbAlignedDimension } from '../src/entity/dimension/AcDbAlignedDimension'
+import { AcDbArcDimension } from '../src/entity/dimension/AcDbArcDimension'
 import { AcDb3dPolyline, AcDbPoly3dType } from '../src/entity/AcDb3dPolyline'
 import { AcDb3dVertex } from '../src/entity/AcDb3dVertex'
 import { AcDbBlockReference } from '../src/entity/AcDbBlockReference'
+import { AcDbCircle } from '../src/entity/AcDbCircle'
+import { AcDbEntity } from '../src/entity/AcDbEntity'
 import { AcDbFace } from '../src/entity/AcDbFace'
+import { AcDbHatch } from '../src/entity/AcDbHatch'
+import { AcDbLine } from '../src/entity/AcDbLine'
+import { AcDbMText } from '../src/entity/AcDbMText'
+import { AcDbOrdinateDimension } from '../src/entity/dimension/AcDbOrdinateDimension'
+import { AcDbPolyFaceMesh } from '../src/entity/AcDbPolyFaceMesh'
+import { AcDbPolygonMesh } from '../src/entity/AcDbPolygonMesh'
+import { AcDbPoint } from '../src/entity/AcDbPoint'
 import { AcDbPolyline } from '../src/entity/AcDbPolyline'
 import { AcDbRasterImage } from '../src/entity/AcDbRasterImage'
+import { AcDbRadialDimension } from '../src/entity/dimension/AcDbRadialDimension'
 import { AcDbTable } from '../src/entity/AcDbTable'
 import { AcDbText } from '../src/entity/AcDbText'
+import { AcDbTrace } from '../src/entity/AcDbTrace'
+import { AcDbViewport } from '../src/entity/AcDbViewport'
+import { AcDbWipeout } from '../src/entity/AcDbWipeout'
+import { AcDbEllipse } from '../src/entity/AcDbEllipse'
+import { AcDbLeader } from '../src/entity/AcDbLeader'
+import { AcDbRay } from '../src/entity/AcDbRay'
+import { AcDbSpline } from '../src/entity/AcDbSpline'
+import { AcDbDiametricDimension } from '../src/entity/dimension/AcDbDiametricDimension'
+import { AcDbXline } from '../src/entity/AcDbXline'
+import { AcDbOsnapMode } from '../src/misc'
+
+const expectPoint3dClose = (
+  actual: { x: number; y: number; z: number },
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(actual.x).toBeCloseTo(expected.x, 8)
+  expect(actual.y).toBeCloseTo(expected.y, 8)
+  expect(actual.z).toBeCloseTo(expected.z, 8)
+}
+
+const expectVector3dClose = (
+  actual: { x: number; y: number; z: number },
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(actual.x).toBeCloseTo(expected.x, 8)
+  expect(actual.y).toBeCloseTo(expected.y, 8)
+  expect(actual.z).toBeCloseTo(expected.z, 8)
+}
+
+class DummyEntity extends AcDbEntity {
+  override get dxfTypeName() {
+    return 'DUMMY'
+  }
+
+  override get geometricExtents() {
+    return new AcGeBox3d().expandByPoint(new AcGePoint3d())
+  }
+
+  override subWorldDraw() {
+    return undefined
+  }
+}
 
 describe('AcDbEntity.dxfTypeName', () => {
   it('uses explicit DXF type names defined by each entity', () => {
@@ -36,5 +100,576 @@ describe('AcDbEntity.dxfTypeName', () => {
         new AcGePoint3d(1, 1, 0)
       ).dxfTypeName
     ).toBe('DIMENSION')
+  })
+})
+
+describe('AcDbEntity.transformBy', () => {
+  it('keeps point-like entities aligned across matrix families', () => {
+    const cases = [
+      {
+        name: 'translation',
+        matrix: new AcGeMatrix3d().makeTranslation(3, 4, 5)
+      },
+      {
+        name: 'rotation',
+        matrix: new AcGeMatrix3d().makeRotationZ(Math.PI / 2)
+      },
+      {
+        name: 'mirror',
+        matrix: new AcGeMatrix3d().makeScale(-1, 1, 1)
+      },
+      {
+        name: 'non-uniform-scale',
+        matrix: new AcGeMatrix3d().makeScale(2, 3, 4)
+      }
+    ]
+
+    cases.forEach(({ name, matrix }) => {
+      const source = new AcGePoint3d(1, 2, 3)
+
+      const point = new AcDbPoint()
+      point.position = source.clone()
+      point.transformBy(matrix)
+
+      const vertex2d = new AcDb2dVertex()
+      vertex2d.position = source.clone()
+      vertex2d.transformBy(matrix)
+
+      const vertex3d = new AcDb3dVertex()
+      vertex3d.position = source.clone()
+      vertex3d.transformBy(matrix)
+
+      const expected = source.clone().applyMatrix4(matrix)
+      expectPoint3dClose(point.position, expected)
+      expectPoint3dClose(vertex2d.position, expected)
+      expectPoint3dClose(vertex3d.position, expected)
+      expect(name).toBeTruthy()
+    })
+  })
+
+  it('keeps the base AcDbEntity transformBy as a no-op', () => {
+    const entity = new DummyEntity()
+    const result = entity.transformBy(
+      new AcGeMatrix3d().makeTranslation(1, 2, 3)
+    )
+
+    expect(result).toBe(entity)
+    expect(entity.geometricExtents.min.x).toBe(0)
+  })
+
+  it('transforms lightweight and legacy polylines', () => {
+    const lwPolyline = new AcDbPolyline()
+    lwPolyline.elevation = 1
+    lwPolyline.addVertexAt(0, new AcGePoint2d(0, 0), 1)
+    lwPolyline.addVertexAt(1, new AcGePoint2d(2, 0))
+
+    lwPolyline.transformBy(new AcGeMatrix3d().makeTranslation(3, 4, 5))
+
+    expect(lwPolyline.elevation).toBeCloseTo(6, 8)
+    expect(lwPolyline.getPoint3dAt(0)).toMatchObject({ x: 3, y: 4, z: 6 })
+    expect(lwPolyline.getPoint3dAt(1)).toMatchObject({ x: 5, y: 4, z: 6 })
+
+    const legacyPolyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 }
+      ],
+      2
+    )
+    legacyPolyline.transformBy(new AcGeMatrix3d().makeTranslation(-1, 2, 3))
+
+    expect(legacyPolyline.elevation).toBeCloseTo(5, 8)
+    expect(legacyPolyline.getPointAt(0)).toMatchObject({ x: -1, y: 2 })
+    expect(legacyPolyline.getPointAt(1)).toMatchObject({ x: 0, y: 2 })
+  })
+
+  it('transforms primitive entities and vertex entities', () => {
+    const point = new AcDbPoint()
+    point.position = new AcGePoint3d(1, 2, 3)
+    point.transformBy(new AcGeMatrix3d().makeTranslation(4, -1, 2))
+    expectPoint3dClose(point.position, { x: 5, y: 1, z: 5 })
+
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 2, 3)
+    )
+    line.transformBy(new AcGeMatrix3d().makeTranslation(2, 3, 4))
+    expectPoint3dClose(line.startPoint, { x: 2, y: 3, z: 4 })
+    expectPoint3dClose(line.endPoint, { x: 3, y: 5, z: 7 })
+
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 2, 0, Math.PI / 2)
+    arc.transformBy(new AcGeMatrix3d().makeTranslation(1, 2, 3))
+    expectPoint3dClose(arc.center, { x: 1, y: 2, z: 3 })
+    expectPoint3dClose(arc.startPoint, { x: 3, y: 2, z: 3 })
+
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 3)
+    circle.transformBy(new AcGeMatrix3d().makeTranslation(-2, 4, 1))
+    expectPoint3dClose(circle.center, { x: -2, y: 4, z: 1 })
+    expect(circle.radius).toBeCloseTo(3, 8)
+
+    const vertex2d = new AcDb2dVertex()
+    vertex2d.position = new AcGePoint3d(1, 1, 0)
+    vertex2d.transformBy(new AcGeMatrix3d().makeTranslation(3, 4, 5))
+    expectPoint3dClose(vertex2d.position, { x: 4, y: 5, z: 5 })
+
+    const vertex3d = new AcDb3dVertex()
+    vertex3d.position = new AcGePoint3d(1, 1, 1)
+    vertex3d.transformBy(new AcGeMatrix3d().makeTranslation(-1, 2, -3))
+    expectPoint3dClose(vertex3d.position, { x: 0, y: 3, z: -2 })
+  })
+
+  it('keeps line-like entities aligned across translation rotation and mirror', () => {
+    const cases = [
+      new AcGeMatrix3d().makeTranslation(4, -1, 2),
+      new AcGeMatrix3d().makeRotationZ(Math.PI / 2),
+      new AcGeMatrix3d().makeScale(-1, 1, 1)
+    ]
+
+    cases.forEach(matrix => {
+      const start = new AcGePoint3d(1, 2, 3)
+      const end = new AcGePoint3d(4, 5, 6)
+
+      const line = new AcDbLine(start.clone(), end.clone())
+      line.transformBy(matrix)
+      expectPoint3dClose(line.startPoint, start.clone().applyMatrix4(matrix))
+      expectPoint3dClose(line.endPoint, end.clone().applyMatrix4(matrix))
+
+      const ray = new AcDbRay()
+      ray.basePoint = start.clone()
+      ray.unitDir = new AcGePoint3d(1, 0, 0)
+      ray.transformBy(matrix)
+      expectPoint3dClose(ray.basePoint, start.clone().applyMatrix4(matrix))
+      expect(ray.unitDir.length()).toBeCloseTo(1, 8)
+
+      const xline = new AcDbXline()
+      xline.basePoint = start.clone()
+      xline.unitDir = new AcGePoint3d(1, 0, 0)
+      xline.transformBy(matrix)
+      expectPoint3dClose(xline.basePoint, start.clone().applyMatrix4(matrix))
+      expect(xline.unitDir.length()).toBeCloseTo(1, 8)
+    })
+  })
+
+  it('keeps polyline entities aligned across rotation and mirror transforms', () => {
+    const cases = [
+      {
+        matrix: new AcGeMatrix3d().makeRotationZ(Math.PI / 2),
+        expectedBulge: 1
+      },
+      {
+        matrix: new AcGeMatrix3d().makeScale(-1, 1, 1),
+        expectedBulge: -1
+      }
+    ]
+
+    cases.forEach(({ matrix, expectedBulge }) => {
+      const lwPolyline = new AcDbPolyline()
+      lwPolyline.addVertexAt(0, new AcGePoint2d(0, 0), 1)
+      lwPolyline.addVertexAt(1, new AcGePoint2d(2, 0))
+      lwPolyline.transformBy(matrix)
+      expect(
+        (
+          lwPolyline as unknown as {
+            _geo: { vertices: Array<{ bulge?: number }> }
+          }
+        )._geo.vertices[0].bulge
+      ).toBe(expectedBulge)
+
+      const legacyPolyline = new AcDb2dPolyline(
+        AcDbPoly2dType.SimplePoly,
+        [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 }
+        ],
+        0,
+        false,
+        0,
+        0,
+        [1, 0]
+      )
+      legacyPolyline.transformBy(matrix)
+      expect(legacyPolyline.getBulgeAt(0)).toBe(expectedBulge)
+
+      const polyline3d = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 2, z: 3 }
+      ])
+      polyline3d.transformBy(matrix)
+      expectPoint3dClose(
+        polyline3d.getPointAt(1),
+        new AcGePoint3d(1, 2, 3).applyMatrix4(matrix)
+      )
+    })
+  })
+
+  it('transforms 3d polylines, splines, ellipses, leaders and infinite lines', () => {
+    const polyline3d = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1 }
+    ])
+    polyline3d.transformBy(new AcGeMatrix3d().makeTranslation(4, -2, 3))
+    expect(polyline3d.getPointAt(1)).toMatchObject({ x: 5, y: -1, z: 4 })
+
+    const spline = new AcDbSpline(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 2, y: 0, z: 0 },
+        { x: 3, y: 1, z: 0 }
+      ],
+      [0, 0, 0, 0, 1, 1, 1, 1]
+    )
+    const splineSnapPoints: AcGePoint3d[] = []
+    spline.transformBy(new AcGeMatrix3d().makeTranslation(2, 3, 4))
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      splineSnapPoints
+    )
+    expect(splineSnapPoints[0]).toMatchObject({ x: 2, y: 3, z: 4 })
+
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      4,
+      2,
+      0,
+      Math.PI / 2
+    )
+    ellipse.transformBy(new AcGeMatrix3d().makeTranslation(1, 2, 3))
+    expect(ellipse.center).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    const leader = new AcDbLeader()
+    leader.appendVertex({ x: 0, y: 0, z: 0 })
+    leader.appendVertex({ x: 1, y: 0, z: 0 })
+    leader.transformBy(new AcGeMatrix3d().makeTranslation(5, 6, 7))
+    expect(leader.vertices[0]).toMatchObject({ x: 5, y: 6, z: 7 })
+    expect(leader.vertices[1]).toMatchObject({ x: 6, y: 6, z: 7 })
+
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(1, 0, 0)
+    ray.unitDir = new AcGePoint3d(1, 0, 0)
+    ray.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expect(ray.basePoint.x).toBeCloseTo(0, 8)
+    expect(ray.basePoint.y).toBeCloseTo(1, 8)
+    expect(ray.unitDir.x).toBeCloseTo(0, 8)
+    expect(ray.unitDir.y).toBeCloseTo(1, 8)
+
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(2, 0, 0)
+    xline.unitDir = new AcGePoint3d(1, 0, 0)
+    xline.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expectPoint3dClose(xline.basePoint, { x: 0, y: 2, z: 0 })
+    expectVector3dClose(xline.unitDir, { x: 0, y: 1, z: 0 })
+
+    const blockRef = new AcDbBlockReference('TEST')
+    blockRef.position = new AcGePoint3d(1, 0, 0)
+    blockRef.scaleFactors = new AcGePoint3d(2, 3, 1)
+    const attrib = new AcDbAttribute()
+    attrib.position = new AcGePoint3d(2, 0, 0)
+    blockRef.appendAttributes(attrib)
+    blockRef.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expect(blockRef.position.x).toBeCloseTo(0, 8)
+    expect(blockRef.position.y).toBeCloseTo(1, 8)
+    expect(blockRef.rotation).toBeCloseTo(Math.PI / 2, 8)
+    expect(blockRef.scaleFactors.x).toBeCloseTo(2, 8)
+    expect(blockRef.scaleFactors.y).toBeCloseTo(3, 8)
+    expectPoint3dClose(attrib.position, { x: 0, y: 2, z: 0 })
+  })
+
+  it('transforms block references correctly under combined rotation and scaling', () => {
+    const blockRef = new AcDbBlockReference('TEST')
+    blockRef.position = new AcGePoint3d(2, 1, 0)
+    blockRef.rotation = Math.PI / 4
+    blockRef.scaleFactors = new AcGePoint3d(2, 1, 3)
+
+    blockRef.transformBy(
+      new AcGeMatrix3d()
+        .makeRotationZ(Math.PI / 2)
+        .multiply(new AcGeMatrix3d().makeScale(2, 3, 4))
+    )
+
+    expectPoint3dClose(blockRef.position, { x: -3, y: 4, z: 0 })
+    expect(blockRef.rotation).toBeCloseTo(Math.atan2(2, -3), 8)
+    expect(blockRef.scaleFactors.x).toBeCloseTo(Math.sqrt(26), 8)
+    expect(blockRef.scaleFactors.y).toBeCloseTo(Math.sqrt(6.5), 8)
+    expect(blockRef.scaleFactors.z).toBeCloseTo(12, 8)
+  })
+
+  it('transforms text-like, hatch-like and mesh entities', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(0, 0, 0)
+    text.height = 2
+    text.widthFactor = 1
+    text.thickness = 1
+    text.transformBy(new AcGeMatrix3d().makeScale(2, 3, 4))
+    expect(text.height).toBeCloseTo(6, 8)
+    expect(text.widthFactor).toBeCloseTo(2 / 3, 8)
+    expect(text.thickness).toBeCloseTo(4, 8)
+
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(1, 0, 0)
+    mtext.direction = new AcGeVector3d(1, 0, 0)
+    mtext.width = 10
+    mtext.height = 2
+    mtext.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expect(mtext.location.x).toBeCloseTo(0, 8)
+    expect(mtext.location.y).toBeCloseTo(1, 8)
+    expect(mtext.direction.x).toBeCloseTo(0, 8)
+    expect(mtext.direction.y).toBeCloseTo(1, 8)
+
+    const hatch = new AcDbHatch()
+    hatch.elevation = 1
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0 },
+          { x: 2, y: 0 },
+          { x: 2, y: 2 },
+          { x: 0, y: 2 }
+        ],
+        true
+      )
+    )
+    hatch.transformBy(new AcGeMatrix3d().makeTranslation(5, 6, 7))
+    expect(hatch.elevation).toBeCloseTo(8, 8)
+    expect(hatch.geometricExtents.min).toMatchObject({ x: 5, y: 6, z: 8 })
+
+    const rasterImage = new AcDbRasterImage()
+    rasterImage.position = new AcGePoint3d(1, 0, 0)
+    rasterImage.width = 2
+    rasterImage.height = 1
+    rasterImage.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expect(rasterImage.position.x).toBeCloseTo(0, 8)
+    expect(rasterImage.position.y).toBeCloseTo(1, 8)
+    expect(rasterImage.rotation).toBeCloseTo(Math.PI / 2, 8)
+
+    const viewport = new AcDbViewport()
+    viewport.centerPoint = new AcGePoint3d(1, 2, 0)
+    viewport.width = 2
+    viewport.height = 4
+    viewport.viewHeight = 10
+    viewport.transformBy(new AcGeMatrix3d().makeScale(2, 3, 1))
+    expect(viewport.centerPoint).toMatchObject({ x: 2, y: 6, z: 0 })
+    expect(viewport.width).toBeCloseTo(4, 8)
+    expect(viewport.height).toBeCloseTo(12, 8)
+    expect(viewport.viewHeight).toBeCloseTo(30, 8)
+
+    const polyFace = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 }
+      ],
+      [[1, 2, 3]]
+    )
+    polyFace.transformBy(new AcGeMatrix3d().makeTranslation(1, 2, 3))
+    expect(polyFace.getVertexAt(0).position).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    const polygonMesh = new AcDbPolygonMesh(1, 2, [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1 }
+    ])
+    polygonMesh.transformBy(new AcGeMatrix3d().makeTranslation(-1, -2, -3))
+    expect(polygonMesh.getVertexAt(1).position).toMatchObject({
+      x: 0,
+      y: -1,
+      z: -2
+    })
+  })
+
+  it('updates text, mtext, hatch, raster image and viewport under combined transforms', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(1, 0, 0)
+    text.rotation = 0
+    text.height = 2
+    text.widthFactor = 1
+    text.transformBy(
+      new AcGeMatrix3d()
+        .makeRotationZ(Math.PI / 2)
+        .multiply(new AcGeMatrix3d().makeScale(2, 3, 1))
+    )
+    expectPoint3dClose(text.position, { x: 0, y: 2, z: 0 })
+    expect(text.rotation).toBeCloseTo(Math.PI / 2, 8)
+    expect(text.height).toBeCloseTo(6, 8)
+    expect(text.widthFactor).toBeCloseTo(2 / 3, 8)
+
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(2, 0, 0)
+    mtext.direction = new AcGeVector3d(1, 0, 0)
+    mtext.width = 5
+    mtext.height = 2
+    mtext.transformBy(new AcGeMatrix3d().makeScale(2, 3, 1))
+    expectPoint3dClose(mtext.location, { x: 4, y: 0, z: 0 })
+    expectVector3dClose(mtext.direction, { x: 1, y: 0, z: 0 })
+    expect(mtext.width).toBeCloseTo(10, 8)
+    expect(mtext.height).toBeCloseTo(6, 8)
+
+    const hatch = new AcDbHatch()
+    hatch.patternAngle = Math.PI / 6
+    hatch.patternScale = 2
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 1, y: 1 },
+          { x: 0, y: 1 }
+        ],
+        true
+      )
+    )
+    hatch.transformBy(new AcGeMatrix3d().makeScale(3, 2, 1))
+    expect(hatch.patternAngle).toBeCloseTo(Math.PI / 6, 8)
+    expect(hatch.patternScale).toBeCloseTo(6, 8)
+
+    const rasterImage = new AcDbRasterImage()
+    rasterImage.position = new AcGePoint3d(1, 0, 0)
+    rasterImage.width = 2
+    rasterImage.height = 3
+    rasterImage.scale = new AcGePoint2d(2, 3) as never
+    rasterImage.rotation = 0
+    rasterImage.transformBy(new AcGeMatrix3d().makeScale(2, 4, 1))
+    expectPoint3dClose(rasterImage.position, { x: 2, y: 0, z: 0 })
+    expect(rasterImage.width).toBeCloseTo(8, 8)
+    expect(rasterImage.height).toBeCloseTo(36, 8)
+
+    const viewport = new AcDbViewport()
+    viewport.centerPoint = new AcGePoint3d(1, 1, 0)
+    viewport.width = 2
+    viewport.height = 3
+    viewport.viewHeight = 4
+    viewport.transformBy(
+      new AcGeMatrix3d()
+        .makeRotationZ(Math.PI / 2)
+        .multiply(new AcGeMatrix3d().makeScale(2, 5, 1))
+    )
+    expectPoint3dClose(viewport.centerPoint, { x: -5, y: 2, z: 0 })
+    expect(viewport.width).toBeCloseTo(4, 8)
+    expect(viewport.height).toBeCloseTo(15, 8)
+    expect(viewport.viewHeight).toBeCloseTo(20, 8)
+  })
+
+  it('transforms face and trace entities', () => {
+    const face = new AcDbFace()
+    face.setVertexAt(0, new AcGePoint3d(0, 0, 0))
+    face.setVertexAt(1, new AcGePoint3d(1, 0, 0))
+    face.setVertexAt(2, new AcGePoint3d(0, 1, 0))
+    face.transformBy(new AcGeMatrix3d().makeTranslation(2, 3, 4))
+    expectPoint3dClose(face.getVertexAt(0), { x: 2, y: 3, z: 4 })
+    expectPoint3dClose(face.getVertexAt(2), { x: 2, y: 4, z: 4 })
+
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, new AcGePoint3d(0, 0, 0))
+    trace.setPointAt(1, new AcGePoint3d(1, 0, 0))
+    trace.setPointAt(2, new AcGePoint3d(1, 1, 0))
+    trace.setPointAt(3, new AcGePoint3d(0, 1, 0))
+    trace.transformBy(new AcGeMatrix3d().makeTranslation(-1, 2, 5))
+    expectPoint3dClose(trace.getPointAt(0), { x: -1, y: 2, z: 5 })
+    expect(trace.elevation).toBeCloseTo(5, 8)
+  })
+
+  it('transforms inherited text, raster and block-reference entity kinds', () => {
+    const attribute = new AcDbAttribute()
+    attribute.position = new AcGePoint3d(0, 0, 0)
+    attribute.height = 1
+    attribute.transformBy(new AcGeMatrix3d().makeScale(2, 3, 1))
+    expect(attribute.height).toBeCloseTo(3, 8)
+
+    const attributeDefinition = new AcDbAttributeDefinition()
+    attributeDefinition.position = new AcGePoint3d(1, 1, 0)
+    attributeDefinition.transformBy(new AcGeMatrix3d().makeTranslation(2, 4, 6))
+    expectPoint3dClose(attributeDefinition.position, { x: 3, y: 5, z: 6 })
+
+    const wipeout = new AcDbWipeout()
+    wipeout.position = new AcGePoint3d(1, 0, 0)
+    wipeout.width = 4
+    wipeout.height = 2
+    wipeout.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expectPoint3dClose(wipeout.position, { x: 0, y: 1, z: 0 })
+    expect(wipeout.rotation).toBeCloseTo(Math.PI / 2, 8)
+
+    const table = new AcDbTable('TEST', 1, 1)
+    table.position = new AcGePoint3d(2, 0, 0)
+    table.scaleFactors = new AcGePoint3d(1, 2, 1)
+    table.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    expectPoint3dClose(table.position, { x: 0, y: 2, z: 0 })
+    expect(table.rotation).toBeCloseTo(Math.PI / 2, 8)
+    expect(table.scaleFactors.y).toBeCloseTo(2, 8)
+  })
+
+  it('transforms dimension entities through base and subclass definition points', () => {
+    const dimension = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(2, 0, 0),
+      new AcGePoint3d(1, 1, 0)
+    )
+    dimension.dimBlockPosition = new AcGePoint3d(1, 2, 3)
+    dimension.textPosition = new AcGePoint3d(2, 0, 0)
+    dimension.textRotation = 0
+    dimension.normal = AcGeVector3d.Z_AXIS
+    dimension.transformBy(
+      new AcGeMatrix3d()
+        .makeRotationZ(Math.PI / 2)
+        .multiply(new AcGeMatrix3d().makeTranslation(3, 4, 5))
+    )
+
+    expectPoint3dClose(dimension.xLine1Point, { x: -4, y: 3, z: 5 })
+    expectPoint3dClose(dimension.xLine2Point, { x: -4, y: 5, z: 5 })
+    expectPoint3dClose(dimension.dimLinePoint, { x: -5, y: 4, z: 5 })
+    expectPoint3dClose(dimension.dimBlockPosition, { x: -6, y: 4, z: 8 })
+    expectPoint3dClose(dimension.textPosition, { x: -4, y: 5, z: 5 })
+    expect(dimension.textRotation).toBeCloseTo(Math.PI / 2, 8)
+
+    const angularDimension = new AcDb3PointAngularDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(0, 1, 0),
+      new AcGePoint3d(1, 1, 0)
+    )
+    angularDimension.transformBy(new AcGeMatrix3d().makeTranslation(1, 2, 3))
+    expectPoint3dClose(angularDimension.centerPoint, { x: 1, y: 2, z: 3 })
+    expectPoint3dClose(angularDimension.arcPoint, { x: 2, y: 3, z: 3 })
+
+    const arcDimension = new AcDbArcDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(0, 1, 0),
+      new AcGePoint3d(1, 1, 0)
+    )
+    arcDimension.transformBy(new AcGeMatrix3d().makeTranslation(2, 3, 4))
+    expectPoint3dClose(arcDimension.centerPoint, { x: 2, y: 3, z: 4 })
+    expectPoint3dClose(arcDimension.arcPoint, { x: 3, y: 4, z: 4 })
+
+    const diametricDimension = new AcDbDiametricDimension(
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(-1, 0, 0),
+      2
+    )
+    diametricDimension.transformBy(new AcGeMatrix3d().makeTranslation(5, 6, 7))
+    expectPoint3dClose(diametricDimension.chordPoint, { x: 6, y: 6, z: 7 })
+    expectPoint3dClose(diametricDimension.farChordPoint, { x: 4, y: 6, z: 7 })
+
+    const ordinateDimension = new AcDbOrdinateDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 2, 3)
+    )
+    ordinateDimension.transformBy(
+      new AcGeMatrix3d().makeTranslation(-1, -2, -3)
+    )
+    expectPoint3dClose(ordinateDimension.definingPoint, { x: -1, y: -2, z: -3 })
+    expectPoint3dClose(ordinateDimension.leaderEndPoint, { x: 0, y: 0, z: 0 })
+
+    const radialDimension = new AcDbRadialDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(2, 0, 0),
+      1
+    )
+    radialDimension.transformBy(new AcGeMatrix3d().makeTranslation(7, 8, 9))
+    expectPoint3dClose(radialDimension.center, { x: 7, y: 8, z: 9 })
+    expectPoint3dClose(radialDimension.chordPoint, { x: 9, y: 8, z: 9 })
   })
 })

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -33,9 +33,9 @@ export const AcDbSystemVariables = {
   CLAYER: 'CLAYER',
   /** UI color theme selector used by the application shell or viewer integration. */
   COLORTHEME: 'COLORTHEME',
-  /** 
-   * Controls the display and behavior of dynamic input at the cursor, enabling or 
-   * disabling on-screen pointer and dimension input 
+  /**
+   * Controls the display and behavior of dynamic input at the cursor, enabling or
+   * disabling on-screen pointer and dimension input
    */
   DYNMODE: 'DYNMODE',
   /** Controls display of prompts in Dynamic Input tooltips. */

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
@@ -257,6 +258,34 @@ export class AcDb2dPolyline extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this legacy 2D polyline by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const flipBulge = matrix.determinant() < 0
+    let elevation = this._elevation
+
+    this._geo.vertices.forEach(vertex => {
+      const transformedPoint = new AcGePoint3d(
+        vertex.x,
+        vertex.y,
+        this._elevation
+      ).applyMatrix4(matrix)
+      vertex.x = transformedPoint.x
+      vertex.y = transformedPoint.y
+      elevation = transformedPoint.z
+      if (flipBulge && vertex.bulge != null) {
+        vertex.bulge = -vertex.bulge
+      }
+    })
+
+    this._elevation = elevation
+    ;(this._geo as AcGePolyline2d<AcGePolyline2dVertex> & {
+      _boundingBoxNeedsUpdate: boolean
+    })._boundingBoxNeedsUpdate = true
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
@@ -114,7 +115,9 @@ export class AcDb3dPolyline extends AcDbCurve {
   }
 
   getPointAt(index: number) {
-    return this._geo.getPointAt(index)
+    const vertex = this._geo.vertices[index] as AcGePolyline2dVertex &
+      AcGePoint3dLike
+    return new AcGePoint3d(vertex.x, vertex.y, vertex.z || 0)
   }
 
   /**
@@ -129,12 +132,11 @@ export class AcDb3dPolyline extends AcDbCurve {
    * ```
    */
   get geometricExtents(): AcGeBox3d {
-    const box = this._geo.box
-    // TODO: Set the correct z value for 3d box
-    return new AcGeBox3d(
-      { x: box.min.x, y: box.min.y, z: 0 },
-      { x: box.max.x, y: box.max.y, z: 0 }
+    const points = this._geo.vertices.map(
+      vertex =>
+        new AcGePoint3d(vertex.x, vertex.y, (vertex as AcGePoint3dLike).z || 0)
     )
+    return new AcGeBox3d().setFromPoints(points)
   }
 
   /**
@@ -176,14 +178,34 @@ export class AcDb3dPolyline extends AcDbCurve {
       case AcDbOsnapMode.EndPoint:
         {
           for (let i = 0; i < this._geo.numberOfVertices; ++i) {
-            const temp = this._geo.getPointAt(i)
-            snapPoints.push(new AcGePoint3d(temp.x, temp.y, 0))
+            snapPoints.push(this.getPointAt(i))
           }
         }
         break
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this 3D polyline by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._geo.vertices.forEach(vertex => {
+      const transformedPoint = new AcGePoint3d(
+        vertex.x,
+        vertex.y,
+        (vertex as AcGePoint3dLike).z || 0
+      ).applyMatrix4(matrix)
+      vertex.x = transformedPoint.x
+      vertex.y = transformedPoint.y
+      ;(vertex as AcGePoint3dLike).z = transformedPoint.z
+    })
+
+    ;(this._geo as AcGePolyline2d<AcGePolyline2dVertex> & {
+      _boundingBoxNeedsUpdate: boolean
+    })._boundingBoxNeedsUpdate = true
+    return this
   }
 
   /**
@@ -267,11 +289,9 @@ export class AcDb3dPolyline extends AcDbCurve {
    * @returns The rendered polyline entity, or undefined if drawing failed
    */
   subWorldDraw(renderer: AcGiRenderer) {
-    const points: AcGePoint3d[] = []
-    const tmp = this._geo.getPoints(100)
-    // TODO: Set the correct z value
-    tmp.forEach(point =>
-      points.push(new AcGePoint3d().set(point.x, point.y, 0))
+    const points = this._geo.vertices.map(
+      vertex =>
+        new AcGePoint3d(vertex.x, vertex.y, (vertex as AcGePoint3dLike).z || 0)
     )
     return renderer.lines(points)
   }
@@ -305,7 +325,7 @@ export class AcDb3dPolyline extends AcDbCurve {
       filer.writePoint3d(10, {
         x: point.x,
         y: point.y,
-        z: 0
+        z: point.z
       })
       filer.writeInt16(70, 32)
     }

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -422,6 +422,54 @@ export class AcDbBlockReference extends AcDbEntity {
   }
 
   /**
+   * Transforms this block reference by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const extrusion = new AcGeMatrix3d().setFromExtrusionDirection(this._normal)
+    const rotation = new AcGeMatrix3d().makeRotationZ(this._rotation)
+    const localToWcs = new AcGeMatrix3d().multiplyMatrices(extrusion, rotation)
+
+    const origin = this._position.clone()
+    const xAxisPoint = new AcGePoint3d(this._scaleFactors.x, 0, 0)
+      .applyMatrix4(localToWcs)
+      .add(origin)
+    const yAxisPoint = new AcGePoint3d(0, this._scaleFactors.y, 0)
+      .applyMatrix4(localToWcs)
+      .add(origin)
+    const zAxisPoint = new AcGePoint3d(0, 0, this._scaleFactors.z)
+      .applyMatrix4(localToWcs)
+      .add(origin)
+
+    origin.applyMatrix4(matrix)
+    xAxisPoint.applyMatrix4(matrix)
+    yAxisPoint.applyMatrix4(matrix)
+    zAxisPoint.applyMatrix4(matrix)
+
+    const xAxis = new AcGeVector3d(xAxisPoint).sub(origin)
+    const yAxis = new AcGeVector3d(yAxisPoint).sub(origin)
+    const zAxis = new AcGeVector3d(zAxisPoint).sub(origin)
+
+    let normal = new AcGeVector3d().crossVectors(xAxis, yAxis)
+    if (normal.lengthSq() === 0) {
+      normal = this._normal.clone().transformDirection(matrix)
+    } else {
+      normal.normalize()
+    }
+
+    const extrusionMatrix = new AcGeMatrix3d().setFromExtrusionDirection(normal)
+    const ocsInverse = extrusionMatrix.clone().invert()
+    const localXAxis = xAxis.clone().applyMatrix4(ocsInverse)
+
+    this._position.copy(origin)
+    this._normal.copy(normal)
+    this._rotation = Math.atan2(localXAxis.y, localXAxis.x)
+    this._scaleFactors.set(xAxis.length(), yAxis.length(), zAxis.length())
+
+    this._attribs.forEach(attrib => attrib.transformBy(matrix))
+    return this
+  }
+
+  /**
    * Returns the full property definition for this block reference entity, including
    * general group and geometry group.
    *

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -1,5 +1,6 @@
 import {
   AcGeEllipseArc3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
@@ -354,6 +355,14 @@ export class AcDbEllipse extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this ellipse by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._geo.transform(matrix)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike
@@ -211,6 +212,14 @@ export class AcDbFace extends AcDbEntity {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this face by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._vertices.forEach(vertex => vertex.applyMatrix4(matrix))
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -7,7 +7,10 @@ import {
   AcGeLine2d,
   AcGeLoop2d,
   AcGeLoop2dType,
+  AcGeMatrix2d,
+  AcGeMatrix3d,
   AcGePoint2d,
+  AcGePoint3d,
   AcGePolyline2d,
   AcGeSpline3d
 } from '@mlightcad/geometry-engine'
@@ -427,6 +430,37 @@ export class AcDbHatch extends AcDbEntity {
     }
     const entities = areas.map(area => renderer.area(area))
     return renderer.group(entities)
+  }
+
+  /**
+   * Transforms this hatch by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const te = matrix.elements
+    const matrix2d = new AcGeMatrix2d(
+      te[0],
+      te[4],
+      te[12],
+      te[1],
+      te[5],
+      te[13],
+      0,
+      0,
+      1
+    )
+    this._geo.transform(matrix2d)
+    this._elevation = new AcGePoint3d(0, 0, this._elevation).applyMatrix4(
+      matrix
+    ).z
+
+    const xAxis = new AcGePoint3d(1, 0, 0).applyMatrix4(matrix)
+    const origin = new AcGePoint3d().applyMatrix4(matrix)
+    const xVector = new AcGePoint3d(xAxis).sub(origin)
+    if (xVector.length() > 0) {
+      this._patternAngle += Math.atan2(xVector.y, xVector.x)
+      this._patternScale *= xVector.length()
+    }
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeSpline3d
@@ -324,6 +325,20 @@ export class AcDbLeader extends AcDbCurve {
   }
   set closed(_value: boolean) {
     // TODO: Not sure whether the leader really support setting value of property 'closed'
+  }
+
+  /**
+   * Transforms this leader by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._vertices.forEach(point => point.applyMatrix4(matrix))
+    if (this._splineGeo) {
+      this._splineGeo.transform(matrix)
+      this._updated = false
+    } else {
+      this._updated = true
+    }
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeVector3d,
@@ -371,6 +372,49 @@ export class AcDbMText extends AcDbEntity {
     if (AcDbOsnapMode.Insertion === osnapMode) {
       snapPoints.push(this._location)
     }
+  }
+
+  /**
+   * Transforms this mtext by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const origin = this._location.clone()
+    const xDir =
+      this._direction.lengthSq() > 0
+        ? this._direction.clone().normalize()
+        : new AcGeVector3d(
+            Math.cos(this._rotation),
+            Math.sin(this._rotation),
+            0
+          )
+    const yDir = new AcGeVector3d(-xDir.y, xDir.x, xDir.z)
+    if (yDir.lengthSq() === 0) {
+      yDir.set(0, 1, 0)
+    }
+    yDir.normalize()
+
+    const xAxisPoint = origin.clone().add(xDir)
+    const yAxisPoint = origin.clone().add(yDir)
+
+    origin.applyMatrix4(matrix)
+    xAxisPoint.applyMatrix4(matrix)
+    yAxisPoint.applyMatrix4(matrix)
+
+    const xAxis = new AcGeVector3d(xAxisPoint).sub(origin)
+    const yAxis = new AcGeVector3d(yAxisPoint).sub(origin)
+    const xScale = xAxis.length()
+    const yScale = yAxis.length()
+
+    this._location.copy(origin)
+    if (xScale > 0) {
+      this._direction.copy(xAxis).normalize()
+      this._rotation = Math.atan2(this._direction.y, this._direction.x)
+      this._width *= xScale
+    }
+    if (yScale > 0) {
+      this._height *= yScale
+    }
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -178,6 +179,16 @@ export class AcDbPolyFaceMesh extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this polyface mesh by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._vertices.forEach(vertex => {
+      vertex.position.applyMatrix4(matrix)
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPolygonMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolygonMesh.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -200,6 +201,16 @@ export class AcDbPolygonMesh extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this polygon mesh by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._vertices.forEach(vertex => {
+      vertex.position.applyMatrix4(matrix)
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
@@ -345,6 +346,37 @@ export class AcDbPolyline extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this polyline by the specified matrix.
+   *
+   * The lightweight polyline stores 2D vertices plus a shared elevation, so we
+   * transform each vertex in 3D and then write the projected XY values back.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const flipBulge = matrix.determinant() < 0
+    let elevation = this._elevation
+
+    this._geo.vertices.forEach(vertex => {
+      const transformedPoint = new AcGePoint3d(
+        vertex.x,
+        vertex.y,
+        this._elevation
+      ).applyMatrix4(matrix)
+      vertex.x = transformedPoint.x
+      vertex.y = transformedPoint.y
+      elevation = transformedPoint.z
+      if (flipBulge && vertex.bulge != null) {
+        vertex.bulge = -vertex.bulge
+      }
+    })
+
+    this._elevation = elevation
+    ;(this._geo as AcGePolyline2d<AcDbPolylineVertex> & {
+      _boundingBoxNeedsUpdate: boolean
+    })._boundingBoxNeedsUpdate = true
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbRasterImage.ts
+++ b/packages/data-model/src/entity/AcDbRasterImage.ts
@@ -1,9 +1,11 @@
 import {
   AcGeBox2d,
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
-  AcGeVector2d
+  AcGeVector2d,
+  AcGeVector3d
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -372,6 +374,42 @@ export class AcDbRasterImage extends AcDbEntity {
     } else {
       return renderer.lines(points)
     }
+  }
+
+  /**
+   * Transforms this raster image by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const wcsWidth = this._width * this._scale.x
+    const wcsHeight = this._height * this._scale.y
+    const uAxis = new AcGeVector3d(
+      wcsWidth * Math.cos(this._rotation),
+      wcsWidth * Math.sin(this._rotation),
+      0
+    )
+    const vAxis = new AcGeVector3d(
+      -wcsHeight * Math.sin(this._rotation),
+      wcsHeight * Math.cos(this._rotation),
+      0
+    )
+
+    const origin = this._position.clone()
+    const uPoint = this._position.clone().add(uAxis)
+    const vPoint = this._position.clone().add(vAxis)
+
+    origin.applyMatrix4(matrix)
+    uPoint.applyMatrix4(matrix)
+    vPoint.applyMatrix4(matrix)
+
+    const transformedU = new AcGeVector3d(uPoint).sub(origin)
+    const transformedV = new AcGeVector3d(vPoint).sub(origin)
+
+    this._position.copy(origin)
+    this._rotation = Math.atan2(transformedU.y, transformedU.x)
+    this._width = transformedU.length()
+    this._height = transformedV.length()
+    this._scale.set(1, 1)
+    return this
   }
 
   protected boundaryPath() {

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeVector3d
@@ -296,6 +297,15 @@ export class AcDbRay extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this ray by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._basePoint.applyMatrix4(matrix)
+    this._unitDir.transformDirection(matrix)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -1,6 +1,7 @@
 import { AcCmErrors } from '@mlightcad/common'
 import {
   AcGeKnotParameterizationType,
+  AcGeMatrix3d,
   AcGePoint3dLike,
   AcGeSpline3d
 } from '@mlightcad/geometry-engine'
@@ -277,6 +278,14 @@ export class AcDbSpline extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this spline by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._geo.transform(matrix)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -1,7 +1,9 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3d
 } from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
@@ -474,6 +476,51 @@ export class AcDbText extends AcDbEntity {
     if (AcDbOsnapMode.Insertion === osnapMode) {
       snapPoints.push(this._position)
     }
+  }
+
+  /**
+   * Transforms this text by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const origin = this._position.clone()
+    const xAxisPoint = this._position
+      .clone()
+      .add(
+        new AcGeVector3d(Math.cos(this._rotation), Math.sin(this._rotation), 0)
+      )
+    const yAxisPoint = this._position
+      .clone()
+      .add(
+        new AcGeVector3d(-Math.sin(this._rotation), Math.cos(this._rotation), 0)
+      )
+    const zAxisPoint = this._position.clone().add(new AcGeVector3d(0, 0, 1))
+
+    origin.applyMatrix4(matrix)
+    xAxisPoint.applyMatrix4(matrix)
+    yAxisPoint.applyMatrix4(matrix)
+    zAxisPoint.applyMatrix4(matrix)
+
+    const xAxis = new AcGeVector3d(xAxisPoint).sub(origin)
+    const yAxis = new AcGeVector3d(yAxisPoint).sub(origin)
+    const zAxis = new AcGeVector3d(zAxisPoint).sub(origin)
+    const yScale = yAxis.length()
+    const xScale = xAxis.length()
+    const zScale = zAxis.length()
+
+    this._position.copy(origin)
+    if (xScale > 0) {
+      this._rotation = Math.atan2(xAxis.y, xAxis.x)
+    }
+    if (yScale > 0) {
+      this._height *= yScale
+      if (xScale > 0) {
+        this._widthFactor *= xScale / yScale
+      }
+    }
+    if (zScale > 0) {
+      this._thickness *= zScale
+    }
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -1,6 +1,7 @@
 import {
   AcGeArea2d,
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
@@ -260,6 +261,15 @@ export class AcDbTrace extends AcDbCurve {
       default:
         break
     }
+  }
+
+  /**
+   * Transforms this trace by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._vertices.forEach(vertex => vertex.applyMatrix4(matrix))
+    this._elevation = this._vertices[0].z
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbViewport.ts
+++ b/packages/data-model/src/entity/AcDbViewport.ts
@@ -1,4 +1,9 @@
-import { AcGeBox3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
   AcGiRenderer,
@@ -185,6 +190,33 @@ export class AcDbViewport extends AcDbEntity {
   get geometricExtents(): AcGeBox3d {
     // TODO: Implement it correctly
     return new AcGeBox3d()
+  }
+
+  /**
+   * Transforms this viewport entity by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const origin = this._centerPoint.clone()
+    const xAxisPoint = this._centerPoint
+      .clone()
+      .add(new AcGeVector3d(this._width, 0, 0))
+    const yAxisPoint = this._centerPoint
+      .clone()
+      .add(new AcGeVector3d(0, this._height, 0))
+
+    origin.applyMatrix4(matrix)
+    xAxisPoint.applyMatrix4(matrix)
+    yAxisPoint.applyMatrix4(matrix)
+
+    const xAxis = new AcGeVector3d(xAxisPoint).sub(origin)
+    const yAxis = new AcGeVector3d(yAxisPoint).sub(origin)
+    const yScale = this._height !== 0 ? yAxis.length() / this._height : 1
+
+    this._centerPoint.copy(origin)
+    this._width = xAxis.length()
+    this._height = yAxis.length()
+    this._viewHeight *= yScale
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGeVector3d
 } from '@mlightcad/geometry-engine'
@@ -268,6 +269,15 @@ export class AcDbXline extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this.basePoint)
     return gripPoints
+  }
+
+  /**
+   * Transforms this xline by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._basePoint.applyMatrix4(matrix)
+    this._unitDir.transformDirection(matrix)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePointLike
 } from '@mlightcad/geometry-engine'
@@ -122,6 +123,16 @@ export class AcDb3PointAngularDimension extends AcDbDimension {
   }
   set xLine2Point(value: AcGePoint3d) {
     this._xLine2Point.copy(value)
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._arcPoint.applyMatrix4(matrix)
+    this._centerPoint.applyMatrix4(matrix)
+    this._xLine1Point.applyMatrix4(matrix)
+    this._xLine2Point.applyMatrix4(matrix)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
@@ -2,6 +2,7 @@ import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 import {
   AcGeBox3d,
   AcGeLine3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
@@ -264,6 +265,16 @@ export class AcDbAlignedDimension extends AcDbDimension {
    */
   set oblique(value: number) {
     this._oblique = value
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._dimLinePoint.applyMatrix4(matrix)
+    this._xLine1Point.applyMatrix4(matrix)
+    this._xLine2Point.applyMatrix4(matrix)
+    this.calculateRotation()
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -124,6 +125,16 @@ export class AcDbArcDimension extends AcDbDimension {
   }
   set xLine2Point(value: AcGePoint3d) {
     this._xLine2Point.copy(value)
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._arcPoint.applyMatrix4(matrix)
+    this._centerPoint.applyMatrix4(matrix)
+    this._xLine1Point.applyMatrix4(matrix)
+    this._xLine2Point.applyMatrix4(matrix)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -149,6 +150,14 @@ export class AcDbDiametricDimension extends AcDbDimension {
    */
   get leaderLength() {
     return this._leaderLength
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._chordPoint.applyMatrix4(matrix)
+    this._farChordPoint.applyMatrix4(matrix)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -340,6 +340,36 @@ export abstract class AcDbDimension extends AcDbEntity {
   }
 
   /**
+   * Transforms this dimension by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d): this {
+    const origin = this._textPosition.clone()
+    const rotationPoint = this._textPosition
+      .clone()
+      .add(
+        new AcGeVector3d(
+          Math.cos(this._textRotation),
+          Math.sin(this._textRotation),
+          0
+        )
+      )
+
+    this._dimBlockPosition.applyMatrix4(matrix)
+    this._textPosition.applyMatrix4(matrix)
+    this._normal.transformDirection(matrix)
+
+    origin.applyMatrix4(matrix)
+    rotationPoint.applyMatrix4(matrix)
+    const rotationVector = new AcGeVector3d(rotationPoint).sub(origin)
+    if (rotationVector.lengthSq() > 0) {
+      this._textRotation = Math.atan2(rotationVector.y, rotationVector.x)
+    }
+
+    this.subTransformBy(matrix)
+    return this
+  }
+
+  /**
    * @inheritdoc
    */
   subWorldDraw(renderer: AcGiRenderer) {
@@ -616,6 +646,11 @@ export abstract class AcDbDimension extends AcDbEntity {
     // ------------------------------------------------------------
     return new AcGeMatrix3d().multiplyMatrices(mInsert, mBase)
   }
+
+  /**
+   * Subclasses can override this to transform their own definition points.
+   */
+  protected subTransformBy(_matrix: AcGeMatrix3d) {}
 
   /**
    * Writes DXF fields for this object.

--- a/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -85,6 +86,14 @@ export class AcDbOrdinateDimension extends AcDbDimension {
   }
   set leaderEndPoint(value: AcGePoint3d) {
     this._leaderEndPoint.copy(value)
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._definingPoint.applyMatrix4(matrix)
+    this._leaderEndPoint.applyMatrix4(matrix)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -257,6 +258,14 @@ export class AcDbRadialDimension extends AcDbDimension {
    */
   set leaderLenght(value: number) {
     this._leaderLength = value
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override subTransformBy(matrix: AcGeMatrix3d) {
+    this._center.applyMatrix4(matrix)
+    this._chordPoint.applyMatrix4(matrix)
   }
 
   /**

--- a/packages/geometry-engine/__tests__/AcGeTransform.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeTransform.spec.ts
@@ -1,0 +1,340 @@
+import {
+  AcGeArea2d,
+  AcGeCatmullRomCurve3d,
+  AcGeCircArc2d,
+  AcGeCircArc3d,
+  AcGeEllipseArc2d,
+  AcGeEllipseArc3d,
+  AcGeLine2d,
+  AcGeLine3d,
+  AcGeLoop2d,
+  AcGeMatrix2d,
+  AcGeMatrix3d,
+  AcGePoint2d,
+  AcGePoint3d,
+  AcGePolyline2d,
+  AcGeSpline3d,
+  AcGeVector3d
+} from '../src'
+
+const expectPoint2dClose = (
+  actual: { x: number; y: number },
+  expected: { x: number; y: number }
+) => {
+  expect(actual.x).toBeCloseTo(expected.x, 8)
+  expect(actual.y).toBeCloseTo(expected.y, 8)
+}
+
+const expectPoint3dClose = (
+  actual: { x: number; y: number; z: number },
+  expected: { x: number; y: number; z: number }
+) => {
+  expect(actual.x).toBeCloseTo(expected.x, 8)
+  expect(actual.y).toBeCloseTo(expected.y, 8)
+  expect(actual.z).toBeCloseTo(expected.z, 8)
+}
+
+const transformPoint2d = (
+  point: { x: number; y: number },
+  matrix: AcGeMatrix2d
+) => new AcGePoint2d(point).applyMatrix2d(matrix)
+
+const transformPoint3d = (
+  point: { x: number; y: number; z: number },
+  matrix: AcGeMatrix3d
+) => new AcGePoint3d(point).applyMatrix4(matrix)
+
+describe('Geometry transform regression', () => {
+  it('keeps line geometry aligned across common matrix families', () => {
+    const line2dCases = [
+      {
+        name: 'translation',
+        matrix: new AcGeMatrix2d().makeTranslation(3, -2)
+      },
+      {
+        name: 'rotation',
+        matrix: new AcGeMatrix2d().makeRotation(Math.PI / 2)
+      },
+      {
+        name: 'mirror',
+        matrix: new AcGeMatrix2d().makeScale(-1, 1)
+      },
+      {
+        name: 'non-uniform-scale',
+        matrix: new AcGeMatrix2d().makeScale(2, 3)
+      }
+    ]
+    const line3dCases = [
+      {
+        name: 'translation',
+        matrix: new AcGeMatrix3d().makeTranslation(3, -2, 5)
+      },
+      {
+        name: 'rotation',
+        matrix: new AcGeMatrix3d().makeRotationZ(Math.PI / 2)
+      },
+      {
+        name: 'mirror',
+        matrix: new AcGeMatrix3d().makeScale(-1, 1, 1)
+      },
+      {
+        name: 'non-uniform-scale',
+        matrix: new AcGeMatrix3d().makeScale(2, 3, 4)
+      }
+    ]
+
+    line2dCases.forEach(({ matrix }) => {
+      const start = { x: 1, y: 2 }
+      const end = { x: 4, y: -1 }
+      const line = new AcGeLine2d(start, end)
+
+      line.transform(matrix)
+
+      expectPoint2dClose(line.startPoint, transformPoint2d(start, matrix))
+      expectPoint2dClose(line.endPoint, transformPoint2d(end, matrix))
+    })
+
+    line3dCases.forEach(({ matrix }) => {
+      const start = { x: 1, y: 2, z: 3 }
+      const end = { x: 4, y: -1, z: 2 }
+      const line = new AcGeLine3d(start, end)
+
+      line.transform(matrix)
+
+      expectPoint3dClose(line.startPoint, transformPoint3d(start, matrix))
+      expectPoint3dClose(line.endPoint, transformPoint3d(end, matrix))
+    })
+  })
+
+  it('transforms 2d and 3d lines directly', () => {
+    const line2d = new AcGeLine2d({ x: 0, y: 0 }, { x: 2, y: 1 })
+    const line3d = new AcGeLine3d(
+      new AcGePoint3d(1, 2, 3),
+      new AcGePoint3d(4, 5, 6)
+    )
+
+    line2d.transform(new AcGeMatrix2d().makeTranslation(3, -4))
+    line3d.transform(new AcGeMatrix3d().makeTranslation(-1, 2, -3))
+
+    expectPoint2dClose(line2d.startPoint, { x: 3, y: -4 })
+    expectPoint2dClose(line2d.endPoint, { x: 5, y: -3 })
+    expectPoint3dClose(line3d.startPoint, { x: 0, y: 4, z: 0 })
+    expectPoint3dClose(line3d.endPoint, { x: 3, y: 7, z: 3 })
+  })
+
+  it('transforms 2d circular arcs and flips orientation on mirror', () => {
+    const arc = new AcGeCircArc2d({ x: 0, y: 0 }, 2, 0, Math.PI / 2, false)
+    arc.transform(new AcGeMatrix2d().makeScale(1, -1))
+
+    expectPoint2dClose(arc.center, { x: 0, y: 0 })
+    expect(arc.radius).toBeCloseTo(2, 8)
+    expect(arc.clockwise).toBe(true)
+    expectPoint2dClose(arc.startPoint, { x: 2, y: 0 })
+    expectPoint2dClose(arc.endPoint, { x: 0, y: -2 })
+  })
+
+  it('transforms 2d ellipse arcs with rotation', () => {
+    const ellipse = new AcGeEllipseArc2d({ x: 0, y: 0 }, 4, 2, 0, Math.PI / 2)
+    ellipse.transform(new AcGeMatrix2d().makeRotation(Math.PI / 2))
+
+    expectPoint2dClose(ellipse.center, { x: 0, y: 0 })
+    expect(ellipse.rotation).toBeCloseTo(Math.PI / 2, 8)
+    expectPoint2dClose(ellipse.startPoint, { x: 0, y: 4 })
+    expectPoint2dClose(ellipse.endPoint, { x: -2, y: 0 })
+  })
+
+  it('transforms 2d polylines and mirrored bulges', () => {
+    const polyline = new AcGePolyline2d([
+      { x: 0, y: 0, bulge: 1 },
+      { x: 2, y: 0 }
+    ])
+
+    polyline.transform(new AcGeMatrix2d().makeScale(1, -1))
+
+    expectPoint2dClose(polyline.getPointAt(0), { x: 0, y: 0 })
+    expectPoint2dClose(polyline.getPointAt(1), { x: 2, y: 0 })
+    expect(polyline.vertices[0].bulge).toBe(-1)
+  })
+
+  it('keeps polyline vertices consistent across translation rotation and mirror', () => {
+    const cases = [
+      {
+        matrix: new AcGeMatrix2d().makeTranslation(5, 6),
+        expectedBulge: 1
+      },
+      {
+        matrix: new AcGeMatrix2d().makeRotation(Math.PI / 2),
+        expectedBulge: 1
+      },
+      {
+        matrix: new AcGeMatrix2d().makeScale(-1, 1),
+        expectedBulge: -1
+      }
+    ]
+
+    cases.forEach(({ matrix, expectedBulge }) => {
+      const vertices = [
+        { x: 0, y: 0, bulge: 1 },
+        { x: 2, y: 1 }
+      ]
+      const polyline = new AcGePolyline2d(
+        vertices.map(vertex => ({ ...vertex }))
+      )
+
+      polyline.transform(matrix)
+
+      expectPoint2dClose(
+        polyline.getPointAt(0),
+        transformPoint2d(vertices[0], matrix)
+      )
+      expectPoint2dClose(
+        polyline.getPointAt(1),
+        transformPoint2d(vertices[1], matrix)
+      )
+      expect(polyline.vertices[0].bulge).toBe(expectedBulge)
+    })
+  })
+
+  it('transforms loops and areas through child curves', () => {
+    const loop = new AcGeLoop2d([
+      new AcGeLine2d({ x: 0, y: 0 }, { x: 1, y: 0 }),
+      new AcGeLine2d({ x: 1, y: 0 }, { x: 1, y: 1 }),
+      new AcGeLine2d({ x: 1, y: 1 }, { x: 0, y: 1 }),
+      new AcGeLine2d({ x: 0, y: 1 }, { x: 0, y: 0 })
+    ])
+    const area = new AcGeArea2d()
+    area.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 1, y: 1 },
+          { x: 0, y: 1 }
+        ],
+        true
+      )
+    )
+
+    loop.transform(new AcGeMatrix2d().makeTranslation(3, 4))
+    area.transform(new AcGeMatrix2d().makeScale(2, 2))
+
+    expectPoint2dClose(loop.startPoint, { x: 3, y: 4 })
+    expect(area.area).toBeCloseTo(4, 8)
+  })
+
+  it('transforms 3d circular arcs using transformed points instead of origin-relative vectors', () => {
+    const arc = new AcGeCircArc3d(
+      new AcGePoint3d(5, 5, 0),
+      2,
+      0,
+      Math.PI / 2,
+      AcGeVector3d.Z_AXIS
+    )
+
+    arc.transform(new AcGeMatrix3d().makeTranslation(3, -1, 2))
+
+    expectPoint3dClose(arc.center, { x: 8, y: 4, z: 2 })
+    expectPoint3dClose(arc.startPoint, { x: 10, y: 4, z: 2 })
+    expectPoint3dClose(arc.endPoint, { x: 8, y: 6, z: 2 })
+  })
+
+  it('transforms mirrored 3d circular arcs and updates the plane normal', () => {
+    const arc = new AcGeCircArc3d(
+      new AcGePoint3d(0, 0, 0),
+      2,
+      0,
+      Math.PI / 2,
+      AcGeVector3d.Z_AXIS
+    )
+
+    arc.transform(new AcGeMatrix3d().makeScale(-1, 1, 1))
+
+    expectPoint3dClose(arc.center, { x: 0, y: 0, z: 0 })
+    expectPoint3dClose(arc.startPoint, { x: -2, y: 0, z: 0 })
+    expectPoint3dClose(arc.endPoint, { x: 0, y: 2, z: 0 })
+    expect(Math.abs(arc.normal.z)).toBeCloseTo(1, 8)
+  })
+
+  it('transforms 3d ellipse arcs and preserves endpoints', () => {
+    const ellipse = new AcGeEllipseArc3d(
+      new AcGePoint3d(1, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      4,
+      2,
+      0,
+      Math.PI / 2
+    )
+    const matrix = new AcGeMatrix3d().makeTranslation(2, 3, 4)
+
+    ellipse.transform(matrix)
+
+    expectPoint3dClose(ellipse.center, { x: 3, y: 3, z: 4 })
+    expectPoint3dClose(ellipse.startPoint, { x: 7, y: 3, z: 4 })
+    expectPoint3dClose(ellipse.endPoint, { x: 3, y: 5, z: 4 })
+  })
+
+  it('transforms 3d ellipse arcs under non-uniform scaling', () => {
+    const ellipse = new AcGeEllipseArc3d(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      2,
+      1,
+      0,
+      Math.PI / 2
+    )
+
+    ellipse.transform(new AcGeMatrix3d().makeScale(3, 4, 1))
+
+    expect(ellipse.majorAxisRadius).toBeCloseTo(6, 8)
+    expect(ellipse.minorAxisRadius).toBeCloseTo(4, 8)
+    expectPoint3dClose(ellipse.startPoint, { x: 6, y: 0, z: 0 })
+    expectPoint3dClose(ellipse.endPoint, { x: 0, y: 4, z: 0 })
+  })
+
+  it('transforms splines built from control points and fit points', () => {
+    const controlSpline = new AcGeSpline3d(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 2, y: 0, z: 0 },
+        { x: 3, y: 1, z: 0 }
+      ],
+      [0, 0, 0, 0, 1, 1, 1, 1]
+    )
+    const fitSpline = new AcGeSpline3d(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 2, y: 0, z: 0 },
+        { x: 3, y: 1, z: 0 }
+      ],
+      'Uniform'
+    )
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -2, 5)
+
+    controlSpline.transform(matrix)
+    fitSpline.transform(matrix)
+
+    expectPoint3dClose(controlSpline.startPoint, { x: 10, y: -2, z: 5 })
+    expectPoint3dClose(controlSpline.endPoint, { x: 13, y: -1, z: 5 })
+    expectPoint3dClose(fitSpline.startPoint, { x: 10, y: -2, z: 5 })
+    expectPoint3dClose(fitSpline.endPoint, { x: 13, y: -1, z: 5 })
+  })
+
+  it('transforms catmull-rom curves by moving their control points', () => {
+    const curve = new AcGeCatmullRomCurve3d([
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 2, z: 0 },
+      { x: 3, y: 2, z: 1 },
+      { x: 4, y: 0, z: 1 }
+    ])
+
+    curve.transform(new AcGeMatrix3d().makeTranslation(2, -3, 4))
+
+    expectPoint3dClose(curve.startPoint, { x: 2, y: -3, z: 4 })
+    expectPoint3dClose(curve.endPoint, { x: 6, y: -3, z: 5 })
+    expectPoint3dClose(curve.points[1], { x: 3, y: -1, z: 4 })
+  })
+})

--- a/packages/geometry-engine/src/geometry/AcGeArea2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeArea2d.ts
@@ -67,8 +67,10 @@ export class AcGeArea2d extends AcGeShape2d {
   /**
    * @inheritdoc
    */
-  transform(_matrix: AcGeMatrix2d) {
-    // TODO: implement it
+  transform(matrix: AcGeMatrix2d) {
+    this._loops.forEach(loop => {
+      loop.transform(matrix)
+    })
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGeCircArc2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc2d.ts
@@ -410,7 +410,53 @@ export class AcGeCircArc2d extends AcGeCurve2d {
    * @inheritdoc
    */
   transform(_matrix: AcGeMatrix2d) {
-    // TODO: implement it
+    const matrix = _matrix
+    const transformedCenter = this.center.clone().applyMatrix2d(matrix)
+    const transformedStart = this.startPoint.clone().applyMatrix2d(matrix)
+
+    if (this.closed) {
+      this.center = transformedCenter
+      this.radius = transformedCenter.distanceTo(transformedStart)
+      this._startAngle = Math.atan2(
+        transformedStart.y - transformedCenter.y,
+        transformedStart.x - transformedCenter.x
+      )
+      this._endAngle = this._startAngle
+      this._clockwise =
+        matrix.determinant() < 0 ? !this._clockwise : this._clockwise
+      this._boundingBoxNeedsUpdate = true
+      return this
+    }
+
+    const transformedMid = this.midPoint.clone().applyMatrix2d(matrix)
+    const transformedEnd = this.endPoint.clone().applyMatrix2d(matrix)
+    const transformedArc = new AcGeCircArc2d(
+      transformedStart,
+      transformedMid,
+      transformedEnd
+    )
+    const clockwise =
+      matrix.determinant() < 0 ? !this.clockwise : this.clockwise
+    const toPublicAngle = (angle: number) => {
+      const normalized = AcGeMathUtil.normalizeAngle(angle)
+      return clockwise ? this._mirrorAngle(normalized) : normalized
+    }
+
+    this.center = transformedArc.center
+    this.radius = transformedArc.radius
+    this.clockwise = clockwise
+    this.startAngle = toPublicAngle(
+      Math.atan2(
+        transformedStart.y - transformedArc.center.y,
+        transformedStart.x - transformedArc.center.x
+      )
+    )
+    this.endAngle = toPublicAngle(
+      Math.atan2(
+        transformedEnd.y - transformedArc.center.y,
+        transformedEnd.x - transformedArc.center.x
+      )
+    )
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
@@ -491,23 +491,45 @@ export class AcGeCircArc3d extends AcGeCurve3d {
    * @inheritdoc
    */
   transform(matrix: AcGeMatrix3d) {
-    const startVec = _vector3
-      .copy(this.refVec)
-      .applyAxisAngle(this.normal, this.startAngle)
-      .multiplyScalar(this.radius)
-    const endVec = _vector3
-      .copy(this.refVec)
-      .applyAxisAngle(this.normal, this.endAngle)
-      .multiplyScalar(this.radius)
+    const transformedCenter = this.center.clone().applyMatrix4(matrix)
+    const transformedStart = this.startPoint.clone().applyMatrix4(matrix)
+    const transformedEnd = this.endPoint.clone().applyMatrix4(matrix)
+    const referencePoint = this.getPointAtAngle(
+      this.closed ? Math.PI / 2 : this.startAngle + this.deltaAngle / 2
+    )
+      .clone()
+      .applyMatrix4(matrix)
 
-    this.center.applyMatrix4(matrix)
-    startVec.applyMatrix4(matrix)
-    endVec.applyMatrix4(matrix)
-    this.normal.applyMatrix4(matrix).normalize()
-    this.refVec.applyMatrix4(matrix).normalize()
+    const refVector = new AcGeVector3d(transformedStart)
+      .sub(transformedCenter)
+      .normalize()
+    const radius = transformedCenter.distanceTo(transformedStart)
 
-    this.startAngle = this.getAngle(startVec)
-    this.endAngle = this.getAngle(endVec)
+    let normal = new AcGeVector3d()
+      .crossVectors(
+        new AcGeVector3d(transformedStart).sub(transformedCenter),
+        new AcGeVector3d(referencePoint).sub(transformedCenter)
+      )
+      .normalize()
+
+    if (normal.lengthSq() === 0) {
+      normal = this.normal.clone().transformDirection(matrix)
+    }
+
+    const getAngle = (point: AcGePoint3d) => {
+      const vec = new AcGeVector3d(point).sub(transformedCenter)
+      return Math.atan2(
+        vec.dot(_vector3.crossVectors(normal, refVector)),
+        vec.dot(refVector)
+      )
+    }
+
+    this.center = transformedCenter
+    this.radius = radius
+    this.normal = normal
+    this.refVec = refVector
+    this.startAngle = 0
+    this.endAngle = this.closed ? TAU : getAngle(transformedEnd)
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
@@ -253,8 +253,84 @@ export class AcGeEllipseArc2d extends AcGeCurve2d {
    * @inheritdoc
    */
   transform(_matrix: AcGeMatrix2d) {
+    const matrix = _matrix
+    const transformedCenter2d = new AcGePoint2d(this.center).applyMatrix2d(
+      matrix
+    )
+    const transformedCenter = new AcGePoint3d(
+      transformedCenter2d.x,
+      transformedCenter2d.y,
+      this.center.z
+    )
+    const transformedMajorPoint = this.getPointAtAngle(0)
+      .clone()
+      .applyMatrix2d(matrix)
+    const transformedMinorPoint = this.getPointAtAngle(Math.PI / 2)
+      .clone()
+      .applyMatrix2d(matrix)
+
+    const majorVector = new AcGePoint2d(transformedMajorPoint).sub(
+      transformedCenter2d
+    )
+    const minorVector = new AcGePoint2d(transformedMinorPoint).sub(
+      transformedCenter2d
+    )
+
+    const majorAxisRadius = majorVector.length()
+    const minorAxisRadius = minorVector.length()
+    const rotation = Math.atan2(majorVector.y, majorVector.x)
+    const majorDirection = majorVector.clone().normalize()
+    const minorDirection = minorVector.clone().normalize()
+
+    const getAngle = (point: AcGePoint2d) => {
+      const relative = new AcGePoint2d(point).sub(transformedCenter2d)
+      const x = relative.dot(majorDirection)
+      const y = relative.dot(minorDirection)
+      return AcGeMathUtil.normalizeAngle(
+        Math.atan2(y / minorAxisRadius, x / majorAxisRadius)
+      )
+    }
+
+    const clockwise =
+      matrix.determinant() < 0 ? !this.clockwise : this.clockwise
+
+    const transformedEllipse = this.closed
+      ? new AcGeEllipseArc2d(
+          transformedCenter,
+          majorAxisRadius,
+          minorAxisRadius,
+          0,
+          TAU,
+          clockwise,
+          rotation
+        )
+      : new AcGeEllipseArc2d(
+          transformedCenter,
+          majorAxisRadius,
+          minorAxisRadius,
+          getAngle(this.startPoint.clone().applyMatrix2d(matrix)),
+          getAngle(this.endPoint.clone().applyMatrix2d(matrix)),
+          clockwise,
+          rotation
+        )
+
+    this.center = transformedEllipse.center
+    this.majorAxisRadius = transformedEllipse.majorAxisRadius
+    this.minorAxisRadius = transformedEllipse.minorAxisRadius
+    this._startAngle = transformedEllipse._startAngle
+    this._endAngle = transformedEllipse._endAngle
+    this._clockwise = transformedEllipse._clockwise
+    this.rotation = transformedEllipse.rotation
     this._boundingBoxNeedsUpdate = true
     return this
+  }
+
+  private getPointAtAngle(angle: number) {
+    return this.getPoint(
+      this.closed
+        ? angle / TAU
+        : AcGeMathUtil.normalizeAngle(angle - this.startAngle) / this.deltaAngle
+    )
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -440,6 +440,74 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
    * @inheritdoc
    */
   transform(_matrix: AcGeMatrix3d) {
+    const matrix = _matrix
+    const transformedCenter = this.center.clone().applyMatrix4(matrix)
+    const transformedMajorPoint = this.getPointAtAngle(0)
+      .clone()
+      .applyMatrix4(matrix)
+    const transformedMinorPoint = this.getPointAtAngle(Math.PI / 2)
+      .clone()
+      .applyMatrix4(matrix)
+
+    const majorVector = new AcGeVector3d(transformedMajorPoint).sub(
+      transformedCenter
+    )
+    const transformedMinorVector = new AcGeVector3d(transformedMinorPoint).sub(
+      transformedCenter
+    )
+
+    const majorAxisRadius = majorVector.length()
+    const minorAxisRadius = transformedMinorVector.length()
+    const majorAxis = majorVector.clone().normalize()
+
+    const normal = new AcGeVector3d()
+      .crossVectors(majorVector, transformedMinorVector)
+      .normalize()
+    let minorAxis = new AcGeVector3d()
+      .crossVectors(normal, majorAxis)
+      .normalize()
+
+    if (minorAxis.dot(transformedMinorVector) < 0) {
+      normal.negate()
+      minorAxis = new AcGeVector3d().crossVectors(normal, majorAxis).normalize()
+    }
+
+    const getAngle = (point: AcGePoint3d) => {
+      const relative = new AcGeVector3d(point).sub(transformedCenter)
+      const x = relative.dot(majorAxis)
+      const y = relative.dot(minorAxis)
+      return AcGeMathUtil.normalizeAngle(
+        Math.atan2(y / minorAxisRadius, x / majorAxisRadius)
+      )
+    }
+
+    const transformedEllipse = this.closed
+      ? new AcGeEllipseArc3d(
+          transformedCenter,
+          normal,
+          majorAxis,
+          majorAxisRadius,
+          minorAxisRadius,
+          0,
+          TAU
+        )
+      : new AcGeEllipseArc3d(
+          transformedCenter,
+          normal,
+          majorAxis,
+          majorAxisRadius,
+          minorAxisRadius,
+          getAngle(this.startPoint.clone().applyMatrix4(matrix)),
+          getAngle(this.endPoint.clone().applyMatrix4(matrix))
+        )
+
+    this.center = transformedEllipse.center
+    this.normal = transformedEllipse.normal
+    this.majorAxis = transformedEllipse.majorAxis
+    this.majorAxisRadius = transformedEllipse.majorAxisRadius
+    this.minorAxisRadius = transformedEllipse.minorAxisRadius
+    this._startAngle = transformedEllipse._startAngle
+    this._endAngle = transformedEllipse._endAngle
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
@@ -1,5 +1,11 @@
 import { AcGeEllipseArc2d, AcGeSpline3d } from '../geometry'
-import { AcGeBox2d, AcGeMatrix2d, AcGePoint2d, AcGePoint3d } from '../math'
+import {
+  AcGeBox2d,
+  AcGeMatrix2d,
+  AcGeMatrix3d,
+  AcGePoint2d,
+  AcGePoint3d
+} from '../math'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGeCurve2d } from './AcGeCurve2d'
 import { AcGeLine2d } from './AcGeLine2d'
@@ -155,8 +161,34 @@ export class AcGeLoop2d extends AcGeCurve2d {
   /**
    * @inheritdoc
    */
-  transform(_matrix: AcGeMatrix2d) {
-    // TODO: implement it
+  transform(matrix: AcGeMatrix2d) {
+    const matrix3d = new AcGeMatrix3d().set(
+      matrix.elements[0],
+      matrix.elements[3],
+      0,
+      matrix.elements[6],
+      matrix.elements[1],
+      matrix.elements[4],
+      0,
+      matrix.elements[7],
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1
+    )
+
+    this._curves.forEach(curve => {
+      if (curve instanceof AcGeSpline3d) {
+        curve.transform(matrix3d)
+      } else {
+        curve.transform(matrix)
+      }
+    })
+
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
@@ -205,8 +205,18 @@ export class AcGePolyline2d<
   /**
    * @inheritdoc
    */
-  transform(_matrix: AcGeMatrix2d) {
-    // TODO: implement it
+  transform(matrix: AcGeMatrix2d) {
+    const flipBulge = matrix.determinant() < 0
+
+    this._vertices.forEach(vertex => {
+      const transformedPoint = new AcGePoint2d(vertex).applyMatrix2d(matrix)
+      vertex.x = transformedPoint.x
+      vertex.y = transformedPoint.y
+      if (flipBulge && vertex.bulge != null) {
+        vertex.bulge = -vertex.bulge
+      }
+    })
+
     this._boundingBoxNeedsUpdate = true
     return this
   }

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -415,8 +415,39 @@ export class AcGeSpline3d extends AcGeCurve3d {
   /**
    * @inheritdoc
    */
-  transform(_matrix: AcGeMatrix3d) {
-    // TODO: Implement this method
+  transform(matrix: AcGeMatrix3d) {
+    if (this._fitPoints && this._knotParameterization) {
+      this._fitPoints = this._fitPoints.map(point =>
+        new AcGePoint3d(point).applyMatrix4(matrix)
+      )
+
+      if (this._startTangent) {
+        this._startTangent = new AcGePoint3d(
+          this._startTangent
+        ).transformDirection(matrix)
+      }
+      if (this._endTangent) {
+        this._endTangent = new AcGePoint3d(this._endTangent).transformDirection(
+          matrix
+        )
+      }
+
+      this.buildCurve()
+    } else {
+      const knots = this._nurbsCurve.knots()
+      const weights = this._nurbsCurve.weights()
+
+      this._controlPoints = this._controlPoints.map(point =>
+        new AcGePoint3d(point).applyMatrix4(matrix)
+      )
+      this._nurbsCurve = AcGeNurbsCurve.byKnotsControlPointsWeights(
+        this._degree,
+        knots,
+        this._controlPoints,
+        weights.length > 0 ? weights : undefined
+      )
+    }
+
     this._boundingBoxNeedsUpdate = true
     return this
   }


### PR DESCRIPTION
## Summary

This PR fills in missing or incomplete transformation logic across geometry-engine and data-model, and adds broader regression coverage for transform behavior.

### What changed

-   Implemented or completed transform(...) methods for geometry types in packages/geometry-engine/src/geometry

-   Implemented or completed transformBy(...) methods for entity types in packages/data-model/src/entity

-   Fixed transform behavior for cases that require recomputing derived geometry instead of only moving raw coordinates

-   Added and expanded regression tests to ensure each concrete geometry/entity transform implementation is exercised

-   Added extra coverage for:

    -   translation
    -   rotation
    -   mirror transforms
    -   non-uniform scaling
    -   combined transforms

## Main areas covered

### Geometry

-   2D/3D circular arcs
-   2D/3D ellipse arcs
-   2D polylines
-   loops and areas
-   3D splines
-   Catmull-Rom curves
-   2D/3D lines

### Entities

-   polylines (AcDbPolyline, AcDb2dPolyline, AcDb3dPolyline)
-   spline, ellipse, leader
-   text and mtext
-   block reference and attached attributes
-   hatch, raster image, viewport
-   face, trace, polygon mesh, polyface mesh
-   point, line, arc, circle, ray, xline
-   dimension base class and concrete dimension subclasses

## Why

A number of transform implementations were previously missing, partial, or too shallow for real affine transforms. This PR makes transform behavior more consistent and adds tests so regressions are easier to catch.

## Testing

`pnpm exec tsc -p tsconfig.json --noEmit pnpm test -- packages/geometry-engine/__tests__/AcGeTransform.spec.ts packages/data-model/__tests__/AcDbEntity.spec.ts`

## Notes

-   Some entity transforms now rebuild orientation, scale, angle, or plane-related state from transformed reference geometry instead of only updating stored points.
-   The added tests focus on behavior, especially around mirrored and non-uniform transforms, where regressions are most likely.