### PR TITLE
feat: improve text style fallback resolution and bump libredwg-web to 0.6.10

### DIFF
--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -620,10 +620,13 @@ export class AcDbMText extends AcDbEntity {
 
   private getTextStyle(): AcGiTextStyle {
     const textStyleTable = this.database.tables.textStyleTable
-    let style = textStyleTable.getAt(this.styleName)
+    const style =
+      textStyleTable.getAt(this.styleName) ??
+      textStyleTable.getAt(this.database.textstyle) ??
+      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
+
     if (!style) {
-      style = (textStyleTable.getAt(DEFAULT_TEXT_STYLE) ||
-        textStyleTable.getAt(DEFAULT_TEXT_STYLE))!
+      throw new Error('No valid text style found in text style table.')
     }
     return style.textStyle
   }

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -13,7 +13,6 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
-import { AcDbTextStyleTableRecord } from '../database'
 import { DEFAULT_TEXT_STYLE } from '../misc'
 import { AcDbBlockReference } from './AcDbBlockReference'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
@@ -656,13 +655,12 @@ export class AcDbTable extends AcDbBlockReference {
    */
   private getTextStyle(cell: AcDbTableCell): AcGiTextStyle {
     const textStyleTable = this.database.tables.textStyleTable
-    let style: AcDbTextStyleTableRecord | undefined
-    if (cell.textStyle) {
-      style = textStyleTable.getAt(cell.textStyle)
-    }
+    const style =
+      (cell.textStyle ? textStyleTable.getAt(cell.textStyle) : undefined) ??
+      textStyleTable.getAt(this.database.textstyle) ??
+      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
     if (!style) {
-      style = (textStyleTable.getAt(DEFAULT_TEXT_STYLE) ||
-        textStyleTable.getAt(DEFAULT_TEXT_STYLE))!
+      throw new Error('No valid text style found in text style table.')
     }
     return style.textStyle
   }

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -666,10 +666,12 @@ export class AcDbText extends AcDbEntity {
    */
   protected getTextStyle(): AcGiTextStyle {
     const textStyleTable = this.database.tables.textStyleTable
-    let style = textStyleTable.getAt(this.styleName)
+    const style =
+      textStyleTable.getAt(this.styleName) ??
+      textStyleTable.getAt(this.database.textstyle) ??
+      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
     if (!style) {
-      style = (textStyleTable.getAt(DEFAULT_TEXT_STYLE) ||
-        textStyleTable.getAt(DEFAULT_TEXT_STYLE))!
+      throw new Error('No valid text style found in text style table.')
     }
     return style.textStyle
   }

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "0.6.9"
+    "@mlightcad/libredwg-web": "0.6.10"
   },
   "devDependencies": {
     "vite": "^5.2.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: workspace:*
         version: link:../data-model
       '@mlightcad/libredwg-web':
-        specifier: 0.6.9
-        version: 0.6.9
+        specifier: 0.6.10
+        version: 0.6.10
     devDependencies:
       vite:
         specifier: ^5.2.10
@@ -1383,8 +1383,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.6.9':
-    resolution: {integrity: sha512-BZ713nAwuMcWUcbHuDYOqxrQTHBvT8lw3Eu6UedRYHo/UuxcZQloppJTV+uXtoJLFCtFJI5Evv4gLHmzjeDNIA==}
+  '@mlightcad/libredwg-web@0.6.10':
+    resolution: {integrity: sha512-yJ9bTyuKWTst2vEaYmWjW36bIM5xkfTPg3QhpbexdG+bqi7/UY/Jyp3X7tovcOv0HJ/gnDXV9RaeAs+IzUxJ5w==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1453,24 +1453,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1516,36 +1520,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.0':
     resolution: {integrity: sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.0':
     resolution: {integrity: sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==}
@@ -1601,46 +1611,55 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -1698,24 +1717,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.13':
     resolution: {integrity: sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.13':
     resolution: {integrity: sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.13':
     resolution: {integrity: sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.13':
     resolution: {integrity: sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==}
@@ -6274,7 +6297,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.6.9': {}
+  '@mlightcad/libredwg-web@0.6.10': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Improve text style lookup in `AcDbMText`, `AcDbText`, and `AcDbTable` by using a clearer fallback chain.
- Add explicit error handling when no valid text style exists instead of relying on unsafe fallback assertions.
- Bump `@mlightcad/libredwg-web` from `0.6.9` to `0.6.10` and refresh `pnpm-lock.yaml`.

## Why
- Text entities and table cells should resolve styles more reliably when entity-level style names are missing.
- Throwing a clear error prevents silent misuse of undefined styles and makes failures easier to diagnose.
- The converter dependency bump aligns the package with the newer `libredwg-web` release.

## What Changed
- `AcDbMText.getTextStyle()` now resolves style with:
  - entity `styleName`
  - database default `textstyle`
  - `DEFAULT_TEXT_STYLE`
  - then throws `No valid text style found in text style table.` if unresolved.
- `AcDbText.getTextStyle()` now follows the same fallback and error behavior.
- `AcDbTable.getTextStyle(cell)` now follows the same fallback and error behavior for `cell.textStyle`.
- Removed an unused `AcDbTextStyleTableRecord` import in `AcDbTable.ts`.
- Updated `packages/libredwg-converter/package.json` dependency:
  - `@mlightcad/libredwg-web`: `0.6.9` -> `0.6.10`
- Updated `pnpm-lock.yaml` for the version bump and lockfile metadata refresh.

## Risks / Notes
- Throwing when no style exists may surface previously hidden data issues at runtime.
- `pnpm-lock.yaml` includes additional platform/libc metadata updates beyond the direct dependency bump; reviewers may want to confirm this came from the package manager refresh.
