### PR TITLE
feat: add unit tests for data-model and geometry-engine modules and clone method

### DIFF
--- a/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
@@ -1,0 +1,270 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbDxfFiler } from '../src/base'
+import { AcDb2dPolyline, AcDbPoly2dType } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import {
+  attachEntityToNewModelSpace,
+  getDxfGroupValues
+} from '../test-utils/entityTestUtils'
+
+describe('AcDb2dPolyline', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, []))
+  })
+
+  it('covers constructor behavior, basic getters and setters', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 2, y: 3, z: 0 }
+      ],
+      5,
+      true,
+      0,
+      0,
+      [0.5]
+    )
+
+    expect(polyline.dxfTypeName).toBe('POLYLINE')
+    expect(polyline.numberOfVertices).toBe(2)
+    expect(polyline.polyType).toBe(AcDbPoly2dType.SimplePoly)
+    expect(polyline.elevation).toBe(5)
+    expect(polyline.closed).toBe(true)
+    expect(polyline.getPointAt(1)).toEqual({ x: 2, y: 3 })
+    expect(polyline.getBulgeAt(0)).toBe(0)
+
+    polyline.polyType = AcDbPoly2dType.CubicSplinePoly
+    polyline.elevation = 9
+    polyline.closed = false
+    expect(polyline.polyType).toBe(AcDbPoly2dType.CubicSplinePoly)
+    expect(polyline.elevation).toBe(9)
+    expect(polyline.closed).toBe(false)
+  })
+
+  it('gets bulges and falls back to 0 when missing/out of range', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 3, y: 0, z: 0 }
+      ],
+      0,
+      false,
+      0,
+      0,
+      [0.25, -0.5]
+    )
+
+    expect(polyline.getBulgeAt(0)).toBe(0.25)
+    expect(polyline.getBulgeAt(1)).toBe(-0.5)
+    expect(polyline.getBulgeAt(9)).toBe(0)
+
+    const noBulgePolyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 }
+    ])
+    expect(noBulgePolyline.getBulgeAt(0)).toBe(0)
+  })
+
+  it('returns geometric extents with elevation', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: -1, y: 2, z: 0 },
+        { x: 3, y: -4, z: 0 }
+      ],
+      7
+    )
+
+    const ext = polyline.geometricExtents
+    expect(ext.min).toMatchObject({ x: -1, y: -4, z: 7 })
+    expect(ext.max).toMatchObject({ x: 3, y: 2, z: 7 })
+  })
+
+  it('returns grip points and osnap points for endpoint mode only', () => {
+    const polyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 0 },
+      { x: 2, y: 2, z: 0 }
+    ])
+
+    const gripPoints = polyline.subGetGripPoints()
+    expect(gripPoints).toHaveLength(3)
+    expect(gripPoints[0]).toEqual(new AcGePoint3d(0, 0, 0))
+
+    const endpointSnaps: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    expect(endpointSnaps).toHaveLength(3)
+
+    const otherModeSnaps: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      otherModeSnaps
+    )
+    expect(otherModeSnaps).toHaveLength(0)
+  })
+
+  it('transforms geometry and flips bulges for mirrored transform', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 1, y: 2, z: 0 },
+        { x: 3, y: 4, z: 0 }
+      ],
+      3,
+      false,
+      0,
+      0,
+      [0.25, -0.5]
+    )
+
+    const result = polyline.transformBy(new AcGeMatrix3d().makeScale(-1, 1, 1))
+    expect(result).toBe(polyline)
+    expect(polyline.getPointAt(0)).toEqual({ x: -1, y: 2 })
+    expect(polyline.getBulgeAt(0)).toBe(-0.25)
+    expect(polyline.getBulgeAt(1)).toBe(0.5)
+
+    polyline.transformBy(new AcGeMatrix3d().makeTranslation(0, 0, 5))
+    expect(polyline.elevation).toBe(8)
+  })
+
+  it('exposes properties groups and property accessors', () => {
+    const polyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 3, y: 4, z: 0 }
+    ])
+
+    const props = polyline.properties
+    expect(props.type).toBe(polyline.type)
+
+    const geometryGroup = props.groups.find(g => g.groupName === 'geometry')
+    const othersGroup = props.groups.find(g => g.groupName === 'others')
+    expect(geometryGroup).toBeDefined()
+    expect(othersGroup).toBeDefined()
+
+    const verticesProp = geometryGroup!.properties.find(
+      p => p.name === 'vertices'
+    )
+    const elevationProp = geometryGroup!.properties.find(
+      p => p.name === 'elevation'
+    )
+    const lengthProp = geometryGroup!.properties.find(p => p.name === 'length')
+    const closedProp = othersGroup!.properties.find(p => p.name === 'closed')
+
+    expect((verticesProp?.accessor.get() as unknown[]).length).toBe(2)
+    expect(lengthProp?.accessor.get()).toBe(5)
+
+    elevationProp?.accessor.set?.(11)
+    expect(elevationProp?.accessor.get()).toBe(11)
+
+    closedProp?.accessor.set?.(true)
+    expect(closedProp?.accessor.get()).toBe(true)
+  })
+
+  it('draws through subWorldDraw using sampled points at current elevation', () => {
+    const polyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 0 }
+    ])
+    polyline.elevation = 6
+
+    const renderer = {
+      lines: jest.fn(() => 'rendered')
+    }
+
+    const result = polyline.subWorldDraw(renderer as never)
+    expect(result).toBe('rendered')
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    const [points] = renderer.lines.mock.calls[0] as unknown as [AcGePoint3d[]]
+    expect(points.length).toBeGreaterThan(1)
+    expect(points.every(p => p.z === 6)).toBe(true)
+  })
+
+  it('writes dxf fields with expected flags and vertex-follow marker', () => {
+    const cases = [
+      {
+        polyline: new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
+          { x: 0, y: 0, z: 0 }
+        ]),
+        expected66: 1,
+        expectedFlag: 0
+      },
+      {
+        polyline: new AcDb2dPolyline(AcDbPoly2dType.FitCurvePoly, []),
+        expected66: 0,
+        expectedFlag: 2
+      },
+      {
+        polyline: new AcDb2dPolyline(AcDbPoly2dType.QuadSplinePoly, [
+          { x: 0, y: 0, z: 0 }
+        ]),
+        expected66: 1,
+        expectedFlag: 4
+      },
+      {
+        polyline: new AcDb2dPolyline(AcDbPoly2dType.CubicSplinePoly, [
+          { x: 0, y: 0, z: 0 }
+        ]),
+        expected66: 1,
+        expectedFlag: 9,
+        closed: true,
+        elevation: 12
+      }
+    ]
+
+    cases.forEach(
+      ({ polyline, expected66, expectedFlag, closed, elevation }) => {
+        if (closed != null) polyline.closed = closed
+        if (elevation != null) polyline.elevation = elevation
+        attachEntityToNewModelSpace(polyline)
+        const filer = new AcDbDxfFiler()
+        polyline.dxfOutFields(filer)
+        const out = filer.toString()
+
+        expect(getDxfGroupValues(out, 100)).toContain('AcDb2dPolyline')
+        expect(getDxfGroupValues(out, 66)).toContain(String(expected66))
+        expect(getDxfGroupValues(out, 70)).toContain(String(expectedFlag))
+        if (elevation != null) {
+          expect(getDxfGroupValues(out, 30)).toContain(String(elevation))
+        }
+      }
+    )
+  })
+
+  it('writes full dxf records including VERTEX and SEQEND records', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 2, y: 0, z: 0 }
+      ],
+      3,
+      false,
+      0,
+      0,
+      [0.5, 0]
+    )
+    attachEntityToNewModelSpace(polyline)
+
+    const filer = new AcDbDxfFiler()
+    const result = polyline.dxfOut(filer)
+    expect(result).toBe(polyline)
+
+    const out = filer.toString()
+    const vertexRecords = out.match(/\n0\nVERTEX\n/g) ?? []
+    expect(vertexRecords.length).toBe(2)
+    expect(out).toContain('\n0\nSEQEND\n')
+    expect(out).toContain('\n100\nAcDb2dVertex\n')
+    expect(out).toContain('\n42\n0.5\n')
+    expect(out).toContain('\n30\n3\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDb2dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dVertex.spec.ts
@@ -1,0 +1,115 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDb2dVertex, AcDb2dVertexType } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDb2dVertex', () => {
+  it('exposes expected type names and default values', () => {
+    const vertex = new AcDb2dVertex()
+
+    expect(AcDb2dVertex.typeName).toBe('2dVertex')
+    expect(vertex.dxfTypeName).toBe('VERTEX')
+    expect(vertex.position).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(vertex.bulge).toBe(0)
+    expect(vertex.startWidth).toBe(0)
+    expect(vertex.endWidth).toBe(0)
+    expect(vertex.vertexType).toBe(AcDb2dVertexType.Vertex)
+  })
+
+  it('supports all public setters and getters', () => {
+    const vertex = new AcDb2dVertex()
+
+    vertex.position = { x: 1.5, y: -2.25, z: 3.75 }
+    vertex.bulge = 0.5
+    vertex.startWidth = 2.2
+    vertex.endWidth = 3.3
+    vertex.vertexType = AcDb2dVertexType.CurveFitVertex
+
+    expect(vertex.position).toMatchObject({ x: 1.5, y: -2.25, z: 3.75 })
+    expect(vertex.bulge).toBe(0.5)
+    expect(vertex.startWidth).toBe(2.2)
+    expect(vertex.endWidth).toBe(3.3)
+    expect(vertex.vertexType).toBe(AcDb2dVertexType.CurveFitVertex)
+  })
+
+  it('returns a point-like extents box centered on position', () => {
+    const vertex = new AcDb2dVertex()
+    vertex.position = { x: 6, y: 7, z: 8 }
+
+    const extents = vertex.geometricExtents
+
+    expect(extents.min).toMatchObject({ x: 6, y: 7, z: 8 })
+    expect(extents.max).toMatchObject({ x: 6, y: 7, z: 8 })
+  })
+
+  it('returns one grip point and one osnap point at vertex position', () => {
+    const vertex = new AcDb2dVertex()
+    vertex.position = { x: 9, y: 10, z: 11 }
+
+    const grips = vertex.subGetGripPoints()
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(vertex.position)
+
+    const snapPoints: AcGePoint3d[] = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 1, 1),
+      snapPoints
+    )
+    expect(snapPoints).toHaveLength(1)
+    expect(snapPoints[0]).toBe(vertex.position)
+  })
+
+  it('transforms position and returns itself', () => {
+    const vertex = new AcDb2dVertex()
+    vertex.position = { x: 1, y: 2, z: 3 }
+
+    const matrix = new AcGeMatrix3d().makeTranslation(4, -5, 6)
+    const result = vertex.transformBy(matrix)
+
+    expect(result).toBe(vertex)
+    expect(vertex.position).toMatchObject({ x: 5, y: -3, z: 9 })
+  })
+
+  it('returns undefined from subWorldDraw because parent polyline draws it', () => {
+    const vertex = new AcDb2dVertex()
+
+    expect(vertex.subWorldDraw({} as never)).toBeUndefined()
+  })
+
+  it('writes DXF fields for AcDbVertex/AcDb2dVertex data and returns itself', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const vertex = new AcDb2dVertex()
+    db.tables.blockTable.modelSpace.appendEntity(vertex)
+    vertex.position = { x: 1.25, y: 2.5, z: 3.75 }
+    vertex.startWidth = 4.5
+    vertex.endWidth = 5.5
+    vertex.bulge = 0.25
+    vertex.vertexType = AcDb2dVertexType.SplineFitVertex
+
+    const filer = new AcDbDxfFiler()
+    const result = vertex.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(vertex)
+    expect(dxf).toContain('100\nAcDbVertex\n')
+    expect(dxf).toContain('100\nAcDb2dVertex\n')
+    expect(dxf).toContain('10\n1.25\n')
+    expect(dxf).toContain('20\n2.5\n')
+    expect(dxf).toContain('40\n4.5\n')
+    expect(dxf).toContain('41\n5.5\n')
+    expect(dxf).toContain('42\n0.25\n')
+    expect(dxf).toContain('70\n8\n')
+  })
+
+  it('clone creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDb2dVertex())
+  })
+})

--- a/packages/data-model/__tests__/AcDb3PointAngularDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDb3PointAngularDimension.spec.ts
@@ -1,0 +1,17 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDb3PointAngularDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDb3PointAngularDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDb3PointAngularDimension(
+          new AcGePoint3d(),
+          new AcGePoint3d(1, 0, 0),
+          new AcGePoint3d(0, 1, 0),
+          new AcGePoint3d(1, 1, 0)
+        )
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
@@ -1,0 +1,230 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbDxfFiler } from '../src/base'
+import { AcDb3dPolyline, AcDbPoly3dType } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import {
+  appendEntityToModelSpace,
+  getDxfGroupValues,
+  setupWorkingDatabase
+} from '../test-utils/entityTestUtils'
+
+describe('AcDb3dPolyline', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, []))
+  })
+  it('supports public getters/setters and point accessors', () => {
+    const polyline = new AcDb3dPolyline(
+      AcDbPoly3dType.SimplePoly,
+      [
+        { x: 1, y: 2, z: 3 },
+        { x: 4, y: 5 } as unknown as { x: number; y: number; z: number },
+        { x: -1, y: 0, z: 8 }
+      ],
+      true
+    )
+
+    expect(polyline.dxfTypeName).toBe('POLYLINE')
+    expect(polyline.polyType).toBe(AcDbPoly3dType.SimplePoly)
+    expect(polyline.closed).toBe(true)
+    expect(polyline.numberOfVertices).toBe(3)
+    expect(polyline.getPointAt(0)).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(polyline.getPointAt(1)).toMatchObject({ x: 4, y: 5, z: 0 })
+
+    polyline.polyType = AcDbPoly3dType.CubicSplinePoly
+    polyline.closed = false
+
+    expect(polyline.polyType).toBe(AcDbPoly3dType.CubicSplinePoly)
+    expect(polyline.closed).toBe(false)
+  })
+
+  it('computes geometric extents and grip/osnap points', () => {
+    const polyline = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+      { x: -1, y: 2, z: 3 },
+      { x: 4, y: -5 } as unknown as { x: number; y: number; z: number },
+      { x: 0, y: 1, z: -2 }
+    ])
+
+    const extents = polyline.geometricExtents
+    expect(extents.min).toMatchObject({ x: -1, y: -5, z: -2 })
+    expect(extents.max).toMatchObject({ x: 4, y: 2, z: 3 })
+
+    const grips = polyline.subGetGripPoints()
+    expect(grips).toHaveLength(3)
+    expect(grips[0]).toMatchObject({ x: -1, y: 2, z: 0 })
+    expect(grips[2]).toMatchObject({ x: 0, y: 1, z: 0 })
+
+    const endPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(3)
+    expect(endPoints[1]).toMatchObject({ x: 4, y: -5, z: 0 })
+
+    const nonEndPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      nonEndPoints
+    )
+    expect(nonEndPoints).toHaveLength(0)
+  })
+
+  it('transforms vertices and returns itself for chaining', () => {
+    const polyline = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 2, z: 3 }
+    ])
+
+    const result = polyline.transformBy(
+      new AcGeMatrix3d().makeTranslation(3, -2, 5)
+    )
+    expect(result).toBe(polyline)
+    expect(polyline.getPointAt(0)).toMatchObject({ x: 3, y: -2, z: 5 })
+    expect(polyline.getPointAt(1)).toMatchObject({ x: 4, y: 0, z: 8 })
+  })
+
+  it('returns runtime properties that can read and update values', () => {
+    const polyline = new AcDb3dPolyline(
+      AcDbPoly3dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 2, y: 0, z: 0 }
+      ],
+      false
+    )
+
+    const geometryGroup = polyline.properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    const othersGroup = polyline.properties.groups.find(
+      group => group.groupName === 'others'
+    )
+
+    expect(geometryGroup).toBeDefined()
+    expect(othersGroup).toBeDefined()
+
+    const verticesProp = geometryGroup!.properties.find(
+      p => p.name === 'vertices'
+    )
+    const lengthProp = geometryGroup!.properties.find(p => p.name === 'length')
+    const closedProp = othersGroup!.properties.find(p => p.name === 'closed')
+
+    expect(verticesProp?.accessor.get()).toHaveLength(2)
+    expect(lengthProp?.accessor.get()).toBeCloseTo(2, 8)
+    expect(closedProp?.accessor.get()).toBe(false)
+
+    closedProp?.accessor.set?.(true)
+    expect(polyline.closed).toBe(true)
+  })
+
+  it('draws using renderer.lines with 3d points', () => {
+    const polyline = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+      { x: 1, y: 2 } as unknown as { x: number; y: number; z: number },
+      { x: 4, y: 5, z: 6 }
+    ])
+    const giEntity = { id: 'gi' }
+    const renderer = {
+      lines: jest.fn(() => giEntity)
+    }
+
+    const result = polyline.subWorldDraw(renderer as never)
+    expect(result).toBe(giEntity)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.lines).toHaveBeenCalledWith([
+      expect.objectContaining({ x: 1, y: 2, z: 0 }),
+      expect.objectContaining({ x: 4, y: 5, z: 6 })
+    ])
+  })
+
+  it('writes dxfOutFields flags for closed/polyType/vertex-count combinations', () => {
+    const db = setupWorkingDatabase()
+    const cases = [
+      {
+        polyline: new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+          { x: 0, y: 0, z: 0 },
+          { x: 1, y: 1, z: 1 }
+        ]),
+        expectedFlag: 8,
+        expected66: 1
+      },
+      {
+        polyline: new AcDb3dPolyline(
+          AcDbPoly3dType.SimplePoly,
+          [{ x: 0, y: 0, z: 0 }],
+          true
+        ),
+        expectedFlag: 9,
+        expected66: 1
+      },
+      {
+        polyline: new AcDb3dPolyline(AcDbPoly3dType.QuadSplinePoly, [
+          { x: 0, y: 0, z: 0 }
+        ]),
+        expectedFlag: 24,
+        expected66: 1
+      },
+      {
+        polyline: new AcDb3dPolyline(AcDbPoly3dType.CubicSplinePoly, []),
+        expectedFlag: 40,
+        expected66: 0
+      }
+    ]
+
+    cases.forEach(({ polyline, expectedFlag, expected66 }) => {
+      appendEntityToModelSpace(db, polyline)
+      const filer = new AcDbDxfFiler()
+      polyline.dxfOutFields(filer)
+      const dxfText = filer.toString()
+
+      expect(getDxfGroupValues(dxfText, 100)).toContain('AcDb3dPolyline')
+      expect(getDxfGroupValues(dxfText, 66)).toContain(String(expected66))
+      expect(getDxfGroupValues(dxfText, 70)).toContain(String(expectedFlag))
+    })
+  })
+
+  it('writes vertex and seqend records in dxfOut', () => {
+    const db = setupWorkingDatabase()
+    const polyline = appendEntityToModelSpace(
+      db,
+      new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+        { x: 1, y: 2, z: 3 },
+        { x: 4, y: 5, z: 6 }
+      ])
+    )
+    const filer = new AcDbDxfFiler({ database: db })
+
+    const result = polyline.dxfOut(filer, true)
+    const dxfText = filer.toString()
+
+    expect(result).toBe(polyline)
+    expect((dxfText.match(/\n0\nVERTEX\n/g) || []).length).toBe(2)
+    expect(dxfText).toContain('\n0\nSEQEND\n')
+    expect((dxfText.match(/\n100\nAcDb3dPolylineVertex\n/g) || []).length).toBe(
+      2
+    )
+    expect(dxfText).toContain('\n10\n1\n20\n2\n30\n3\n')
+    expect(dxfText).toContain('\n10\n4\n20\n5\n30\n6\n')
+  })
+
+  it('writes dxfOut without allXdata argument and handles zero vertices', () => {
+    const db = setupWorkingDatabase()
+    const polyline = appendEntityToModelSpace(
+      db,
+      new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [])
+    )
+    const filer = new AcDbDxfFiler({ database: db })
+
+    polyline.dxfOut(filer)
+    const dxfText = filer.toString()
+
+    expect(getDxfGroupValues(dxfText, 66)).toContain('0')
+    expect(dxfText).not.toContain('\n0\nVERTEX\n')
+    expect(dxfText).toContain('\n0\nSEQEND\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDb3dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dVertex.spec.ts
@@ -1,0 +1,114 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDb3dVertex, AcDb3dVertexType } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDb3dVertex', () => {
+  it('exposes static and DXF type names', () => {
+    const vertex = new AcDb3dVertex()
+
+    expect(AcDb3dVertex.typeName).toBe('3dVertex')
+    expect(vertex.dxfTypeName).toBe('VERTEX')
+  })
+
+  it('initializes with default position and vertex type', () => {
+    const vertex = new AcDb3dVertex()
+
+    expect(vertex.position).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(vertex.vertexType).toBe(AcDb3dVertexType.SimpleVertex)
+  })
+
+  it('sets position by copying input values and updates geometric extents', () => {
+    const vertex = new AcDb3dVertex()
+    const source = new AcGePoint3d(1, 2, 3)
+
+    vertex.position = source
+    source.x = 100
+    source.y = 200
+    source.z = 300
+
+    expect(vertex.position).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    const extents = vertex.geometricExtents
+    expect(extents.min).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(extents.max).toMatchObject({ x: 1, y: 2, z: 3 })
+  })
+
+  it('gets and sets vertexType', () => {
+    const vertex = new AcDb3dVertex()
+
+    vertex.vertexType = AcDb3dVertexType.ControlVertex
+    expect(vertex.vertexType).toBe(AcDb3dVertexType.ControlVertex)
+  })
+
+  it('returns grip points containing its position', () => {
+    const vertex = new AcDb3dVertex()
+    vertex.position = { x: 7, y: 8, z: 9 }
+
+    const gripPoints = vertex.subGetGripPoints()
+    expect(gripPoints).toHaveLength(1)
+    expect(gripPoints[0]).toBe(vertex.position)
+    expect(gripPoints[0]).toMatchObject({ x: 7, y: 8, z: 9 })
+  })
+
+  it('appends osnap point with current position', () => {
+    const vertex = new AcDb3dVertex()
+    vertex.position = { x: -1, y: 2.5, z: 3 }
+
+    const snapPoints: Array<{ x: number; y: number; z: number }> = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1 },
+      snapPoints
+    )
+
+    expect(snapPoints).toHaveLength(1)
+    expect(snapPoints[0]).toBe(vertex.position)
+    expect(snapPoints[0]).toMatchObject({ x: -1, y: 2.5, z: 3 })
+  })
+
+  it('transforms position by matrix and returns itself', () => {
+    const vertex = new AcDb3dVertex()
+    vertex.position = { x: 1, y: 2, z: 3 }
+
+    const result = vertex.transformBy(
+      new AcGeMatrix3d().makeTranslation(4, -2, 1)
+    )
+
+    expect(result).toBe(vertex)
+    expect(vertex.position).toMatchObject({ x: 5, y: 0, z: 4 })
+  })
+
+  it('subWorldDraw returns undefined', () => {
+    const vertex = new AcDb3dVertex()
+
+    expect(vertex.subWorldDraw({} as never)).toBeUndefined()
+  })
+
+  it('writes vertex-specific DXF fields', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const vertex = new AcDb3dVertex()
+    vertex.position = { x: 1.25, y: -2, z: 3.5 }
+    vertex.vertexType = AcDb3dVertexType.ControlVertex
+    db.tables.blockTable.modelSpace.appendEntity(vertex)
+
+    const filer = new AcDbDxfFiler()
+    const result = vertex.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(vertex)
+    expect(dxf).toContain('100\nAcDbVertex\n100\nAcDb3dPolylineVertex\n')
+    expect(dxf).toContain('10\n1.25\n20\n-2\n30\n3.5\n')
+    expect(dxf).toContain('70\n33\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDb3dVertex())
+  })
+})

--- a/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
@@ -1,0 +1,16 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbAlignedDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbAlignedDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbAlignedDimension(
+          new AcGePoint3d(),
+          new AcGePoint3d(1, 0, 0),
+          new AcGePoint3d(0, 1, 0)
+        )
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -1,0 +1,249 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbArc } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbArc', () => {
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(() => new AcDbArc(new AcGePoint3d(), 1, 0, Math.PI))
+  })
+
+  it('supports public geometric getters and setters', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(1, 2, 0), 2, 0, Math.PI / 2)
+    const arcWithNormal = new AcDbArc(
+      new AcGePoint3d(0, 0, 0),
+      1,
+      0,
+      Math.PI / 2,
+      new AcGeVector3d(0, 0, 1)
+    )
+
+    expect(arc.dxfTypeName).toBe('ARC')
+    expect(arc.center).toBeInstanceOf(AcGePoint3d)
+    expect(arc.radius).toBe(2)
+    expect(arc.startAngle).toBe(0)
+    expect(arc.endAngle).toBeCloseTo(Math.PI / 2)
+    expect(arc.normal).toBeInstanceOf(AcGeVector3d)
+    expect(arcWithNormal.normal.z).toBeCloseTo(1)
+
+    arc.center = new AcGePoint3d(3, 4, 1)
+    arc.radius = 5
+    arc.startAngle = Math.PI / 4
+    arc.endAngle = Math.PI
+    arc.normal = new AcGeVector3d(0, 0, 1)
+
+    expect(arc.center.x).toBeCloseTo(3)
+    expect(arc.center.y).toBeCloseTo(4)
+    expect(arc.center.z).toBeCloseTo(1)
+    expect(arc.radius).toBe(5)
+    expect(arc.startAngle).toBeCloseTo(Math.PI / 4)
+    expect(arc.endAngle).toBeCloseTo(Math.PI)
+    expect(arc.normal.z).toBeCloseTo(1)
+
+    expect(arc.startPoint).toBeInstanceOf(AcGePoint3d)
+    expect(arc.endPoint).toBeInstanceOf(AcGePoint3d)
+    expect(arc.midPoint).toBeInstanceOf(AcGePoint3d)
+    expect(arc.geometricExtents).toBeDefined()
+    expect(typeof arc.closed).toBe('boolean')
+  })
+
+  it('exposes runtime properties and accessors', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 3, 0, Math.PI / 2)
+    const properties = arc.properties
+
+    expect(properties.type).toBe('Arc')
+    expect(properties.groups.length).toBe(2)
+
+    const geometryGroup = properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(geometryGroup).toBeDefined()
+
+    const radiusProp = geometryGroup!.properties.find(p => p.name === 'radius')
+    expect(radiusProp?.editable).toBe(true)
+    radiusProp?.accessor.set?.(10)
+    expect(arc.radius).toBe(10)
+    expect(radiusProp?.accessor.get()).toBe(10)
+
+    const centerXProp = geometryGroup!.properties.find(
+      p => p.name === 'centerX'
+    )
+    centerXProp?.accessor.set?.(7)
+    expect(arc.center.x).toBe(7)
+
+    const arcLengthProp = geometryGroup!.properties.find(
+      p => p.name === 'arcLength'
+    )
+    expect(arcLengthProp?.editable).toBe(false)
+    expect(typeof arcLengthProp?.accessor.get()).toBe('number')
+
+    const propertyValues: Record<string, number> = {
+      centerX: 11,
+      centerY: 12,
+      centerZ: 13,
+      radius: 14,
+      startAngle: Math.PI / 6,
+      endAngle: Math.PI / 3,
+      normalX: 0,
+      normalY: 0,
+      normalZ: 1
+    }
+
+    for (const prop of geometryGroup!.properties) {
+      prop.accessor.get()
+      if (prop.editable && prop.accessor.set) {
+        prop.accessor.set(propertyValues[prop.name] ?? 0)
+      }
+      prop.accessor.get()
+    }
+
+    expect(arc.center.x).toBeCloseTo(11)
+    expect(arc.center.y).toBeCloseTo(12)
+    expect(arc.center.z).toBeCloseTo(13)
+    expect(arc.radius).toBeCloseTo(14)
+    expect(arc.startAngle).toBeCloseTo(Math.PI / 6)
+    expect(arc.endAngle).toBeCloseTo(Math.PI / 3)
+    expect(arc.normal.z).toBeCloseTo(1)
+  })
+
+  it('returns grip points for center/start/end', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 2, 0, Math.PI / 2)
+    const gripPoints = arc.subGetGripPoints()
+
+    expect(gripPoints).toHaveLength(3)
+    expect(gripPoints[0]).toBe(arc.center)
+    expect(gripPoints[1]).toEqual(arc.startPoint)
+    expect(gripPoints[2]).toEqual(arc.endPoint)
+  })
+
+  it('computes osnap points for all supported modes', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 5, 0, Math.PI)
+    const geo = (
+      arc as unknown as {
+        _geo: {
+          nearestPoint: (pick: AcGePoint3d) => AcGePoint3d
+          tangentPoints: (pick: AcGePoint3d) => AcGePoint3d[]
+        }
+      }
+    )._geo
+
+    const nearest = new AcGePoint3d(1, 1, 0)
+    const tangentA = new AcGePoint3d(2, 2, 0)
+    const tangentB = new AcGePoint3d(3, 3, 0)
+    jest.spyOn(geo, 'nearestPoint').mockReturnValue(nearest)
+    jest.spyOn(geo, 'tangentPoints').mockReturnValue([tangentA, tangentB])
+
+    const endPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(2)
+
+    const midPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(1)
+
+    const nearestPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toEqual([nearest])
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(0)
+
+    const tangentPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.Tangent,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      tangentPoints
+    )
+    expect(tangentPoints).toEqual([tangentA, tangentB])
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('transforms itself and draws with renderer', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(1, 2, 3), 2, 0, Math.PI / 2)
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -2, 1)
+
+    expect(arc.transformBy(matrix)).toBe(arc)
+    expect(arc.center.x).toBeCloseTo(11)
+    expect(arc.center.y).toBeCloseTo(0)
+    expect(arc.center.z).toBeCloseTo(4)
+
+    const drawResult = { id: 'arc-rendered' }
+    const renderer = {
+      circularArc: jest.fn(() => drawResult)
+    }
+
+    expect(arc.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.circularArc).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes arc-specific DXF fields', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(1, 2, 3), 4, 0, Math.PI / 2)
+    arc.ownerId = 'ABC'
+    const filer = new AcDbDxfFiler()
+
+    expect(arc.dxfOutFields(filer)).toBe(arc)
+
+    const out = filer.toString()
+    expect(out).toContain('100\nAcDbEntity')
+    expect(out).toContain('100\nAcDbArc')
+    expect(out).toContain('10\n1')
+    expect(out).toContain('20\n2')
+    expect(out).toContain('30\n3')
+    expect(out).toContain('40\n4')
+    expect(out).toContain('50\n0')
+    expect(out).toContain('51\n90')
+    expect(out).toContain('210\n0')
+    expect(out).toContain('220\n0')
+    expect(out).toContain('230\n1')
+  })
+})

--- a/packages/data-model/__tests__/AcDbArcDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbArcDimension.spec.ts
@@ -1,0 +1,17 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbArcDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbArcDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbArcDimension(
+          new AcGePoint3d(),
+          new AcGePoint3d(1, 0, 0),
+          new AcGePoint3d(0, 1, 0),
+          new AcGePoint3d(1, 1, 0)
+        )
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbAttribute.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttribute.spec.ts
@@ -1,0 +1,146 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbAttribute, AcDbMText } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const setWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+const createDxf = (attribute: AcDbAttribute) => {
+  const filer = new AcDbDxfFiler()
+  attribute.dxfOutFields(filer)
+  return filer.toString()
+}
+
+const prepareAttributeForDxf = (attribute: AcDbAttribute) => {
+  attribute.ownerId = 'NON_EXIST_OWNER'
+  attribute.layer = '0'
+  attribute.lineWeight = 0
+  attribute.linetypeScale = 1
+}
+
+describe('AcDbAttribute', () => {
+  it('has expected type metadata', () => {
+    const attribute = new AcDbAttribute()
+
+    expect(AcDbAttribute.typeName).toBe('Attrib')
+    expect(attribute.dxfTypeName).toBe('ATTRIB')
+  })
+
+  it('toggles attribute flags via boolean accessors', () => {
+    const attribute = new AcDbAttribute()
+
+    expect(attribute.isInvisible).toBe(false)
+    attribute.isInvisible = true
+    expect(attribute.isInvisible).toBe(true)
+    attribute.isInvisible = false
+    expect(attribute.isInvisible).toBe(false)
+
+    expect(attribute.isConst).toBe(false)
+    attribute.isConst = true
+    expect(attribute.isConst).toBe(true)
+    attribute.isConst = false
+    expect(attribute.isConst).toBe(false)
+
+    expect(attribute.isVerifiable).toBe(false)
+    attribute.isVerifiable = true
+    expect(attribute.isVerifiable).toBe(true)
+    attribute.isVerifiable = false
+    expect(attribute.isVerifiable).toBe(false)
+
+    expect(attribute.isPreset).toBe(false)
+    attribute.isPreset = true
+    expect(attribute.isPreset).toBe(true)
+    attribute.isPreset = false
+    expect(attribute.isPreset).toBe(false)
+
+    expect(attribute.isConstMTextAttribute).toBe(false)
+    attribute.isConstMTextAttribute = true
+    expect(attribute.isConstMTextAttribute).toBe(true)
+    attribute.isConstMTextAttribute = false
+    expect(attribute.isConstMTextAttribute).toBe(false)
+  })
+
+  it('supports scalar properties', () => {
+    const attribute = new AcDbAttribute()
+
+    attribute.tag = 'TAG_A'
+    attribute.fieldLength = 64
+    attribute.lockPositionInBlock = true
+    attribute.isReallyLocked = true
+
+    expect(attribute.tag).toBe('TAG_A')
+    expect(attribute.fieldLength).toBe(64)
+    expect(attribute.lockPositionInBlock).toBe(true)
+    expect(attribute.isReallyLocked).toBe(true)
+  })
+
+  it('updates mtext and multiline flags automatically', () => {
+    const attribute = new AcDbAttribute()
+    const mtext = new AcDbMText()
+
+    expect(attribute.mtext).toBeUndefined()
+    expect(attribute.isMTextAttribute).toBe(false)
+
+    attribute.mtext = mtext
+    expect(attribute.mtext).toBe(mtext)
+    expect(attribute.isMTextAttribute).toBe(true)
+
+    attribute.isMTextAttribute = false
+    expect(attribute.isMTextAttribute).toBe(false)
+
+    attribute.mtext = undefined
+    expect(attribute.mtext).toBeUndefined()
+    expect(attribute.isMTextAttribute).toBe(false)
+  })
+
+  it('writes expected DXF fields for single-line attribute', () => {
+    setWorkingDb()
+    const attribute = new AcDbAttribute()
+    prepareAttributeForDxf(attribute)
+    attribute.tag = 'TAG_A'
+    attribute.fieldLength = 32
+    attribute.isInvisible = true
+    attribute.isReallyLocked = true
+
+    const filer = new AcDbDxfFiler()
+    expect(attribute.dxfOutFields(filer)).toBe(attribute)
+
+    const dxf = filer.toString()
+    expect(dxf).toContain('100\nAcDbAttribute\n')
+    expect(dxf).toContain('70\n1\n')
+    expect(dxf).toContain('73\n32\n')
+    expect(dxf).toContain('2\nTAG_A\n')
+    expect(dxf).toContain('74\n1\n')
+    expect(dxf).not.toContain('\n71\n')
+  })
+
+  it('writes group 71 as 1 when multiline attribute is enabled', () => {
+    setWorkingDb()
+    const attribute = new AcDbAttribute()
+    prepareAttributeForDxf(attribute)
+    attribute.mtext = new AcDbMText()
+
+    const dxf = createDxf(attribute)
+    expect(dxf).toContain('71\n1\n')
+  })
+
+  it('writes group 71 as 0 when mtext exists but multiline flag is disabled', () => {
+    setWorkingDb()
+    const attribute = new AcDbAttribute()
+    prepareAttributeForDxf(attribute)
+    attribute.mtext = new AcDbMText()
+    attribute.isMTextAttribute = false
+
+    const dxf = createDxf(attribute)
+    expect(dxf).toContain('71\n0\n')
+  })
+
+  it('clone creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbAttribute())
+  })
+})

--- a/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
@@ -1,0 +1,132 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbAttributeDefinition, AcDbMText } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const setWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbAttributeDefinition', () => {
+  it('exposes correct type names', () => {
+    const attDef = new AcDbAttributeDefinition()
+    expect(AcDbAttributeDefinition.typeName).toBe('AttDef')
+    expect(attDef.dxfTypeName).toBe('ATTDEF')
+  })
+
+  it('supports attribute flag toggles through public getters/setters', () => {
+    const attDef = new AcDbAttributeDefinition()
+
+    expect(attDef.isInvisible).toBe(false)
+    expect(attDef.isConst).toBe(false)
+    expect(attDef.isVerifiable).toBe(false)
+    expect(attDef.isPreset).toBe(false)
+    expect(attDef.isMTextAttribute).toBe(false)
+    expect(attDef.isConstMTextAttribute).toBe(false)
+
+    attDef.isInvisible = true
+    attDef.isConst = true
+    attDef.isVerifiable = true
+    attDef.isPreset = true
+    attDef.isMTextAttribute = true
+    attDef.isConstMTextAttribute = true
+
+    expect(attDef.isInvisible).toBe(true)
+    expect(attDef.isConst).toBe(true)
+    expect(attDef.isVerifiable).toBe(true)
+    expect(attDef.isPreset).toBe(true)
+    expect(attDef.isMTextAttribute).toBe(true)
+    expect(attDef.isConstMTextAttribute).toBe(true)
+
+    attDef.isInvisible = false
+    attDef.isConst = false
+    attDef.isVerifiable = false
+    attDef.isPreset = false
+    attDef.isMTextAttribute = false
+    attDef.isConstMTextAttribute = false
+
+    expect(attDef.isInvisible).toBe(false)
+    expect(attDef.isConst).toBe(false)
+    expect(attDef.isVerifiable).toBe(false)
+    expect(attDef.isPreset).toBe(false)
+    expect(attDef.isMTextAttribute).toBe(false)
+    expect(attDef.isConstMTextAttribute).toBe(false)
+  })
+
+  it('supports basic scalar properties', () => {
+    const attDef = new AcDbAttributeDefinition()
+
+    expect(attDef.prompt).toBe('')
+    expect(attDef.tag).toBe('')
+    expect(attDef.fieldLength).toBe(0)
+    expect(attDef.lockPositionInBlock).toBe(false)
+    expect(attDef.isReallyLocked).toBe(false)
+
+    attDef.prompt = 'Please input tag value'
+    attDef.tag = 'TAG_01'
+    attDef.fieldLength = 123
+    attDef.lockPositionInBlock = true
+    attDef.isReallyLocked = true
+
+    expect(attDef.prompt).toBe('Please input tag value')
+    expect(attDef.tag).toBe('TAG_01')
+    expect(attDef.fieldLength).toBe(123)
+    expect(attDef.lockPositionInBlock).toBe(true)
+    expect(attDef.isReallyLocked).toBe(true)
+  })
+
+  it('keeps mtext and isMTextAttribute in sync', () => {
+    const attDef = new AcDbAttributeDefinition()
+    const mtext = new AcDbMText()
+
+    expect(attDef.mtext).toBeUndefined()
+    expect(attDef.isMTextAttribute).toBe(false)
+
+    attDef.mtext = mtext
+    expect(attDef.mtext).toBe(mtext)
+    expect(attDef.isMTextAttribute).toBe(true)
+
+    attDef.mtext = undefined
+    expect(attDef.mtext).toBeUndefined()
+    expect(attDef.isMTextAttribute).toBe(false)
+  })
+
+  it('returns undefined in subWorldDraw', () => {
+    const attDef = new AcDbAttributeDefinition()
+    expect(attDef.subWorldDraw({} as never)).toBeUndefined()
+  })
+
+  it('writes expected ATTDEF-specific fields in dxfOutFields', () => {
+    const db = setWorkingDb()
+    const attDef = new AcDbAttributeDefinition()
+    const filer = new AcDbDxfFiler()
+
+    attDef.ownerId = db.tables.blockTable.modelSpace.objectId
+    attDef.layer = '0'
+    attDef.lineWeight = 0
+    attDef.linetypeScale = 1
+    attDef.prompt = 'Prompt text'
+    attDef.tag = 'A_TAG'
+    attDef.isInvisible = true
+    attDef.fieldLength = 42
+    attDef.isReallyLocked = true
+
+    const result = attDef.dxfOutFields(filer)
+    const out = filer.toString()
+
+    expect(result).toBe(attDef)
+    expect(out).toContain('AcDbAttributeDefinition')
+    expect(out).toContain('\n3\nPrompt text\n')
+    expect(out).toContain('\n2\nA_TAG\n')
+    expect(out).toContain('\n70\n1\n')
+    expect(out).toContain('\n73\n42\n')
+    expect(out).toContain('\n74\n1\n')
+  })
+
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbAttributeDefinition())
+  })
+})

--- a/packages/data-model/__tests__/AcDbBatchProcessing.spec.ts
+++ b/packages/data-model/__tests__/AcDbBatchProcessing.spec.ts
@@ -1,0 +1,45 @@
+import { AcDbBatchProcessing } from '../src/converter/AcDbBatchProcessing'
+
+describe('AcDbBatchProcessing', () => {
+  it('processes ranges in chunks and calls complete callback', async () => {
+    const batch = new AcDbBatchProcessing(5, 2, 2)
+    const ranges: Array<[number, number]> = []
+    let completed = false
+
+    await batch.processChunk(
+      async (start, end) => {
+        ranges.push([start, end])
+      },
+      async () => {
+        completed = true
+      }
+    )
+
+    expect(batch.count).toBe(5)
+    expect(batch.numerOfChunk).toBe(2)
+    expect(batch.minimumChunkSize).toBe(2)
+    expect(batch.chunkSize).toBe(2)
+    expect(ranges).toEqual([
+      [0, 2],
+      [2, 4],
+      [4, 5]
+    ])
+    expect(completed).toBe(true)
+  })
+
+  it('handles empty count and minimum size recalculation', async () => {
+    const batch = new AcDbBatchProcessing(0, 0, 50)
+    let completed = false
+    await batch.processChunk(
+      async () => {},
+      () => {
+        completed = true
+      }
+    )
+    expect(completed).toBe(true)
+
+    const batch2 = new AcDbBatchProcessing(5, 10, 1)
+    batch2.minimumChunkSize = 3
+    expect(batch2.chunkSize).toBe(3)
+  })
+})

--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -1,0 +1,322 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import {
+  AcDbAttribute,
+  AcDbBlockReference,
+  AcDbLine,
+  AcDbPoint
+} from '../src/entity'
+import { AcDbOsnapMode, AcDbRenderingCache } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+const createNamedBlock = (db: AcDbDatabase, name: string) => {
+  const block = new AcDbBlockTableRecord()
+  block.name = name
+  db.tables.blockTable.add(block)
+  return block
+}
+
+describe('AcDbBlockReference', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbBlockReference('TEST'))
+  })
+
+  it('supports public getters/setters and block table record lookup', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    block.origin = new AcGePoint3d(1, 2, 3)
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    expect(AcDbBlockReference.typeName).toBe('BlockReference')
+    expect(blockRef.dxfTypeName).toBe('INSERT')
+
+    blockRef.position = { x: 10, y: 20, z: 30 }
+    blockRef.rotation = Math.PI / 3
+    blockRef.scaleFactors = { x: 2, y: 3, z: 4 }
+    blockRef.normal = { x: 0, y: 0, z: 5 }
+
+    expect(blockRef.position).toMatchObject({ x: 10, y: 20, z: 30 })
+    expect(blockRef.rotation).toBeCloseTo(Math.PI / 3)
+    expect(blockRef.scaleFactors).toMatchObject({ x: 2, y: 3, z: 4 })
+    expect(blockRef.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(blockRef.blockName).toBe('TEST_BLOCK')
+    expect(blockRef.blockTableRecord).toBe(block)
+  })
+
+  it('appends attributes and iterates attributes', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const attr1 = new AcDbAttribute()
+    attr1.database = db
+    attr1.tag = 'A1'
+    attr1.textString = 'v1'
+
+    const attr2 = new AcDbAttribute()
+    attr2.database = db
+    attr2.tag = 'A2'
+    attr2.textString = 'v2'
+
+    blockRef.appendAttributes(attr1)
+    blockRef.appendAttributes(attr2)
+
+    const attrs = [...blockRef.attributeIterator()]
+    expect(attrs).toHaveLength(2)
+    expect(attrs.map(a => a.tag)).toEqual(['A1', 'A2'])
+    expect(attr1.ownerId).toBe(blockRef.objectId)
+    expect(attr2.ownerId).toBe(blockRef.objectId)
+  })
+
+  it('computes blockTransform with base-point compensation', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    block.origin = new AcGePoint3d(1, 2, 0)
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(10, 20, 0)
+    blockRef.scaleFactors = new AcGePoint3d(2, 3, 1)
+    blockRef.rotation = Math.PI / 2
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const matrix = blockRef.blockTransform
+    const basePointInBlock = new AcGePoint3d(1, 2, 0).applyMatrix4(matrix)
+    const plusXFromBase = new AcGePoint3d(2, 2, 0).applyMatrix4(matrix)
+
+    expect(basePointInBlock).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(plusXFromBase.x).toBeCloseTo(10)
+    expect(plusXFromBase.y).toBeCloseTo(22)
+  })
+
+  it('returns insertion osnap and delegates to sub-entity osnap by gsMark', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    const point = new AcDbPoint()
+    point.position = new AcGePoint3d(2, 3, 0)
+    block.appendEntity(point)
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(10, 20, 0)
+    blockRef.scaleFactors = new AcGePoint3d(2, 3, 1)
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const insertionSnaps: AcGePoint3d[] = []
+    blockRef.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      insertionSnaps
+    )
+    expect(insertionSnaps).toEqual([blockRef.position])
+
+    const subEntitySnaps: AcGePoint3d[] = []
+    blockRef.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      subEntitySnaps,
+      point.objectId
+    )
+    expect(subEntitySnaps).toHaveLength(1)
+    expect(subEntitySnaps[0]).toMatchObject({ x: 14, y: 29, z: 0 })
+
+    const infiniteLoopGuardSnaps: AcGePoint3d[] = []
+    blockRef.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      infiniteLoopGuardSnaps,
+      blockRef.objectId
+    )
+    expect(infiniteLoopGuardSnaps).toHaveLength(0)
+  })
+
+  it('transforms insertion, scale, rotation, normal and attribute geometry', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(1, 0, 0)
+    blockRef.rotation = 0
+    blockRef.scaleFactors = new AcGePoint3d(2, 3, 4)
+
+    const attr = new AcDbAttribute()
+    attr.database = db
+    attr.position = new AcGePoint3d(2, 0, 0)
+    blockRef.appendAttributes(attr)
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    expect(
+      blockRef.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+    ).toBe(blockRef)
+    expect(blockRef.position.x).toBeCloseTo(0)
+    expect(blockRef.position.y).toBeCloseTo(1)
+    expect(blockRef.rotation).toBeCloseTo(Math.PI / 2)
+    expect(blockRef.scaleFactors.x).toBeCloseTo(2)
+    expect(blockRef.scaleFactors.y).toBeCloseTo(3)
+    expect(blockRef.scaleFactors.z).toBeCloseTo(4)
+    expect(attr.position.x).toBeCloseTo(0)
+    expect(attr.position.y).toBeCloseTo(2)
+  })
+
+  it('exposes geometry and attribute properties with working accessors', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const attr = new AcDbAttribute()
+    attr.database = db
+    attr.tag = 'TAG_A'
+    attr.textString = 'OLD'
+    attr.isConst = false
+    blockRef.appendAttributes(attr)
+
+    const props = blockRef.properties
+    expect(props.type).toBe('BlockReference')
+
+    const geometry = props.groups.find(g => g.groupName === 'geometry')
+    const attribute = props.groups.find(g => g.groupName === 'attribute')
+
+    expect(geometry).toBeDefined()
+    expect(attribute).toBeDefined()
+
+    const posX = geometry?.properties.find(p => p.name === 'positionX')
+    const scaleY = geometry?.properties.find(p => p.name === 'scaleFactorsY')
+    const normalZ = geometry?.properties.find(p => p.name === 'normalZ')
+
+    posX?.accessor.set?.(11)
+    scaleY?.accessor.set?.(2.5)
+    normalZ?.accessor.set?.(3)
+
+    expect(posX?.accessor.get()).toBe(11)
+    expect(scaleY?.accessor.get()).toBe(2.5)
+    expect(normalZ?.accessor.get()).toBe(3)
+
+    const attrProp = attribute?.properties.find(p => p.name === 'TAG_A')
+    expect(attrProp?.editable).toBe(true)
+    attrProp?.accessor.set?.('NEW')
+    expect(attrProp?.accessor.get()).toBe('NEW')
+    expect(attr.textString).toBe('NEW')
+  })
+
+  it('computes geometric extents from referenced block geometry and transform', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    block.appendEntity(new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 2, y: 3, z: 0 }))
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(5, 6, 0)
+    blockRef.scaleFactors = new AcGePoint3d(1, 1, 1)
+    blockRef.rotation = 0
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const extents = blockRef.geometricExtents
+    expect(extents.min).toMatchObject({ x: 5, y: 6, z: 0 })
+    expect(extents.max).toMatchObject({ x: 7, y: 9, z: 0 })
+  })
+
+  it('draws through cache for existing block and empty group for missing block', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const visibleAttr = new AcDbAttribute()
+    visibleAttr.database = db
+    visibleAttr.isInvisible = false
+    const hiddenAttr = new AcDbAttribute()
+    hiddenAttr.database = db
+    hiddenAttr.isInvisible = true
+
+    const visibleDrawn = { id: 'visible-attr' }
+    jest.spyOn(visibleAttr, 'worldDraw').mockReturnValue(visibleDrawn as never)
+    jest
+      .spyOn(hiddenAttr, 'worldDraw')
+      .mockReturnValue({ id: 'hidden-attr' } as never)
+
+    blockRef.appendAttributes(visibleAttr)
+    blockRef.appendAttributes(hiddenAttr)
+
+    const cacheResult = { id: 'block-rendered' }
+    const drawSpy = jest
+      .spyOn(AcDbRenderingCache.instance, 'draw')
+      .mockReturnValue(cacheResult as never)
+
+    const renderer = {
+      group: jest.fn((children: unknown[]) => ({ children }))
+    }
+
+    expect(blockRef.subWorldDraw(renderer as never)).toBe(cacheResult)
+    expect(drawSpy).toHaveBeenCalledTimes(1)
+    expect(drawSpy.mock.calls[0][3]).toEqual([visibleDrawn])
+
+    drawSpy.mockRestore()
+
+    const missing = new AcDbBlockReference('NOT_EXIST')
+    db.tables.blockTable.modelSpace.appendEntity(missing)
+    const empty = missing.subWorldDraw(renderer as never)
+    expect(renderer.group).toHaveBeenCalledWith([])
+    expect(empty).toEqual({ children: [] })
+  })
+
+  it('writes INSERT fields and ATTRIB/SEQEND records in DXF output', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(1, 2, 3)
+    blockRef.rotation = Math.PI / 6
+    blockRef.scaleFactors = new AcGePoint3d(2, 3, 4)
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const attr = new AcDbAttribute()
+    attr.database = db
+    attr.tag = 'TAG1'
+    attr.textString = 'VALUE1'
+    blockRef.appendAttributes(attr)
+
+    const filerFields = new AcDbDxfFiler()
+    expect(blockRef.dxfOutFields(filerFields)).toBe(blockRef)
+    const fields = filerFields.toString()
+    expect(fields).toContain('100\nAcDbBlockReference\n')
+    expect(fields).toContain('10\n1\n20\n2\n30\n3\n')
+    expect(fields).toContain('2\nTEST_BLOCK\n')
+    expect(fields).toContain('41\n2\n')
+    expect(fields).toContain('42\n3\n')
+    expect(fields).toContain('43\n4\n')
+    expect(fields).toContain('50\n29.9999999999999964\n')
+    expect(fields).toContain('210\n0\n220\n0\n230\n1\n')
+
+    const filerOut = new AcDbDxfFiler()
+    expect(blockRef.dxfOut(filerOut)).toBe(blockRef)
+    const out = filerOut.toString()
+    expect(out).toContain('\n0\nATTRIB\n')
+    expect(out).toContain('\n2\nTAG1\n')
+    expect(out).toContain('\n1\nVALUE1\n')
+    expect(out).toContain('\n0\nSEQEND\n')
+
+    const withoutAttributes = new AcDbBlockReference('TEST_BLOCK')
+    db.tables.blockTable.modelSpace.appendEntity(withoutAttributes)
+    const filerWithoutAttrs = new AcDbDxfFiler()
+    expect(withoutAttributes.dxfOut(filerWithoutAttrs, true)).toBe(
+      withoutAttributes
+    )
+    expect(filerWithoutAttrs.toString()).not.toContain('\n0\nATTRIB\n')
+    expect(filerWithoutAttrs.toString()).not.toContain('\n0\nSEQEND\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbBlockTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockTable.spec.ts
@@ -1,0 +1,58 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbBlockTable } from '../src/database/AcDbBlockTable'
+import { AcDbBlockTableRecord } from '../src/database/AcDbBlockTableRecord'
+import { AcDbLine } from '../src/entity/AcDbLine'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbBlockTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbBlockTable(new AcDbDatabase()))
+  })
+
+  it('creates model space lazily and reuses the same record', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.blockTable
+
+    const modelA = table.modelSpace
+    const modelB = table.modelSpace
+
+    expect(modelA).toBe(modelB)
+    expect(modelA.name).toBe(AcDbBlockTableRecord.MODEL_SPACE_NAME)
+    expect(table.getAt('*MODEL_SPACE')).toBe(modelA)
+  })
+
+  it('normalizes model/paper space names consistently', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.blockTable
+    const paper = new AcDbBlockTableRecord()
+    paper.name = '*PAPER_SPACE12'
+    table.add(paper)
+
+    expect(table.has('*paper_space12')).toBe(true)
+    expect(table.getAt('*Paper_Space12')).toBe(paper)
+    expect(table.remove('*PAPER_SPACE12')).toBe(true)
+    expect(table.has('*Paper_Space12')).toBe(false)
+  })
+
+  it('finds and removes entities across all block table records', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.blockTable
+    const modelSpace = table.modelSpace
+    const block = new AcDbBlockTableRecord()
+    block.name = 'MyBlock'
+    table.add(block)
+
+    const modelLine = new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 1, y: 0, z: 0 })
+    const blockLine = new AcDbLine({ x: 0, y: 1, z: 0 }, { x: 1, y: 1, z: 0 })
+    modelSpace.appendEntity(modelLine)
+    block.appendEntity(blockLine)
+
+    expect(table.getEntityById(modelLine.objectId)).toBe(modelLine)
+    expect(table.getEntityById(blockLine.objectId)).toBe(blockLine)
+    expect(table.getEntityById('NOT_EXISTS')).toBeUndefined()
+
+    expect(table.removeEntity(blockLine.objectId)).toBe(true)
+    expect(table.getEntityById(blockLine.objectId)).toBeUndefined()
+    expect(table.removeEntity('NOT_EXISTS')).toBe(false)
+  })
+})

--- a/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbBlockTableRecord } from '../src/database/AcDbBlockTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbBlockTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbBlockTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -1,0 +1,237 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+import { AcGiRenderer } from '@mlightcad/graphic-interface'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbCircle } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbCircle', () => {
+  it('exposes static and DXF type names', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(), 1)
+
+    expect(AcDbCircle.typeName).toBe('Circle')
+    expect(circle.dxfTypeName).toBe('CIRCLE')
+  })
+
+  it('initializes center radius normal and closed state', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(1, 2, 3), 4)
+
+    expect(circle.center).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(circle.radius).toBe(4)
+    expect(circle.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(circle.closed).toBe(true)
+
+    const extents = circle.geometricExtents
+    expect(extents.min).toMatchObject({ x: -3, y: -2, z: 3 })
+    expect(extents.max).toMatchObject({ x: 5, y: 6, z: 3 })
+  })
+
+  it('supports center and radius setters', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 1)
+
+    circle.center = new AcGePoint3d(-2, 3, 5)
+    circle.radius = 7
+
+    expect(circle.center).toMatchObject({ x: -2, y: 3, z: 5 })
+    expect(circle.radius).toBe(7)
+  })
+
+  it('returns grip points with center point', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(2, 3, 4), 5)
+
+    const grips = circle.subGetGripPoints()
+
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(circle.center)
+    expect(grips[0]).toMatchObject({ x: 2, y: 3, z: 4 })
+  })
+
+  it('collects center and centroid osnap points', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(3, 4, 0), 2)
+
+    const centerPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      centerPoints
+    )
+    expect(centerPoints).toHaveLength(1)
+    expect(centerPoints[0]).toBe(circle.center)
+
+    const centroidPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Centroid,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      centroidPoints
+    )
+    expect(centroidPoints).toHaveLength(1)
+    expect(centroidPoints[0]).toBe(circle.center)
+  })
+
+  it('collects quadrant osnap points', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(1, 2, 0), 3)
+    const snapPoints: AcGePoint3d[] = []
+
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Quadrant,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapPoints
+    )
+
+    expect(snapPoints).toHaveLength(4)
+    expect(snapPoints[0].x).toBeCloseTo(4, 8)
+    expect(snapPoints[0].y).toBeCloseTo(2, 8)
+    expect(snapPoints[1].x).toBeCloseTo(1, 8)
+    expect(snapPoints[1].y).toBeCloseTo(5, 8)
+    expect(snapPoints[2].x).toBeCloseTo(-2, 8)
+    expect(snapPoints[2].y).toBeCloseTo(2, 8)
+    expect(snapPoints[3].x).toBeCloseTo(1, 8)
+    expect(snapPoints[3].y).toBeCloseTo(-1, 8)
+  })
+
+  it('collects nearest and tangent osnap points and ignores unsupported mode', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 2)
+    const geo = (
+      circle as unknown as {
+        _geo: {
+          nearestPoint: (pick: AcGePoint3d) => AcGePoint3d
+          tangentPoints: (pick: AcGePoint3d) => AcGePoint3d[]
+        }
+      }
+    )._geo
+    const nearest = new AcGePoint3d(1, 1, 0)
+    const tangentA = new AcGePoint3d(2, 0, 0)
+    const tangentB = new AcGePoint3d(0, 2, 0)
+    jest.spyOn(geo, 'nearestPoint').mockReturnValue(nearest)
+    jest.spyOn(geo, 'tangentPoints').mockReturnValue([tangentA, tangentB])
+
+    const nearestPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(3, 1, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toEqual(nearest)
+
+    const tangentPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Tangent,
+      new AcGePoint3d(6, 0, 0),
+      new AcGePoint3d(),
+      tangentPoints
+    )
+    expect(tangentPoints).toEqual([tangentA, tangentB])
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('exposes geometry properties with editable accessors and derived values', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(1, 2, 3), 4)
+    const geometryGroup = circle.properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(geometryGroup).toBeDefined()
+
+    const byName = new Map(
+      geometryGroup!.properties.map(property => [property.name, property])
+    )
+
+    byName.get('centerX')!.accessor.set!(10)
+    byName.get('centerY')!.accessor.set!(20)
+    byName.get('centerZ')!.accessor.set!(30)
+    byName.get('radius')!.accessor.set!(5)
+    byName.get('normalX')!.accessor.set!(0)
+    byName.get('normalY')!.accessor.set!(1)
+    byName.get('normalZ')!.accessor.set!(0)
+
+    expect(byName.get('centerX')!.accessor.get()).toBe(10)
+    expect(byName.get('centerY')!.accessor.get()).toBe(20)
+    expect(byName.get('centerZ')!.accessor.get()).toBe(30)
+    expect(byName.get('radius')!.accessor.get()).toBe(5)
+    expect(byName.get('normalX')!.accessor.get()).toBe(0)
+    expect(byName.get('normalY')!.accessor.get()).toBe(1)
+    expect(byName.get('normalZ')!.accessor.get()).toBe(0)
+    expect(circle.center).toMatchObject({ x: 10, y: 20, z: 30 })
+    expect(circle.radius).toBe(5)
+    expect(circle.normal).toMatchObject({ x: 0, y: 1, z: 0 })
+    expect(byName.get('diameter')!.editable).toBe(false)
+    expect(byName.get('diameter')!.accessor.get()).toBeCloseTo(10, 8)
+    expect(byName.get('perimeter')!.accessor.get()).toBeCloseTo(Math.PI * 10, 8)
+    expect(byName.get('area')!.accessor.get()).toBeCloseTo(Math.PI * 25, 8)
+  })
+
+  it('transforms by matrix and returns itself', () => {
+    const circle = new AcDbCircle(
+      new AcGePoint3d(1, 2, 3),
+      2,
+      new AcGeVector3d(0, 0, 1)
+    )
+
+    const result = circle.transformBy(
+      new AcGeMatrix3d().makeTranslation(4, -2, 5)
+    )
+
+    expect(result).toBe(circle)
+    expect(circle.center).toMatchObject({ x: 5, y: 0, z: 8 })
+    expect(circle.radius).toBeCloseTo(2, 8)
+  })
+
+  it('delegates drawing to renderer.circularArc', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 2)
+    const rendered = { id: 'entity' }
+    const renderer = {
+      circularArc: jest.fn(() => rendered)
+    } as unknown as AcGiRenderer
+
+    const result = circle.subWorldDraw(renderer)
+
+    expect(result).toBe(rendered)
+    expect(
+      (renderer as unknown as { circularArc: jest.Mock }).circularArc
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes circle-specific DXF fields', () => {
+    createWorkingDb()
+    const circle = new AcDbCircle(new AcGePoint3d(1.5, -2, 3.25), 4.75)
+    circle.ownerId = 'ABC'
+    const filer = new AcDbDxfFiler()
+
+    const result = circle.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(circle)
+    expect(dxf).toContain('100\nAcDbCircle\n')
+    expect(dxf).toContain('10\n1.5\n20\n-2\n30\n3.25\n')
+    expect(dxf).toContain('40\n4.75\n')
+    expect(dxf).toContain('210\n0\n220\n0\n230\n1\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbCircle(new AcGePoint3d(), 1))
+  })
+})

--- a/packages/data-model/__tests__/AcDbDataGenerator.spec.ts
+++ b/packages/data-model/__tests__/AcDbDataGenerator.spec.ts
@@ -1,0 +1,32 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDataGenerator } from '../src/misc/AcDbDataGenerator'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+
+describe('AcDbDataGenerator', () => {
+  it('creates default records and arrow block', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    const generator = new AcDbDataGenerator(db)
+
+    generator.createDefaultLayer()
+    expect(db.tables.layerTable.getAt('0')?.name).toBe('0')
+
+    generator.createDefaultLineType()
+    expect(db.tables.linetypeTable.getAt('ByBlock')).toBeDefined()
+    expect(db.tables.linetypeTable.getAt('ByLayer')).toBeDefined()
+    expect(db.tables.linetypeTable.getAt('Continuous')).toBeDefined()
+
+    generator.createDefaultTextStyle()
+    expect(db.tables.textStyleTable.getAt('Standard')).toBeDefined()
+
+    generator.createDefaultDimStyle()
+    expect(db.tables.dimStyleTable.getAt('Standard')).toBeDefined()
+
+    generator.createDefaultLayout()
+    expect(db.objects.layout.getAt('Model')).toBeDefined()
+
+    generator.createArrowBlock()
+    generator.createArrowBlock()
+    expect(db.tables.blockTable.getAt('_CAXARROW')).toBeDefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbDatabase', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbDatabase())
+  })
+})

--- a/packages/data-model/__tests__/AcDbDatabaseConverterManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseConverterManager.spec.ts
@@ -1,0 +1,41 @@
+import { AcDbDxfConverter } from '../src/converter/AcDbDxfConverter'
+import {
+  AcDbDatabaseConverterManager,
+  AcDbFileType
+} from '../src/database/AcDbDatabaseConverterManager'
+
+describe('AcDbDatabaseConverterManager', () => {
+  it('creates singleton instance with default dxf converter', () => {
+    const manager = AcDbDatabaseConverterManager.instance
+    expect(AcDbDatabaseConverterManager.createInstance()).toBe(manager)
+    expect(manager.get(AcDbFileType.DXF)).toBeInstanceOf(AcDbDxfConverter)
+
+    const fileTypes = Array.from(manager.fileTypes)
+    expect(fileTypes).toContain(AcDbFileType.DXF)
+  })
+
+  it('registers and unregisters converters with events', () => {
+    const manager = AcDbDatabaseConverterManager.instance
+    const custom = new AcDbDxfConverter()
+
+    const registered: string[] = []
+    const unregistered: string[] = []
+
+    manager.events.registered.addEventListener(evt =>
+      registered.push(evt.fileType)
+    )
+    manager.events.unregistered.addEventListener(evt =>
+      unregistered.push(evt.fileType)
+    )
+
+    manager.register('custom', custom)
+    expect(manager.get('custom')).toBe(custom)
+    expect(registered).toContain('custom')
+
+    manager.unregister('custom')
+    expect(manager.get('custom')).toBeUndefined()
+    expect(unregistered).toContain('custom')
+
+    manager.unregister('missing')
+  })
+})

--- a/packages/data-model/__tests__/AcDbDiametricDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbDiametricDimension.spec.ts
@@ -1,0 +1,16 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbDiametricDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbDiametricDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbDiametricDimension(
+          new AcGePoint3d(1, 0, 0),
+          new AcGePoint3d(-1, 0, 0),
+          1
+        )
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbDictionary.spec.ts
+++ b/packages/data-model/__tests__/AcDbDictionary.spec.ts
@@ -1,0 +1,9 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDictionary } from '../src/object/AcDbDictionary'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbDictionary', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbDictionary(new AcDbDatabase()))
+  })
+})

--- a/packages/data-model/__tests__/AcDbDimStyleTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbDimStyleTable.spec.ts
@@ -1,0 +1,21 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDimStyleTable } from '../src/database/AcDbDimStyleTable'
+import { AcDbDimStyleTableRecord } from '../src/database/AcDbDimStyleTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbDimStyleTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbDimStyleTable(new AcDbDatabase()))
+  })
+
+  it('supports inherited symbol table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.dimStyleTable
+    const record = new AcDbDimStyleTableRecord({ name: 'D1' })
+    table.add(record)
+
+    expect(table.getAt('D1')).toBe(record)
+    expect(table.remove('D1')).toBe(true)
+    expect(table.getAt('D1')).toBeUndefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbDimStyleTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbDimStyleTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbDimStyleTableRecord } from '../src/database/AcDbDimStyleTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbDimStyleTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbDimStyleTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbDwgVersion.spec.ts
+++ b/packages/data-model/__tests__/AcDbDwgVersion.spec.ts
@@ -1,0 +1,20 @@
+import { AcDbDwgVersion } from '../src/database/AcDbDwgVersion'
+
+describe('AcDbDwgVersion', () => {
+  it('constructs from known name and value', () => {
+    const fromName = new AcDbDwgVersion('AC1032')
+    expect(fromName.value).toBe(33)
+
+    const fromValue = new AcDbDwgVersion(23)
+    expect(fromValue.name).toBe('AC1015')
+  })
+
+  it('throws for unknown values', () => {
+    expect(() => new AcDbDwgVersion('UNKNOWN')).toThrow(
+      'Unknown DWG version name: UNKNOWN'
+    )
+    expect(() => new AcDbDwgVersion(999)).toThrow(
+      'Unknown DWG version value: 999'
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
@@ -1,0 +1,67 @@
+import { AcDbDxfParser } from '../src/converter/AcDbDxfParser'
+import { AcDbDxfConverter } from '../src/converter/AcDbDxfConverter'
+
+class TestDxfConverter extends AcDbDxfConverter {
+  parsePublic(data: ArrayBuffer, timeout?: number) {
+    return this.parse(data, timeout)
+  }
+
+  getFontsPublic(dxf: any) {
+    return this.getFonts(dxf)
+  }
+}
+
+describe('AcDbDxfConverter', () => {
+  it('sets default parser worker url in constructor', () => {
+    const config: Record<string, unknown> = {}
+    new AcDbDxfConverter(config as any)
+    expect(config.parserWorkerUrl).toBe('/assets/dxf-parser-worker.js')
+  })
+
+  it('parses through AcDbDxfParser when worker disabled', async () => {
+    const parseSpy = jest
+      .spyOn(AcDbDxfParser.prototype, 'parse')
+      .mockReturnValue({ entities: [] } as any)
+
+    const converter = new TestDxfConverter({ useWorker: false })
+    const result = await converter.parsePublic(new ArrayBuffer(0))
+
+    expect(result.model).toEqual({ entities: [] })
+    expect(result.data.unknownEntityCount).toBe(0)
+    expect(parseSpy).toHaveBeenCalled()
+
+    parseSpy.mockRestore()
+  })
+
+  it('collects fonts from style table, mtext and nested inserts', () => {
+    const converter = new TestDxfConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      tables: {
+        STYLE: {
+          entries: [
+            {
+              name: 'A',
+              font: 'Arial.ttf',
+              bigFont: 'Bigfont.shx',
+              extendedFont: 'Ext.ttf'
+            }
+          ]
+        }
+      },
+      entities: [
+        { type: 'TEXT', styleName: 'A' },
+        { type: 'MTEXT', styleName: 'A', text: '{\\fCustom|b0|i0;Hello}' },
+        { type: 'INSERT', name: 'B1' }
+      ],
+      blocks: {
+        B1: {
+          entities: [{ type: 'TEXT', styleName: 'A' }]
+        }
+      }
+    })
+
+    expect(fonts).toEqual(
+      expect.arrayContaining(['arial', 'bigfont', 'ext', 'custom'])
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbDxfFiler.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfFiler.spec.ts
@@ -1,0 +1,88 @@
+import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
+
+import { AcDbDwgVersion } from '../src/database/AcDbDwgVersion'
+import { AcDbDxfFiler } from '../src/base/AcDbDxfFiler'
+import { AcDbResultBuffer } from '../src/base/AcDbResultBuffer'
+
+describe('AcDbDxfFiler', () => {
+  it('writes and formats DXF groups through helper methods', () => {
+    const filer = new AcDbDxfFiler({ precision: 20, version: 'AC1015' })
+
+    expect(filer.precision).toBe(16)
+    expect(filer.version?.name).toBe('AC1015')
+    expect(filer.nextHandle).toBe(1)
+
+    filer.setPrecision(-1)
+    expect(filer.precision).toBe(0)
+
+    filer.setVersion(33)
+    expect(filer.version).toBeInstanceOf(AcDbDwgVersion)
+
+    expect(filer.registerHandle('abc')).toBe('ABC')
+    expect(filer.resolveHandle('abc')).toBe('ABC')
+    expect(filer.registerHandle('custom-id')).toBe('1')
+    expect(filer.nextHandle).toBe(2)
+    expect(filer.resolveHandle()).toBeUndefined()
+
+    filer
+      .startSection('HEADER')
+      .writeSubclassMarker('AcDbTest')
+      .writeString(1, 'line\r\nvalue')
+      .writeInt8(70, 3.9)
+      .writeInt16(71, 4.2)
+      .writeInt32(72, 5.8)
+      .writeInt64(73, 6.1)
+      .writeUInt16(74, -3)
+      .writeUInt32(75, -4)
+      .writeBoolean(290, true)
+      .writeBool(291, false)
+      .writeDouble(40, 1.23456789)
+      .writeDouble(41, Number.NaN)
+      .writeAngle(50, Math.PI)
+      .writeHandle(5, 'abc')
+      .writeObjectId(330, 'custom-id')
+      .writePoint2d(10, { x: 1.5, y: 2.5 })
+      .writePoint3d(20, { x: 3, y: 4, z: 5 })
+      .writeVector3d(30, { x: 6, y: 7, z: 8 })
+      .startTable('LAYER')
+      .endTable()
+      .endSection()
+
+    const aciColor = new AcCmColor()
+    aciColor.colorIndex = 7
+    filer.writeCmColor(aciColor)
+
+    const trueColor = new AcCmColor()
+    trueColor.setRGB(255, 0, 0)
+    filer.writeCmColor(trueColor)
+
+    const transparency = new AcCmTransparency(128)
+    filer.writeTransparency(transparency)
+
+    filer.writeResultBuffer(
+      new AcDbResultBuffer([
+        { code: 1000, value: 'x' },
+        { code: 1070, value: 1 }
+      ])
+    )
+
+    const out = filer.toString()
+    expect(out).toContain('SECTION')
+    expect(out).toContain('HEADER')
+    expect(out).toContain('AcDbTest')
+    expect(out).toContain('line value')
+    expect(out).toContain('ENDSEC')
+    expect(out).toContain('ENDTAB')
+    expect(out).toContain('180')
+    expect(out).toContain('ABC')
+    expect(out).toContain('1000')
+    expect(out).toContain('\n0\n')
+  })
+
+  it('supports database getter and setter', () => {
+    const filer = new AcDbDxfFiler()
+    expect(filer.database).toBeUndefined()
+    filer.database = undefined
+    expect(filer.database).toBeUndefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbDxfParser.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfParser.spec.ts
@@ -1,0 +1,32 @@
+import { AcDbDxfParser } from '../src/converter/AcDbDxfParser'
+
+describe('AcDbDxfParser', () => {
+  it('parses minimal valid dxf content', () => {
+    const parser = new AcDbDxfParser()
+    const content = [
+      '0',
+      'SECTION',
+      '2',
+      'HEADER',
+      '9',
+      '$ACADVER',
+      '1',
+      'AC1032',
+      '0',
+      'ENDSEC',
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF'
+    ].join('\n')
+
+    const data = new TextEncoder().encode(content).buffer
+    const parsed = parser.parse(data as ArrayBuffer)
+    expect(parsed).toBeTruthy()
+    expect(parsed.header.$ACADVER).toBe('AC1032')
+  })
+})

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -1,0 +1,297 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbEllipse } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbEllipse', () => {
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(
+      () =>
+        new AcDbEllipse(
+          new AcGePoint3d(),
+          AcGeVector3d.Z_AXIS,
+          AcGeVector3d.X_AXIS,
+          2,
+          1,
+          0,
+          Math.PI
+        )
+    )
+  })
+
+  it('supports public geometric getters and setters', () => {
+    createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(1, 2, 3),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0.1,
+      Math.PI
+    )
+    const openEllipse = new AcDbEllipse(
+      new AcGePoint3d(),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0,
+      Math.PI / 2
+    )
+    const closedEllipse = new AcDbEllipse(
+      new AcGePoint3d(),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0,
+      0
+    )
+
+    expect(AcDbEllipse.typeName).toBe('Ellipse')
+    expect(ellipse.dxfTypeName).toBe('ELLIPSE')
+
+    expect(ellipse.center).toBeInstanceOf(AcGePoint3d)
+    expect(ellipse.majorAxisRadius).toBeCloseTo(5)
+    expect(ellipse.minorAxisRadius).toBeCloseTo(2)
+    expect(ellipse.startAngle).toBeCloseTo(0.1)
+    expect(ellipse.endAngle).toBeCloseTo(Math.PI)
+    expect(ellipse.normal).toBeInstanceOf(AcGeVector3d)
+    expect(ellipse.geometricExtents).toBeDefined()
+    expect(openEllipse.closed).toBe(false)
+    expect(closedEllipse.closed).toBe(true)
+
+    ellipse.center = new AcGePoint3d(7, 8, 9)
+    ellipse.majorAxisRadius = 8
+    ellipse.minorAxisRadius = 3
+    ellipse.startAngle = Math.PI / 4
+    ellipse.endAngle = Math.PI * 1.5
+    ellipse.normal = new AcGeVector3d(0, 1, 0)
+
+    expect(ellipse.center.x).toBeCloseTo(7)
+    expect(ellipse.center.y).toBeCloseTo(8)
+    expect(ellipse.center.z).toBeCloseTo(9)
+    expect(ellipse.majorAxisRadius).toBeCloseTo(8)
+    expect(ellipse.minorAxisRadius).toBeCloseTo(3)
+    expect(ellipse.startAngle).toBeCloseTo(Math.PI / 4)
+    expect(ellipse.endAngle).toBeCloseTo(Math.PI * 1.5)
+    expect(ellipse.normal.y).toBeCloseTo(1)
+  })
+
+  it('computes osnap points for supported modes', () => {
+    createWorkingDb()
+    const openEllipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      6,
+      3,
+      0,
+      Math.PI
+    )
+    const closedEllipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      6,
+      3,
+      0,
+      0
+    )
+
+    const endPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(2)
+
+    const midPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(1)
+
+    const quadrantPoints: AcGePoint3d[] = []
+    closedEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Quadrant,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      quadrantPoints
+    )
+    expect(quadrantPoints).toHaveLength(4)
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    closedEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+
+    const openQuadrantPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Quadrant,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      openQuadrantPoints
+    )
+    expect(openQuadrantPoints).toHaveLength(0)
+  })
+
+  it('exposes runtime properties and accessors', () => {
+    createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      10,
+      5,
+      0,
+      Math.PI
+    )
+
+    const properties = ellipse.properties
+    expect(properties.type).toBe('Ellipse')
+    expect(properties.groups).toHaveLength(2)
+
+    const geometryGroup = properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(geometryGroup).toBeDefined()
+
+    const expectedValues: Record<string, number> = {
+      centerX: 11,
+      centerY: 12,
+      centerZ: 13,
+      minorAxisRadius: 4,
+      startAngle: Math.PI / 6,
+      endAngle: Math.PI / 3,
+      normalX: 0,
+      normalY: 0,
+      normalZ: 1
+    }
+
+    for (const prop of geometryGroup!.properties) {
+      prop.accessor.get()
+      if (
+        prop.editable &&
+        prop.accessor.set &&
+        expectedValues[prop.name] != null
+      ) {
+        prop.accessor.set(expectedValues[prop.name])
+      }
+      prop.accessor.get()
+    }
+
+    const majorAxisProp = geometryGroup!.properties.find(
+      prop => prop.name === 'majorAxisRadius'
+    )
+    const originalMajorRadius = ellipse.majorAxisRadius
+    majorAxisProp?.accessor.set?.(99)
+    expect(ellipse.center.x).toBeCloseTo(99)
+    expect(ellipse.majorAxisRadius).toBeCloseTo(originalMajorRadius)
+    expect(majorAxisProp?.accessor.get()).toBeCloseTo(originalMajorRadius)
+
+    const lengthProp = geometryGroup!.properties.find(
+      prop => prop.name === 'length'
+    )
+    const areaProp = geometryGroup!.properties.find(
+      prop => prop.name === 'area'
+    )
+    expect(lengthProp?.editable).toBe(false)
+    expect(areaProp?.editable).toBe(false)
+    expect(typeof lengthProp?.accessor.get()).toBe('number')
+    expect(typeof areaProp?.accessor.get()).toBe('number')
+
+    expect(ellipse.center.y).toBeCloseTo(12)
+    expect(ellipse.center.z).toBeCloseTo(13)
+    expect(ellipse.minorAxisRadius).toBeCloseTo(4)
+    expect(ellipse.startAngle).toBeCloseTo(Math.PI / 6)
+    expect(ellipse.endAngle).toBeCloseTo(Math.PI / 3)
+    expect(ellipse.normal.z).toBeCloseTo(1)
+  })
+
+  it('transforms itself and draws with renderer', () => {
+    createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(1, 2, 3),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0,
+      Math.PI
+    )
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -2, 1)
+
+    expect(ellipse.transformBy(matrix)).toBe(ellipse)
+    expect(ellipse.center.x).toBeCloseTo(11)
+    expect(ellipse.center.y).toBeCloseTo(0)
+    expect(ellipse.center.z).toBeCloseTo(4)
+
+    const drawResult = { id: 'ellipse-rendered' }
+    const renderer = {
+      ellipticalArc: jest.fn(() => drawResult)
+    }
+
+    expect(ellipse.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.ellipticalArc).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes ellipse-specific DXF fields', () => {
+    const db = createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(1, 2, 3),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.Y_AXIS,
+      4,
+      1,
+      0.25,
+      1.5
+    )
+
+    db.tables.blockTable.modelSpace.appendEntity(ellipse)
+
+    const filer = new AcDbDxfFiler()
+
+    expect(ellipse.dxfOutFields(filer)).toBe(ellipse)
+
+    const dxf = filer.toString()
+    expect(dxf).toContain('100\nAcDbEntity')
+    expect(dxf).toContain('100\nAcDbEllipse')
+    expect(dxf).toContain('10\n1')
+    expect(dxf).toContain('20\n2')
+    expect(dxf).toContain('30\n3')
+    expect(dxf).toContain('11\n0')
+    expect(dxf).toContain('21\n4')
+    expect(dxf).toContain('31\n0')
+    expect(dxf).toContain('210\n0')
+    expect(dxf).toContain('220\n0')
+    expect(dxf).toContain('230\n1')
+    expect(dxf).toContain('40\n0.25')
+    expect(dxf).toContain('41\n0.25')
+    expect(dxf).toContain('42\n1.5')
+  })
+})

--- a/packages/data-model/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntityConverter.spec.ts
@@ -1,0 +1,39 @@
+import { AcDbEntityConverter } from '../src/converter/AcDbEntitiyConverter'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+
+describe('AcDbEntityConverter', () => {
+  it('returns null for unsupported type', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({ type: 'UNKNOWN' } as any)
+    expect(result).toBeNull()
+  })
+
+  it('converts simple line entity with common attrs', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'LINE',
+      startPoint: { x: 0, y: 0, z: 0 },
+      endPoint: { x: 1, y: 1, z: 0 },
+      layer: 'L1',
+      handle: '10',
+      ownerBlockRecordSoftId: '20',
+      lineType: 'Continuous',
+      lineweight: 25,
+      lineTypeScale: 2,
+      color: 0xff0000,
+      colorIndex: 1,
+      colorName: 'red',
+      isVisible: true,
+      transparency: 0x020000ff
+    } as any)
+
+    expect(result).toBeTruthy()
+    expect(result?.type).toBe('Line')
+    expect(result?.layer).toBe('L1')
+    expect(result?.objectId).toBe('10')
+    expect(result?.ownerId).toBe('20')
+  })
+})

--- a/packages/data-model/__tests__/AcDbFace.spec.ts
+++ b/packages/data-model/__tests__/AcDbFace.spec.ts
@@ -1,0 +1,188 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { TEMP_OBJECT_ID_PREFIX } from '../src/base/AcDbObject'
+import { AcDbDatabase } from '../src/database'
+import { AcDbFace } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbFace', () => {
+  it('exposes type names and default vertex behavior', () => {
+    const face = new AcDbFace()
+
+    expect(AcDbFace.typeName).toBe('Face')
+    expect(face.dxfTypeName).toBe('3DFACE')
+
+    expect(face.getVertexAt(0)).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(face.getVertexAt(-1)).toBe(face.getVertexAt(0))
+    expect(face.getVertexAt(1)).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(face.getVertexAt(4)).toBe(face.getVertexAt(2))
+    expect(face.getVertexAt(3)).toBeUndefined()
+  })
+
+  it('supports setVertexAt for normal and high indexes, and keeps current negative-index behavior', () => {
+    const face = new AcDbFace()
+
+    face.setVertexAt(1, { x: 1, y: 2, z: 3 })
+    expect(face.getVertexAt(1)).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    expect(() => face.setVertexAt(-1, { x: 9, y: 8, z: 7 })).toThrow()
+    expect(face.getVertexAt(0)).toMatchObject({ x: 9, y: 8, z: 7 })
+
+    face.setVertexAt(3, { x: 4, y: 5, z: 6 })
+    expect(face.getVertexAt(3)).toMatchObject({ x: 4, y: 5, z: 6 })
+
+    face.setVertexAt(99, { x: 7, y: 8, z: 9 })
+    expect(face.getVertexAt(3)).toMatchObject({ x: 7, y: 8, z: 9 })
+  })
+
+  it('falls back to temporary object id when working database is unavailable', () => {
+    const services = acdbHostApplicationServices() as unknown as {
+      _workingDatabase: AcDbDatabase | null
+    }
+    const previousDb = services._workingDatabase
+    services._workingDatabase = null
+
+    try {
+      const face = new AcDbFace()
+      expect(face.objectId.startsWith(TEMP_OBJECT_ID_PREFIX)).toBe(true)
+    } finally {
+      services._workingDatabase = previousDb
+    }
+  })
+
+  it('supports edge visibility bit operations and throws for invalid edge indexes', () => {
+    const face = new AcDbFace()
+
+    expect(face.isEdgeVisibleAt(0)).toBe(true)
+    expect(face.isEdgeVisibleAt(1)).toBe(true)
+    expect(face.isEdgeVisibleAt(2)).toBe(true)
+    expect(face.isEdgeVisibleAt(3)).toBe(true)
+
+    face.setEdgeInvisibilities(0b0101)
+    expect(face.isEdgeVisibleAt(0)).toBe(false)
+    expect(face.isEdgeVisibleAt(1)).toBe(true)
+    expect(face.isEdgeVisibleAt(2)).toBe(false)
+    expect(face.isEdgeVisibleAt(3)).toBe(true)
+
+    face.makeEdgeInvisibleAt(1)
+    expect(face.isEdgeVisibleAt(1)).toBe(false)
+
+    expect(() => face.isEdgeVisibleAt(-1)).toThrow('Index out of range')
+    expect(() => face.isEdgeVisibleAt(4)).toThrow('Index out of range')
+    expect(() => face.makeEdgeInvisibleAt(-1)).toThrow('Index out of range')
+    expect(() => face.makeEdgeInvisibleAt(4)).toThrow('Index out of range')
+  })
+
+  it('returns extents, grip points and endpoint osnap points', () => {
+    const face = new AcDbFace()
+    face.setVertexAt(0, { x: -1, y: 4, z: 2 })
+    face.setVertexAt(1, { x: 3, y: 1, z: 8 })
+    face.setVertexAt(2, { x: 2, y: -5, z: -3 })
+    face.setVertexAt(3, { x: 6, y: 2, z: 0 })
+
+    const extents = face.geometricExtents
+    expect(extents.min).toMatchObject({ x: -1, y: -5, z: -3 })
+    expect(extents.max).toMatchObject({ x: 6, y: 4, z: 8 })
+
+    const grips = face.subGetGripPoints()
+    expect(grips).toHaveLength(4)
+    expect(grips[0]).toBe(face.getVertexAt(0))
+    expect(grips[3]).toBe(face.getVertexAt(3))
+
+    const endPoints: AcGePoint3d[] = []
+    face.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toEqual(grips)
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    face.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('transforms vertices and draws visible edges via line segments', () => {
+    const face = new AcDbFace()
+    face.setVertexAt(0, { x: 0, y: 0, z: 0 })
+    face.setVertexAt(1, { x: 1, y: 0, z: 0 })
+    face.setVertexAt(2, { x: 1, y: 1, z: 0 })
+    face.setVertexAt(3, { x: 0, y: 1, z: 0 })
+
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -2, 3)
+    expect(face.transformBy(matrix)).toBe(face)
+    expect(face.getVertexAt(0)).toMatchObject({ x: 10, y: -2, z: 3 })
+    expect(face.getVertexAt(2)).toMatchObject({ x: 11, y: -1, z: 3 })
+
+    face.setEdgeInvisibilities(0b0010)
+
+    const drawResult = { id: 'face-rendered' }
+    const renderer = {
+      lineSegments: jest.fn(() => drawResult)
+    }
+
+    expect(face.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
+
+    const [buffer, stride, indices] = renderer.lineSegments.mock
+      .calls[0] as unknown as [Float32Array, number, Uint16Array]
+
+    expect(stride).toBe(3)
+    expect(buffer).toHaveLength(12)
+    expect(indices).toEqual(new Uint16Array([0, 1, 0, 0, 2, 3, 3, 0]))
+  })
+
+  it('writes face-specific DXF fields and edge visibility mask', () => {
+    const db = createWorkingDb()
+    const face = new AcDbFace()
+
+    db.tables.blockTable.modelSpace.appendEntity(face)
+
+    face.setVertexAt(0, { x: 1, y: 2, z: 3 })
+    face.setVertexAt(1, { x: 4, y: 5, z: 6 })
+    face.setVertexAt(2, { x: 7, y: 8, z: 9 })
+    face.setVertexAt(3, { x: 10, y: 11, z: 12 })
+    face.setEdgeInvisibilities(0)
+    face.makeEdgeInvisibleAt(1)
+    face.makeEdgeInvisibleAt(3)
+
+    const filer = new AcDbDxfFiler()
+    expect(face.dxfOutFields(filer)).toBe(face)
+
+    const dxf = filer.toString()
+    expect(dxf).toContain('100\nAcDbEntity\n')
+    expect(dxf).toContain('100\nAcDbFace\n')
+    expect(dxf).toContain('10\n1\n')
+    expect(dxf).toContain('20\n2\n')
+    expect(dxf).toContain('30\n3\n')
+    expect(dxf).toContain('11\n4\n')
+    expect(dxf).toContain('21\n5\n')
+    expect(dxf).toContain('31\n6\n')
+    expect(dxf).toContain('12\n7\n')
+    expect(dxf).toContain('22\n8\n')
+    expect(dxf).toContain('32\n9\n')
+    expect(dxf).toContain('13\n10\n')
+    expect(dxf).toContain('23\n11\n')
+    expect(dxf).toContain('33\n12\n')
+    expect(dxf).toContain('70\n10\n')
+  })
+
+  it('clone creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbFace())
+  })
+})

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -1,0 +1,312 @@
+import {
+  AcGeCircArc2d,
+  AcGeEllipseArc2d,
+  AcGeLine2d,
+  AcGeLoop2d,
+  AcGeMatrix3d,
+  AcGePolyline2d,
+  AcGeSpline3d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbHatch, AcDbHatchPatternType, AcDbHatchStyle } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+const createRectLoop = (x: number, y: number, w: number, h: number) =>
+  new AcGePolyline2d(
+    [
+      { x, y },
+      { x: x + w, y },
+      { x: x + w, y: y + h },
+      { x, y: y + h }
+    ],
+    true
+  )
+
+describe('AcDbHatch', () => {
+  it('exposes type names and public getters/setters', () => {
+    const hatch = new AcDbHatch()
+
+    expect(AcDbHatch.typeName).toBe('Hatch')
+    expect(hatch.dxfTypeName).toBe('HATCH')
+
+    expect(hatch.patternType).toBe(AcDbHatchPatternType.Predefined)
+    expect(hatch.patternName).toBe('')
+    expect(hatch.patternAngle).toBe(0)
+    expect(hatch.patternScale).toBe(1)
+    expect(hatch.hatchStyle).toBe(AcDbHatchStyle.Normal)
+    expect(hatch.elevation).toBe(0)
+    expect(hatch.definitionLines).toEqual([])
+    expect(hatch.isSolidFill).toBe(false)
+
+    hatch.patternType = AcDbHatchPatternType.Custom
+    hatch.patternName = 'ANSI31'
+    hatch.patternAngle = Math.PI / 3
+    hatch.patternScale = 2.5
+    hatch.hatchStyle = AcDbHatchStyle.Outer
+    hatch.elevation = 8
+    hatch.isSolidFill = false
+    hatch.definitionLines.push({
+      angle: 0,
+      base: { x: 0, y: 0 },
+      offset: { x: 1, y: 1 },
+      dashLengths: [1]
+    })
+
+    expect(hatch.patternType).toBe(AcDbHatchPatternType.Custom)
+    expect(hatch.patternName).toBe('ANSI31')
+    expect(hatch.patternAngle).toBeCloseTo(Math.PI / 3)
+    expect(hatch.patternScale).toBeCloseTo(2.5)
+    expect(hatch.hatchStyle).toBe(AcDbHatchStyle.Outer)
+    expect(hatch.elevation).toBe(8)
+    expect(hatch.definitionLines).toHaveLength(1)
+    expect(hatch.isSolidFill).toBe(false)
+
+    hatch.patternName = 'solid'
+    expect(hatch.isSolidFill).toBe(true)
+  })
+
+  it('supports add(), geometricExtents and properties accessors', () => {
+    const hatch = new AcDbHatch()
+    const emptyExtents = hatch.geometricExtents
+    expect(emptyExtents.isEmpty()).toBe(true)
+
+    hatch.add(createRectLoop(0, 0, 10, 5))
+    hatch.add(createRectLoop(2, 1, 2, 2))
+    hatch.add(createRectLoop(20, 2, 2, 3))
+    hatch.elevation = 4
+
+    const extents = hatch.geometricExtents
+    expect(extents.min).toMatchObject({ x: 0, y: 0, z: 4 })
+    expect(extents.max).toMatchObject({ x: 22, y: 5, z: 4 })
+
+    const properties = hatch.properties
+    expect(properties.type).toBe('Hatch')
+
+    const patternGroup = properties.groups.find(g => g.groupName === 'pattern')
+    const geometryGroup = properties.groups.find(
+      g => g.groupName === 'geometry'
+    )
+    expect(patternGroup).toBeDefined()
+    expect(geometryGroup).toBeDefined()
+
+    const propertyValues: Record<string, unknown> = {
+      patternType: AcDbHatchPatternType.UserDefined,
+      patternName: 'TEST_PATTERN',
+      patternAngle: Math.PI / 6,
+      patternScale: 3.25,
+      elevation: 6
+    }
+
+    for (const group of [patternGroup!, geometryGroup!]) {
+      for (const prop of group.properties) {
+        prop.accessor.get()
+        if (prop.editable && prop.accessor.set) {
+          prop.accessor.set(propertyValues[prop.name] as never)
+        }
+        prop.accessor.get()
+      }
+    }
+
+    const patternTypeProp = patternGroup!.properties.find(
+      p => p.name === 'patternType'
+    )
+    expect(patternTypeProp?.options).toHaveLength(3)
+
+    const areaProp = geometryGroup!.properties.find(p => p.name === 'area')
+    expect(areaProp?.editable).toBe(false)
+    expect((areaProp?.accessor.get() as number) > 0).toBe(true)
+
+    expect(hatch.patternType).toBe(AcDbHatchPatternType.UserDefined)
+    expect(hatch.patternName).toBe('TEST_PATTERN')
+    expect(hatch.patternAngle).toBeCloseTo(Math.PI / 6)
+    expect(hatch.patternScale).toBeCloseTo(3.25)
+    expect(hatch.elevation).toBe(6)
+  })
+
+  it('draws empty/single/multi hatch areas and applies fill traits', () => {
+    const makeRenderer = () => ({
+      subEntityTraits: {} as Record<string, unknown>,
+      area: jest.fn((area: unknown) => ({ kind: 'area', area })),
+      group: jest.fn((entities: unknown[]) => ({ kind: 'group', entities }))
+    })
+
+    const emptyHatch = new AcDbHatch()
+    const emptyRenderer = makeRenderer()
+    const emptyDraw = emptyHatch.subWorldDraw(emptyRenderer as never)
+    expect(emptyRenderer.area).toHaveBeenCalledTimes(1)
+    expect(emptyRenderer.group).not.toHaveBeenCalled()
+    expect(emptyDraw).toMatchObject({ kind: 'area' })
+    expect(
+      (emptyRenderer.subEntityTraits.fillType as { solidFill: boolean })
+        .solidFill
+    ).toBe(false)
+
+    const singleHatch = new AcDbHatch()
+    singleHatch.patternName = 'SOLID'
+    singleHatch.definitionLines.push({
+      angle: Math.PI / 4,
+      base: { x: 0, y: 0 },
+      offset: { x: 1, y: 0 },
+      dashLengths: []
+    })
+    singleHatch.add(createRectLoop(0, 0, 3, 2))
+
+    const singleRenderer = makeRenderer()
+    const singleDraw = singleHatch.subWorldDraw(singleRenderer as never)
+    expect(singleRenderer.area).toHaveBeenCalledTimes(1)
+    expect(singleRenderer.group).not.toHaveBeenCalled()
+    expect(singleDraw).toMatchObject({ kind: 'area' })
+    expect(
+      singleRenderer.subEntityTraits.fillType as {
+        solidFill: boolean
+        definitionLines: unknown[]
+      }
+    ).toMatchObject({
+      solidFill: true,
+      definitionLines: singleHatch.definitionLines
+    })
+
+    const multiHatch = new AcDbHatch()
+    multiHatch.add(createRectLoop(0, 0, 2, 2))
+    multiHatch.add(createRectLoop(5, 0, 2, 2))
+
+    const multiRenderer = makeRenderer()
+    const multiDraw = multiHatch.subWorldDraw(
+      multiRenderer as never
+    ) as unknown as {
+      entities: unknown[]
+      kind: string
+    }
+    expect(multiRenderer.area).toHaveBeenCalledTimes(2)
+    expect(multiRenderer.group).toHaveBeenCalledTimes(1)
+    expect(multiDraw.kind).toBe('group')
+    expect(multiDraw.entities).toHaveLength(2)
+  })
+
+  it('transformBy updates loops, elevation, pattern angle/scale and handles zero-length x-axis', () => {
+    const hatch = new AcDbHatch()
+    hatch.add(createRectLoop(0, 0, 1, 1))
+    hatch.elevation = 2
+    hatch.patternAngle = 0.2
+    hatch.patternScale = 1.5
+
+    const matrix = new AcGeMatrix3d()
+      .makeRotationZ(Math.PI / 2)
+      .setPosition(0, 0, 5)
+    expect(hatch.transformBy(matrix)).toBe(hatch)
+    expect(hatch.elevation).toBeCloseTo(7)
+    expect(hatch.patternAngle).toBeCloseTo(0.2 + Math.PI / 2)
+    expect(hatch.patternScale).toBeCloseTo(1.5)
+
+    const previousAngle = hatch.patternAngle
+    const previousScale = hatch.patternScale
+    hatch.transformBy(new AcGeMatrix3d().makeScale(0, 0, 1))
+    expect(hatch.patternAngle).toBeCloseTo(previousAngle)
+    expect(hatch.patternScale).toBeCloseTo(previousScale)
+  })
+
+  it('writes DXF fields for polyline/edge loops and hatch pattern data', () => {
+    const db = createWorkingDb()
+    const hatch = new AcDbHatch()
+    db.tables.blockTable.modelSpace.appendEntity(hatch)
+
+    hatch.patternType = AcDbHatchPatternType.Custom
+    hatch.patternName = ''
+    hatch.patternAngle = Math.PI / 6
+    hatch.patternScale = 2.5
+    hatch.hatchStyle = AcDbHatchStyle.Outer
+    hatch.elevation = 5
+    hatch.isSolidFill = false
+    hatch.definitionLines.push({
+      angle: Math.PI / 4,
+      base: { x: 0, y: 0 },
+      offset: { x: 1, y: 1 },
+      dashLengths: [1, -0.5]
+    })
+
+    hatch.add(
+      new AcGePolyline2d(
+        [
+          { x: 0, y: 0, bulge: 0.5 },
+          { x: 4, y: 0, bulge: 0 },
+          { x: 4, y: 4, bulge: -0.2 },
+          { x: 0, y: 4, bulge: 0 }
+        ],
+        true
+      )
+    )
+    hatch.add(createRectLoop(6, 0, 2, 2))
+
+    const edgeLoop = new AcGeLoop2d([
+      new AcGeLine2d({ x: 10, y: 0 }, { x: 12, y: 0 }),
+      new AcGeSpline3d(
+        [
+          { x: 12, y: 0, z: 0 },
+          { x: 12.5, y: 1, z: 0 },
+          { x: 13.5, y: 1, z: 0 },
+          { x: 14, y: 0, z: 0 }
+        ],
+        [0, 0, 0, 0, 1, 1, 1, 1],
+        [1, 1.5, 1, 1],
+        3,
+        false
+      )
+    ])
+    edgeLoop.add(
+      new AcGeCircArc2d({ x: 13, y: 2 }, 1, -Math.PI / 2, Math.PI / 2, false)
+    )
+    edgeLoop.add(
+      new AcGeEllipseArc2d({ x: 11, y: 2, z: 0 }, 1.5, 1, 0, Math.PI, false, 0)
+    )
+    hatch.add(edgeLoop)
+
+    const filer = new AcDbDxfFiler().setVersion(27)
+    expect(hatch.dxfOutFields(filer)).toBe(hatch)
+
+    const dxf = filer.toString()
+    expect(dxf).toContain('100\nAcDbHatch\n')
+    expect(dxf).toContain('\n2\nUSER\n')
+    expect(dxf).toContain('\n70\n0\n')
+    expect(dxf).toContain('\n91\n3\n')
+    expect(dxf).toContain('\n72\n4\n')
+    expect(dxf).toContain('\n94\n3\n')
+    expect(dxf).toContain('\n95\n8\n')
+    expect(dxf).toContain('\n96\n4\n')
+    expect(dxf).toContain('\n75\n1\n')
+    expect(dxf).toContain('\n76\n2\n')
+    expect(dxf).toContain('\n52\n')
+    expect(dxf).toContain('\n41\n2.5\n')
+    expect(dxf).toContain('\n78\n1\n')
+    expect(dxf).toContain('\n79\n2\n')
+    expect(dxf).toContain('\n98\n0\n')
+  })
+
+  it('writes SOLID fallback when solid fill is enabled and patternName is empty', () => {
+    const db = createWorkingDb()
+    const hatch = new AcDbHatch()
+    db.tables.blockTable.modelSpace.appendEntity(hatch)
+    hatch.patternName = ''
+    hatch.isSolidFill = true
+    hatch.add(createRectLoop(0, 0, 1, 1))
+
+    const filer = new AcDbDxfFiler()
+    hatch.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('\n2\nSOLID\n')
+    expect(dxf).toContain('\n70\n1\n')
+  })
+
+  it('clone creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbHatch())
+  })
+})

--- a/packages/data-model/__tests__/AcDbHostApplicationServices.spec.ts
+++ b/packages/data-model/__tests__/AcDbHostApplicationServices.spec.ts
@@ -1,0 +1,37 @@
+import {
+  AcDbHostApplicationServices,
+  acdbHostApplicationServices,
+  setAcDbLayoutManagerFactory
+} from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+
+describe('AcDbHostApplicationServices', () => {
+  it('exposes singleton, database and lazy layout manager', () => {
+    const services = acdbHostApplicationServices()
+    expect(services).toBe(AcDbHostApplicationServices.instance)
+    ;(
+      services as unknown as { _workingDatabase: AcDbDatabase | null }
+    )._workingDatabase = null
+    expect(() => services.workingDatabase).toThrow(
+      'The current working database must be set before using it!'
+    )
+
+    const db = new AcDbDatabase()
+    services.workingDatabase = db
+    expect(services.workingDatabase).toBe(db)
+    ;(services as unknown as { _layoutManager?: unknown })._layoutManager =
+      undefined
+    setAcDbLayoutManagerFactory(() => ({ kind: 'layout' }) as never)
+    expect(services.layoutManager).toEqual({ kind: 'layout' })
+  })
+
+  it('throws when layout manager factory is not registered', () => {
+    const services = acdbHostApplicationServices()
+    ;(services as unknown as { _layoutManager?: unknown })._layoutManager =
+      undefined
+    setAcDbLayoutManagerFactory(undefined as never)
+    expect(() => services.layoutManager).toThrow(
+      'The layout manager factory must be registered before using it!'
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbLayerTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayerTable.spec.ts
@@ -1,0 +1,28 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbLayerTable } from '../src/database/AcDbLayerTable'
+import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLayerTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLayerTable(new AcDbDatabase()))
+  })
+
+  it('dispatches layerAppended and supports inherited table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.layerTable
+    const appended: string[] = []
+    db.events.layerAppended.addEventListener(evt =>
+      appended.push(evt.layer.name)
+    )
+
+    const layer = new AcDbLayerTableRecord({ name: 'Layer-A' })
+    table.add(layer)
+
+    expect(appended).toEqual(['Layer-A'])
+    expect(table.has('Layer-A')).toBe(true)
+    expect(table.getIdAt(layer.objectId)).toBe(layer)
+    expect(table.removeId(layer.objectId)).toBe(true)
+    expect(table.remove('Layer-A')).toBe(false)
+  })
+})

--- a/packages/data-model/__tests__/AcDbLayerTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayerTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLayerTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLayerTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbLayout.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayout.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbLayout } from '../src/object/layout/AcDbLayout'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLayout', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLayout())
+  })
+})

--- a/packages/data-model/__tests__/AcDbLayoutDictionary.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayoutDictionary.spec.ts
@@ -1,0 +1,9 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbLayoutDictionary } from '../src/object/layout/AcDbLayoutDictionary'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLayoutDictionary', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLayoutDictionary(new AcDbDatabase()))
+  })
+})

--- a/packages/data-model/__tests__/AcDbLayoutManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayoutManager.spec.ts
@@ -1,0 +1,71 @@
+import {
+  acdbHostApplicationServices,
+  setAcDbLayoutManagerFactory
+} from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDataGenerator } from '../src/misc/AcDbDataGenerator'
+import { AcDbLayoutManager } from '../src/object/layout/AcDbLayoutManager'
+
+describe('AcDbLayoutManager', () => {
+  it('manages layouts by name, id and block record id', () => {
+    const db = new AcDbDatabase()
+    new AcDbDataGenerator(db).createDefaultLayout()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const manager = new AcDbLayoutManager()
+    expect(manager.countLayouts(db)).toBeGreaterThanOrEqual(1)
+    expect(manager.findActiveLayout()).toBe('Model')
+
+    const createdEvents: string[] = []
+    const renamedEvents: string[] = []
+    const switchedEvents: string[] = []
+    const removedEvents: string[] = []
+
+    manager.events.layoutCreated.addEventListener(e =>
+      createdEvents.push(e.layout.layoutName)
+    )
+    manager.events.layoutRenamed.addEventListener(e =>
+      renamedEvents.push(`${e.oldName}->${e.newName}`)
+    )
+    manager.events.layoutSwitched.addEventListener(e =>
+      switchedEvents.push(e.layout.layoutName)
+    )
+    manager.events.layoutRemoved.addEventListener(e =>
+      removedEvents.push(e.layout.layoutName)
+    )
+
+    const created = manager.createLayout('Sheet1', db)
+    expect(created.layout.layoutName).toBe('Sheet1')
+    expect(createdEvents).toContain('Sheet1')
+
+    expect(manager.findLayoutNamed('Sheet1', db)).toBeDefined()
+    const modelLayout = manager.findLayoutNamed('Model', db)
+    if (modelLayout) {
+      expect(manager.setCurrentLayout('Model', db)).toBe(true)
+      expect(manager.setCurrentLayoutId(modelLayout.objectId, db)).toBe(true)
+      expect(
+        manager.setCurrentLayoutBtrId(modelLayout.blockTableRecordId, db)
+      ).toBe(true)
+      expect(switchedEvents).toContain('Model')
+    }
+
+    expect(manager.renameLayout('Sheet1', 'SheetA', db)).toBe(true)
+    expect(renamedEvents).toContain('Sheet1->SheetA')
+    expect(manager.renameLayout('Missing', 'X', db)).toBe(false)
+
+    expect(manager.deleteLayout('Sheet1', db)).toBe(true)
+    expect(removedEvents).toContain('SheetA')
+    expect(manager.deleteLayout('Missing', db)).toBe(false)
+
+    expect(manager.setCurrentLayout('Missing', db)).toBe(false)
+    expect(manager.setCurrentLayoutId('missing-id', db)).toBe(false)
+    expect(manager.setCurrentLayoutBtrId('missing-btr-id', db)).toBe(false)
+  })
+
+  it('registers factory for host services', () => {
+    setAcDbLayoutManagerFactory(() => new AcDbLayoutManager())
+    expect(acdbHostApplicationServices().layoutManager).toBeInstanceOf(
+      AcDbLayoutManager
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -1,0 +1,188 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbLeader, AcDbLeaderAnnotationType } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+const createRenderer = () => ({
+  lines: jest.fn((points: unknown[]) => ({ kind: 'lines', points }))
+})
+
+describe('AcDbLeader', () => {
+  it('exposes type names and public getters/setters', () => {
+    const leader = new AcDbLeader()
+
+    expect(AcDbLeader.typeName).toBe('Leader')
+    expect(leader.dxfTypeName).toBe('LEADER')
+
+    expect(leader.isSplined).toBe(false)
+    expect(leader.hasArrowHead).toBe(false)
+    expect(leader.hasHookLine).toBe(false)
+    expect(leader.numVertices).toBe(0)
+    expect(leader.vertices).toEqual([])
+    expect(leader.dimensionStyle).toBe('')
+    expect(leader.annoType).toBe(AcDbLeaderAnnotationType.NoAnnotation)
+    expect(leader.closed).toBe(false)
+
+    leader.isSplined = true
+    leader.hasArrowHead = true
+    leader.hasHookLine = true
+    leader.dimensionStyle = 'Standard'
+    leader.annoType = AcDbLeaderAnnotationType.MText
+    leader.closed = true
+
+    expect(leader.isSplined).toBe(true)
+    expect(leader.hasArrowHead).toBe(true)
+    expect(leader.hasHookLine).toBe(true)
+    expect(leader.dimensionStyle).toBe('Standard')
+    expect(leader.annoType).toBe(AcDbLeaderAnnotationType.MText)
+    expect(leader.closed).toBe(false)
+  })
+
+  it('supports appendVertex, numVertices and returns cloned vertices', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(2, 1, 0))
+
+    expect(leader.numVertices).toBe(2)
+    expect(leader.vertices).toHaveLength(2)
+
+    const exported = leader.vertices
+    exported[0].x = 999
+    expect(leader.vertices[0].x).toBe(0)
+  })
+
+  it('keeps current out-of-range behavior for setVertexAt and vertexAt', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+
+    expect(() => leader.setVertexAt(0, new AcGePoint3d(5, 5, 0))).toThrow(
+      'The vertex index is out of range!'
+    )
+    expect(() => leader.vertexAt(0)).toThrow(
+      'The vertex index is out of range!'
+    )
+
+    const raw = leader as unknown as { _vertices: Record<string, AcGePoint3d> }
+    raw._vertices['-1'] = new AcGePoint3d(1, 2, 3)
+    expect(() => leader.setVertexAt(-1, new AcGePoint3d(9, 8, 7))).toThrow(
+      'The vertex index is out of range!'
+    )
+    expect(raw._vertices['-1']).toMatchObject({ x: 9, y: 8, z: 7 })
+    expect(() => leader.vertexAt(-1)).toThrow(
+      'The vertex index is out of range!'
+    )
+  })
+
+  it('returns geometric extents for non-splined and splined leader', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(-1, 3, 0))
+    leader.appendVertex(new AcGePoint3d(4, -2, 1))
+
+    const extents = leader.geometricExtents
+    expect(extents.min).toMatchObject({ x: -1, y: -2, z: 0 })
+    expect(extents.max).toMatchObject({ x: 4, y: 3, z: 1 })
+
+    leader.appendVertex(new AcGePoint3d(6, 1, 2))
+    leader.appendVertex(new AcGePoint3d(8, 0, 0))
+    leader.isSplined = true
+    leader.subWorldDraw(createRenderer() as never)
+
+    const splineExtents = leader.geometricExtents
+    expect(splineExtents.isEmpty()).toBe(false)
+  })
+
+  it('draws polyline/spline branches in subWorldDraw', () => {
+    const rendererA = createRenderer()
+    const leaderA = new AcDbLeader()
+    leaderA.appendVertex(new AcGePoint3d(0, 0, 0))
+    const drawA = leaderA.subWorldDraw(rendererA as never)
+    expect(rendererA.lines).toHaveBeenCalledTimes(1)
+    expect(drawA).toMatchObject({ kind: 'lines' })
+    expect((rendererA.lines.mock.calls[0] as unknown[][])[0]).toHaveLength(1)
+
+    const rendererB = createRenderer()
+    const leaderB = new AcDbLeader()
+    leaderB.appendVertex(new AcGePoint3d(0, 0, 0))
+    leaderB.isSplined = true
+    leaderB.subWorldDraw(rendererB as never)
+    expect((rendererB.lines.mock.calls[0] as unknown[][])[0]).toHaveLength(1)
+
+    const rendererC = createRenderer()
+    const leaderC = new AcDbLeader()
+    leaderC.appendVertex(new AcGePoint3d(0, 0, 0))
+    leaderC.appendVertex(new AcGePoint3d(2, 1, 0))
+    leaderC.appendVertex(new AcGePoint3d(4, 0, 0))
+    leaderC.appendVertex(new AcGePoint3d(6, 1, 0))
+    leaderC.isSplined = true
+    leaderC.subWorldDraw(rendererC as never)
+    expect((rendererC.lines.mock.calls[0] as unknown[][])[0]).toHaveLength(100)
+  })
+
+  it('transforms vertices and keeps working for splined geometry', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(1, 0, 0))
+
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -2, 3)
+    expect(leader.transformBy(matrix)).toBe(leader)
+    expect(leader.vertices[0]).toMatchObject({ x: 10, y: -2, z: 3 })
+    expect(leader.vertices[1]).toMatchObject({ x: 11, y: -2, z: 3 })
+
+    leader.appendVertex(new AcGePoint3d(12, -1, 3))
+    leader.appendVertex(new AcGePoint3d(14, -2, 3))
+    leader.isSplined = true
+    leader.subWorldDraw(createRenderer() as never)
+    expect(
+      leader.transformBy(new AcGeMatrix3d().makeTranslation(1, 1, 0))
+    ).toBe(leader)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    expect((renderer.lines.mock.calls[0] as unknown[][])[0]).toHaveLength(100)
+  })
+
+  it('writes leader-specific DXF fields', () => {
+    const db = createWorkingDb()
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+
+    leader.dimensionStyle = 'Standard'
+    leader.hasArrowHead = true
+    leader.hasHookLine = true
+    leader.isSplined = true
+    leader.annoType = AcDbLeaderAnnotationType.BlockReference
+    leader.appendVertex(new AcGePoint3d(1, 2, 3))
+    leader.appendVertex(new AcGePoint3d(4, 5, 6))
+
+    const filer = new AcDbDxfFiler()
+    expect(leader.dxfOutFields(filer)).toBe(leader)
+
+    const dxf = filer.toString()
+    expect(dxf).toContain('100\nAcDbLeader\n')
+    expect(dxf).toContain('\n3\nStandard\n')
+    expect(dxf).toContain('\n71\n1\n')
+    expect(dxf).toContain('\n72\n2\n')
+    expect(dxf).toContain('\n73\n1\n')
+    expect(dxf).toContain('\n74\n1\n')
+    expect(dxf).toContain('\n76\n2\n')
+    expect(dxf).toContain('\n10\n1\n')
+    expect(dxf).toContain('\n20\n2\n')
+    expect(dxf).toContain('\n30\n3\n')
+    expect(dxf).toContain('\n10\n4\n')
+    expect(dxf).toContain('\n20\n5\n')
+    expect(dxf).toContain('\n30\n6\n')
+  })
+
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLeader())
+  })
+})

--- a/packages/data-model/__tests__/AcDbLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbLine.spec.ts
@@ -1,0 +1,238 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbLine } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbLine', () => {
+  it('exposes expected type names', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 2, 3)
+    )
+
+    expect(AcDbLine.typeName).toBe('Line')
+    expect(line.dxfTypeName).toBe('LINE')
+    expect(line.closed).toBe(false)
+  })
+
+  it('supports start/end point setters and derived geometric getters', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(-1, 10, 2),
+      new AcGePoint3d(3, 2, -4)
+    )
+
+    line.startPoint = { x: 2, y: 6, z: 8 }
+    line.endPoint = { x: 10, y: 14, z: 16 }
+
+    expect(line.startPoint).toMatchObject({ x: 2, y: 6, z: 8 })
+    expect(line.endPoint).toMatchObject({ x: 10, y: 14, z: 16 })
+    expect(line.midPoint).toMatchObject({ x: 6, y: 10, z: 12 })
+
+    const extents = line.geometricExtents
+    expect(extents.min).toMatchObject({ x: 2, y: 6, z: 8 })
+    expect(extents.max).toMatchObject({ x: 10, y: 14, z: 16 })
+  })
+
+  it('exposes editable geometry properties through accessors', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(3, 4, 0)
+    )
+    const geometryGroup = line.properties.groups.find(
+      g => g.groupName === 'geometry'
+    )
+
+    expect(line.properties.type).toBe('Line')
+    expect(geometryGroup).toBeDefined()
+    expect(geometryGroup?.properties.map(p => p.name)).toEqual([
+      'startX',
+      'startY',
+      'startZ',
+      'endX',
+      'endY',
+      'endZ',
+      'length'
+    ])
+
+    const startX = geometryGroup?.properties.find(p => p.name === 'startX')
+    const startY = geometryGroup?.properties.find(p => p.name === 'startY')
+    const startZ = geometryGroup?.properties.find(p => p.name === 'startZ')
+    const endX = geometryGroup?.properties.find(p => p.name === 'endX')
+    const endY = geometryGroup?.properties.find(p => p.name === 'endY')
+    const endZ = geometryGroup?.properties.find(p => p.name === 'endZ')
+    const length = geometryGroup?.properties.find(p => p.name === 'length')
+
+    startX?.accessor.set?.(1.5)
+    startY?.accessor.set?.(-2.5)
+    startZ?.accessor.set?.(3.25)
+    endX?.accessor.set?.(4.5)
+    endY?.accessor.set?.(5.5)
+    endZ?.accessor.set?.(6.5)
+
+    expect(startX?.accessor.get()).toBe(1.5)
+    expect(startY?.accessor.get()).toBe(-2.5)
+    expect(startZ?.accessor.get()).toBe(3.25)
+    expect(endX?.accessor.get()).toBe(4.5)
+    expect(endY?.accessor.get()).toBe(5.5)
+    expect(endZ?.accessor.get()).toBe(6.5)
+    expect(length?.editable).toBe(false)
+    expect(length?.accessor.get()).toBeCloseTo(
+      Math.sqrt(
+        (4.5 - 1.5) * (4.5 - 1.5) +
+          (5.5 - -2.5) * (5.5 - -2.5) +
+          (6.5 - 3.25) * (6.5 - 3.25)
+      )
+    )
+  })
+
+  it('returns grip points in midpoint-start-end order', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(8, 2, 0)
+    )
+
+    const gripPoints = line.subGetGripPoints()
+
+    expect(gripPoints).toHaveLength(3)
+    expect(gripPoints[0]).toMatchObject({ x: 4, y: 1, z: 0 })
+    expect(gripPoints[1]).toBe(line.startPoint)
+    expect(gripPoints[2]).toBe(line.endPoint)
+  })
+
+  it('computes osnap points for all supported modes', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    const geo = (
+      line as unknown as {
+        _geo: {
+          project: (pickPoint: AcGePoint3d) => AcGePoint3d
+          perpPoint: (pickPoint: AcGePoint3d) => AcGePoint3d
+        }
+      }
+    )._geo
+
+    const projectedPoint = new AcGePoint3d(7, 0, 0)
+    const perpendicularPoint = new AcGePoint3d(2, 0, 0)
+    jest.spyOn(geo, 'project').mockReturnValue(projectedPoint)
+    jest.spyOn(geo, 'perpPoint').mockReturnValue(perpendicularPoint)
+
+    const endPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toEqual([line.startPoint, line.endPoint])
+
+    const midPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(1)
+    expect(midPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(2, 3, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(geo.project).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 2, y: 3, z: 0 })
+    )
+    expect(nearestPoints).toEqual([projectedPoint])
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(4, 3, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(geo.perpPoint).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 4, y: 3, z: 0 })
+    )
+    expect(perpendicularPoints).toEqual([perpendicularPoint])
+
+    const tangentPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.Tangent,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      tangentPoints
+    )
+    expect(tangentPoints).toHaveLength(0)
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    line.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('transforms itself and draws via renderer.lines with z flattened to 0', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(1, 2, 3),
+      new AcGePoint3d(4, 5, 6)
+    )
+    const matrix = new AcGeMatrix3d().makeTranslation(10, -3, 2)
+    const drawResult = { id: 'line-rendered' }
+    const renderer = {
+      lines: jest.fn(() => drawResult)
+    }
+
+    expect(line.transformBy(matrix)).toBe(line)
+    expect(line.startPoint).toMatchObject({ x: 11, y: -1, z: 5 })
+    expect(line.endPoint).toMatchObject({ x: 14, y: 2, z: 8 })
+
+    expect(line.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.lines).toHaveBeenCalledWith([
+      expect.objectContaining({ x: 11, y: -1, z: 0 }),
+      expect.objectContaining({ x: 14, y: 2, z: 0 })
+    ])
+  })
+
+  it('writes line-specific DXF fields and returns itself', () => {
+    const db = createWorkingDb()
+    const line = new AcDbLine(
+      new AcGePoint3d(1.25, -2.5, 3.75),
+      new AcGePoint3d(4.5, 5.25, -6.75)
+    )
+    db.tables.blockTable.modelSpace.appendEntity(line)
+    const filer = new AcDbDxfFiler()
+
+    expect(line.dxfOutFields(filer)).toBe(line)
+
+    const out = filer.toString()
+    expect(out).toContain('100\nAcDbEntity\n')
+    expect(out).toContain('100\nAcDbLine\n')
+    expect(out).toContain('10\n1.25\n20\n-2.5\n30\n3.75\n')
+    expect(out).toContain('11\n4.5\n21\n5.25\n31\n-6.75\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(
+      () => new AcDbLine(new AcGePoint3d(), new AcGePoint3d(1, 1, 0))
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbLinetypeTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbLinetypeTable.spec.ts
@@ -1,0 +1,29 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbLinetypeTable } from '../src/database/AcDbLinetypeTable'
+import { AcDbLinetypeTableRecord } from '../src/database/AcDbLinetypeTableRecord'
+import type { AcGiBaseLineStyle } from '@mlightcad/graphic-interface'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLinetypeTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbLinetypeTable(new AcDbDatabase()))
+  })
+
+  it('supports inherited symbol table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.linetypeTable
+    const style = {
+      name: 'DASHED',
+      standardFlag: 0,
+      description: 'Dashed',
+      totalPatternLength: 1,
+      pattern: [{ elementLength: 0.5, elementTypeFlag: 0 }]
+    } as AcGiBaseLineStyle
+    const record = new AcDbLinetypeTableRecord(style)
+    table.add(record)
+
+    expect(table.getAt('DASHED')).toBe(record)
+    expect(table.removeId(record.objectId)).toBe(true)
+    expect(table.getAt('DASHED')).toBeUndefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbLinetypeTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbLinetypeTableRecord.spec.ts
@@ -1,0 +1,17 @@
+import { AcDbLinetypeTableRecord } from '../src/database/AcDbLinetypeTableRecord'
+import type { AcGiBaseLineStyle } from '@mlightcad/graphic-interface'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbLinetypeTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbLinetypeTableRecord({
+          name: 'CONTINUOUS',
+          standardFlag: 0,
+          description: '',
+          totalPatternLength: 0
+        } as AcGiBaseLineStyle)
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -1,0 +1,307 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+import {
+  AcGiMTextAttachmentPoint,
+  AcGiMTextFlowDirection
+} from '@mlightcad/graphic-interface'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbMText } from '../src/entity'
+import { AcDbOsnapMode, DEFAULT_TEXT_STYLE } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbMText', () => {
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(() => new AcDbMText())
+  })
+
+  it('supports public getters and setters', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+
+    expect(AcDbMText.typeName).toBe('MText')
+    expect(mtext.dxfTypeName).toBe('MTEXT')
+
+    mtext.contents = 'line1\nline2'
+    mtext.height = 2.5
+    mtext.width = 12
+    mtext.rotation = Math.PI / 3
+    mtext.lineSpacingStyle = 2
+    mtext.lineSpacingFactor = 1.25
+    mtext.backgroundFill = true
+    mtext.backgroundFillColor = 0x123456
+    mtext.backgroundFillTransparency = 250
+    mtext.backgroundScaleFactor = 1.8
+    mtext.styleName = 'CustomStyle'
+    mtext.location = { x: 1, y: 2, z: 3 }
+    mtext.attachmentPoint = AcGiMTextAttachmentPoint.BottomRight
+    mtext.direction = { x: 2, y: 3, z: 4 }
+    mtext.drawingDirection = AcGiMTextFlowDirection.TOP_TO_BOTTOM
+
+    expect(mtext.contents).toBe('line1\nline2')
+    expect(mtext.height).toBeCloseTo(2.5)
+    expect(mtext.width).toBeCloseTo(12)
+    expect(mtext.rotation).toBeCloseTo(Math.PI / 3)
+    expect(mtext.lineSpacingStyle).toBe(2)
+    expect(mtext.lineSpacingFactor).toBeCloseTo(1.25)
+    expect(mtext.backgroundFill).toBe(true)
+    expect(mtext.backgroundFillColor).toBe(0x123456)
+    expect(mtext.backgroundFillTransparency).toBe(250)
+    expect(mtext.backgroundScaleFactor).toBeCloseTo(1.8)
+    expect(mtext.styleName).toBe('CustomStyle')
+    expect(mtext.location).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(mtext.attachmentPoint).toBe(AcGiMTextAttachmentPoint.BottomRight)
+    expect(mtext.direction).toMatchObject({ x: 2, y: 3, z: 4 })
+    expect(mtext.drawingDirection).toBe(AcGiMTextFlowDirection.TOP_TO_BOTTOM)
+    expect(mtext.geometricExtents).toBeInstanceOf(AcGeBox3d)
+  })
+
+  it('returns insertion osnap point only for insertion mode', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = { x: 9, y: 8, z: 7 }
+
+    const insertionPoints: AcGePoint3d[] = []
+    mtext.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      insertionPoints
+    )
+    expect(insertionPoints).toEqual([mtext.location])
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    mtext.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('transforms location, direction, width and height with non-zero direction', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = { x: 1, y: 2, z: 3 }
+    mtext.direction = { x: 1, y: 0, z: 0 }
+    mtext.width = 5
+    mtext.height = 7
+
+    const matrix = new AcGeMatrix3d().makeScale(2, 3, 1)
+
+    expect(mtext.transformBy(matrix)).toBe(mtext)
+    expect(mtext.location).toMatchObject({ x: 2, y: 6, z: 3 })
+    expect(mtext.direction).toMatchObject({ x: 1, y: 0, z: 0 })
+    expect(mtext.rotation).toBeCloseTo(0)
+    expect(mtext.width).toBeCloseTo(10)
+    expect(mtext.height).toBeCloseTo(21)
+  })
+
+  it('falls back to rotation when direction is zero and skips scale updates for zero axes', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.direction = { x: 0, y: 0, z: 0 }
+    mtext.rotation = Math.PI / 2
+    mtext.width = 4
+    mtext.height = 6
+
+    mtext.transformBy(new AcGeMatrix3d().makeScale(2, 3, 1))
+    expect(mtext.direction.x).toBeCloseTo(0, 5)
+    expect(mtext.direction.y).toBeCloseTo(1, 5)
+    expect(mtext.width).toBeCloseTo(12)
+    expect(mtext.height).toBeCloseTo(12)
+
+    mtext.width = 8
+    mtext.height = 9
+    const directionBefore = mtext.direction.clone()
+    mtext.transformBy(new AcGeMatrix3d().makeScale(0, 0, 1))
+    expect(mtext.direction).toEqual(directionBefore)
+    expect(mtext.width).toBeCloseTo(8)
+    expect(mtext.height).toBeCloseTo(9)
+  })
+
+  it('uses fallback y direction when computed yDir length is zero', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    const lengthSqSpy = jest
+      .spyOn(AcGeVector3d.prototype, 'lengthSq')
+      .mockReturnValue(0)
+
+    try {
+      expect(mtext.transformBy(new AcGeMatrix3d())).toBe(mtext)
+    } finally {
+      lengthSqSpy.mockRestore()
+    }
+  })
+
+  it('exposes text and geometry runtime properties and accessors', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    const properties = mtext.properties
+
+    expect(properties.type).toBe('MText')
+    expect(properties.groups.map(g => g.groupName)).toEqual([
+      'general',
+      'text',
+      'geometry'
+    ])
+
+    const valueMap: Record<string, number | string> = {
+      contents: 'updated text',
+      styleName: 'AnotherStyle',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      drawingDirection: AcGiMTextFlowDirection.BY_STYLE,
+      textHeight: 3.2,
+      rotation: Math.PI / 4,
+      lineSpacingFactor: 1.1,
+      definedWidth: 16,
+      directionX: 4,
+      directionY: 5,
+      directionZ: 6,
+      locationX: 7,
+      locationY: 8,
+      locationZ: 9
+    }
+
+    for (const groupName of ['text', 'geometry']) {
+      const group = properties.groups.find(g => g.groupName === groupName)
+      expect(group).toBeDefined()
+      for (const prop of group!.properties) {
+        prop.accessor.get()
+        if (prop.editable && prop.accessor.set) {
+          prop.accessor.set(valueMap[prop.name] ?? 0)
+        }
+        prop.accessor.get()
+      }
+    }
+
+    expect(mtext.contents).toBe('updated text')
+    expect(mtext.styleName).toBe('AnotherStyle')
+    expect(mtext.attachmentPoint).toBe(AcGiMTextAttachmentPoint.MiddleCenter)
+    expect(mtext.drawingDirection).toBe(AcGiMTextFlowDirection.BY_STYLE)
+    expect(mtext.height).toBeCloseTo(3.2)
+    expect(mtext.rotation).toBeCloseTo(Math.PI / 4)
+    expect(mtext.lineSpacingFactor).toBeCloseTo(1.1)
+    expect(mtext.width).toBeCloseTo(16)
+    expect(mtext.direction).toMatchObject({ x: 4, y: 5, z: 6 })
+    expect(mtext.location).toMatchObject({ x: 7, y: 8, z: 9 })
+  })
+
+  it('draws mtext and resolves text style via styleName/db.textstyle/default fallback', () => {
+    const db = createWorkingDb()
+    const mtext = new AcDbMText()
+    const drawResult = { id: 'mtext-drawn' }
+    const renderer = {
+      mtext: jest.fn(() => drawResult)
+    }
+
+    mtext.styleName = DEFAULT_TEXT_STYLE
+    expect(mtext.subWorldDraw(renderer as never, true)).toBe(drawResult)
+    expect(renderer.mtext).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        text: mtext.contents,
+        height: mtext.height,
+        width: mtext.width
+      }),
+      expect.any(Object),
+      true
+    )
+
+    mtext.styleName = '__missing_style__'
+    db.textstyle = DEFAULT_TEXT_STYLE
+    expect(mtext.subWorldDraw(renderer as never)).toBe(drawResult)
+
+    db.textstyle = '__missing_textstyle__'
+    expect(mtext.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.mtext).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when subWorldDraw cannot resolve any text style', () => {
+    const db = createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.styleName = '__missing_style__'
+    db.textstyle = '__missing_textstyle__'
+    db.tables.textStyleTable.removeAll()
+
+    const renderer = { mtext: jest.fn() }
+    expect(() => mtext.subWorldDraw(renderer as never)).toThrow(
+      'No valid text style found in text style table.'
+    )
+  })
+
+  it('writes MTEXT DXF fields with encoded content and optional background fields', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.ownerId = 'ABC'
+    mtext.location = { x: 1, y: 2, z: 3 }
+    mtext.height = 2
+    mtext.width = 10
+    mtext.contents = 'a\r\nb\nc\rd'
+    mtext.styleName = 'MyTextStyle'
+    mtext.rotation = Math.PI / 2
+    mtext.direction = { x: 1, y: 0, z: 0 }
+    mtext.attachmentPoint = AcGiMTextAttachmentPoint.TopCenter
+    mtext.drawingDirection = AcGiMTextFlowDirection.TOP_TO_BOTTOM
+    mtext.lineSpacingStyle = 3
+    mtext.lineSpacingFactor = 1.5
+    mtext.backgroundFill = false
+
+    const filerWithoutBackground = new AcDbDxfFiler()
+    expect(mtext.dxfOutFields(filerWithoutBackground)).toBe(mtext)
+    const dxfWithoutBackground = filerWithoutBackground.toString()
+
+    expect(dxfWithoutBackground).toContain('100\nAcDbEntity')
+    expect(dxfWithoutBackground).toContain('100\nAcDbMText')
+    expect(dxfWithoutBackground).toContain('10\n1')
+    expect(dxfWithoutBackground).toContain('20\n2')
+    expect(dxfWithoutBackground).toContain('30\n3')
+    expect(dxfWithoutBackground).toContain('40\n2')
+    expect(dxfWithoutBackground).toContain('41\n10')
+    expect(dxfWithoutBackground).toContain('1\na\\Pb\\Pc\\Pd')
+    expect(dxfWithoutBackground).toContain('7\nMyTextStyle')
+    expect(dxfWithoutBackground).toContain('50\n90')
+    expect(dxfWithoutBackground).toContain('11\n1')
+    expect(dxfWithoutBackground).toContain('21\n0')
+    expect(dxfWithoutBackground).toContain('31\n0')
+    expect(dxfWithoutBackground).toContain(
+      `71\n${AcGiMTextAttachmentPoint.TopCenter}`
+    )
+    expect(dxfWithoutBackground).toContain(
+      `72\n${AcGiMTextFlowDirection.TOP_TO_BOTTOM}`
+    )
+    expect(dxfWithoutBackground).toContain('73\n3')
+    expect(dxfWithoutBackground).toContain('44\n1.5')
+    expect(dxfWithoutBackground).not.toContain('\n90\n1\n')
+    expect(dxfWithoutBackground).not.toContain('63\n')
+    expect(dxfWithoutBackground).not.toContain('441\n')
+    expect(dxfWithoutBackground).not.toContain('45\n')
+
+    mtext.backgroundFill = true
+    mtext.backgroundFillColor = 0x112233
+    mtext.backgroundFillTransparency = 128
+    mtext.backgroundScaleFactor = 2.5
+
+    const filerWithBackground = new AcDbDxfFiler()
+    mtext.dxfOutFields(filerWithBackground)
+    const dxfWithBackground = filerWithBackground.toString()
+
+    expect(dxfWithBackground).toContain('90\n1')
+    expect(dxfWithBackground).toContain('63\n1122867')
+    expect(dxfWithBackground).toContain('441\n128')
+    expect(dxfWithBackground).toContain('45\n2.5')
+  })
+})

--- a/packages/data-model/__tests__/AcDbMeshHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbMeshHelpers.spec.ts
@@ -1,0 +1,24 @@
+import {
+  AcDbPolyFaceMeshFace,
+  AcDbPolyFaceMeshVertex
+} from '../src/entity/AcDbPolyFaceMesh'
+import { AcDbPolygonMeshVertex } from '../src/entity/AcDbPolygonMesh'
+
+describe('Mesh helper classes', () => {
+  it('constructs polyface vertex and face', () => {
+    const vertex = new AcDbPolyFaceMeshVertex({ x: 1, y: 2, z: 3 })
+    const face = new AcDbPolyFaceMeshFace([1, 2, 3])
+
+    expect(vertex.position.x).toBe(1)
+    expect(vertex.position.y).toBe(2)
+    expect(vertex.position.z).toBe(3)
+    expect(face.vertexIndices).toEqual([1, 2, 3])
+  })
+
+  it('constructs polygon mesh vertex with default z', () => {
+    const vertex = new AcDbPolygonMeshVertex({ x: 4, y: 5, z: 0 })
+    expect(vertex.position.x).toBe(4)
+    expect(vertex.position.y).toBe(5)
+    expect(vertex.position.z).toBe(0)
+  })
+})

--- a/packages/data-model/__tests__/AcDbObject.spec.ts
+++ b/packages/data-model/__tests__/AcDbObject.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbObject } from '../src/base/AcDbObject'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbObject', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbObject())
+  })
+})

--- a/packages/data-model/__tests__/AcDbObjectConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbObjectConverter.spec.ts
@@ -1,0 +1,136 @@
+import { AcDbObjectConverter } from '../src/converter/AcDbObjectConverter'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+
+describe('AcDbObjectConverter', () => {
+  it('converts image definition and model layout', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbObjectConverter()
+
+    const image = converter.convertImageDef({
+      fileName: 'a.png',
+      handle: '10',
+      ownerObjectId: '2'
+    } as any)
+    expect(image.sourceFileName).toBe('a.png')
+    expect(image.objectId).toBe('10')
+    expect(image.ownerId).toBe('2')
+
+    const model = {
+      tables: {
+        BLOCK_RECORD: {
+          entries: [{ name: '*Model_Space', handle: '1A' }]
+        }
+      }
+    } as any
+
+    const layout = converter.convertLayout(
+      {
+        layoutName: 'Model',
+        tabOrder: 0,
+        pageSetupName: 'setup',
+        configName: 'cfg',
+        paperSize: 'A4',
+        plotViewName: 'view',
+        currentStyleSheet: 'style.ctb',
+        marginLeft: 1,
+        marginRight: 2,
+        marginTop: 3,
+        marginBottom: 4,
+        paperWidth: 210,
+        paperHeight: 297,
+        plotOriginX: 0,
+        plotOriginY: 0,
+        windowAreaXMin: 0,
+        windowAreaYMin: 0,
+        windowAreaXMax: 10,
+        windowAreaYMax: 10,
+        printScaleNumerator: 1,
+        printScaleDenominator: 1,
+        plotPaperUnit: 0,
+        plotRotation: 0,
+        plotType: 0,
+        standardScaleType: 0,
+        shadePlotMode: 2,
+        shadePlotResolution: 5,
+        shadePlotCustomDPI: 300,
+        shadePlotId: 'sid',
+        layoutFlag: 1024,
+        viewportId: 'vp-id',
+        handle: '20',
+        ownerObjectId: '3'
+      } as any,
+      model
+    )
+
+    expect(layout.layoutName).toBe('Model')
+    expect(layout.blockTableRecordId).toBe('1A')
+    expect(layout.modelType).toBe(true)
+    expect(layout.viewportArray).toContain('vp-id')
+    expect(layout.shadePlotId).toBe('sid')
+    expect(layout.ownerId).toBe('3')
+  })
+
+  it('converts paper layout with block fallback', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbObjectConverter()
+    const model = {
+      tables: {
+        BLOCK_RECORD: {
+          entries: [
+            { name: '*Paper_Space0', handle: '2A', layoutObjects: 'L1' }
+          ]
+        }
+      }
+    } as any
+
+    const layout = converter.convertLayout(
+      {
+        layoutName: 'Layout1',
+        tabOrder: 1,
+        pageSetupName: '',
+        configName: '',
+        paperSize: '',
+        plotViewName: '',
+        currentStyleSheet: '',
+        marginLeft: 0,
+        marginRight: 0,
+        marginTop: 0,
+        marginBottom: 0,
+        paperWidth: 0,
+        paperHeight: 0,
+        plotOriginX: 0,
+        plotOriginY: 0,
+        windowAreaXMin: 0,
+        windowAreaYMin: 0,
+        windowAreaXMax: 0,
+        windowAreaYMax: 0,
+        printScaleNumerator: 1,
+        printScaleDenominator: 1,
+        plotPaperUnit: 0,
+        plotRotation: 0,
+        plotType: 0,
+        standardScaleType: 0,
+        shadePlotMode: 0,
+        shadePlotResolution: 0,
+        handle: 'L1',
+        ownerObjectId: '3',
+        paperSpaceTableId: 'fallback-btr'
+      } as any,
+      model
+    )
+
+    expect(layout.blockTableRecordId).toBe('2A')
+
+    const layoutFallback = converter.convertLayout(
+      {
+        ...(layout as any),
+        handle: 'L2',
+        layoutName: 'Layout2',
+        paperSpaceTableId: 'fallback-btr'
+      } as any,
+      model
+    )
+    expect(layoutFallback.blockTableRecordId).toBe('fallback-btr')
+  })
+})

--- a/packages/data-model/__tests__/AcDbObjectIterator.spec.ts
+++ b/packages/data-model/__tests__/AcDbObjectIterator.spec.ts
@@ -1,0 +1,19 @@
+import { AcDbObjectIterator } from '../src/misc/AcDbObjectIterator'
+
+describe('AcDbObjectIterator', () => {
+  it('iterates map values and reports completion', () => {
+    const records = new Map<string, number>([
+      ['a', 1],
+      ['b', 2]
+    ])
+    const iterator = new AcDbObjectIterator(records)
+
+    expect(iterator.count).toBe(2)
+    expect(iterator.toArray()).toEqual([1, 2])
+    expect(iterator[Symbol.iterator]()).toBe(iterator)
+
+    expect(iterator.next()).toEqual({ value: 1, done: false })
+    expect(iterator.next()).toEqual({ value: 2, done: false })
+    expect(iterator.next()).toEqual({ value: null, done: true })
+  })
+})

--- a/packages/data-model/__tests__/AcDbOrdinateDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbOrdinateDimension.spec.ts
@@ -1,0 +1,12 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbOrdinateDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbOrdinateDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbOrdinateDimension(new AcGePoint3d(), new AcGePoint3d(1, 0, 0))
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbPlotSettings.spec.ts
+++ b/packages/data-model/__tests__/AcDbPlotSettings.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbPlotSettings } from '../src/object/layout/AcDbPlotSettings'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbPlotSettings', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbPlotSettings())
+  })
+})

--- a/packages/data-model/__tests__/AcDbPoint.spec.ts
+++ b/packages/data-model/__tests__/AcDbPoint.spec.ts
@@ -1,0 +1,161 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbPoint } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbPoint', () => {
+  it('exposes static and DXF type names', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+
+    expect(AcDbPoint.typeName).toBe('Point')
+    expect(point.dxfTypeName).toBe('POINT')
+  })
+
+  it('initializes at origin and supports position getter/setter', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+
+    expect(point.position).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    const source = new AcGePoint3d(1, 2, 3)
+    point.position = source
+    source.x = 100
+    source.y = 200
+    source.z = 300
+
+    expect(point.position).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    point.position = { x: -4, y: 5 }
+    expect(point.position).toMatchObject({ x: -4, y: 5, z: 0 })
+  })
+
+  it('returns point-like geometric extents', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 7.5, y: -2, z: 9 }
+
+    const extents = point.geometricExtents
+    expect(extents.min).toMatchObject({ x: 7.5, y: -2, z: 9 })
+    expect(extents.max).toMatchObject({ x: 7.5, y: -2, z: 9 })
+  })
+
+  it('adds osnap point only in Node mode', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 3, y: 4, z: 5 }
+
+    const nodePoints: AcGePoint3d[] = []
+    point.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      nodePoints
+    )
+    expect(nodePoints).toHaveLength(1)
+    expect(nodePoints[0]).toBe(point.position)
+
+    const unsupportedModePoints: AcGePoint3d[] = []
+    point.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedModePoints
+    )
+    expect(unsupportedModePoints).toHaveLength(0)
+  })
+
+  it('exposes geometry properties with editable accessors', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    const geometryGroup = point.properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+
+    expect(point.properties.type).toBe('Point')
+    expect(point.properties.groups.length).toBe(2)
+    expect(geometryGroup).toBeDefined()
+
+    const byName = new Map(
+      geometryGroup!.properties.map(property => [property.name, property])
+    )
+
+    byName.get('positionX')!.accessor.set!(10)
+    byName.get('positionY')!.accessor.set!(-20)
+    byName.get('positionZ')!.accessor.set!(30)
+
+    expect(byName.get('positionX')!.editable).toBe(true)
+    expect(byName.get('positionY')!.editable).toBe(true)
+    expect(byName.get('positionZ')!.editable).toBe(true)
+    expect(byName.get('positionX')!.accessor.get()).toBe(10)
+    expect(byName.get('positionY')!.accessor.get()).toBe(-20)
+    expect(byName.get('positionZ')!.accessor.get()).toBe(30)
+    expect(point.position).toMatchObject({ x: 10, y: -20, z: 30 })
+  })
+
+  it('transforms by matrix and returns itself', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 1, y: 2, z: 3 }
+
+    const result = point.transformBy(
+      new AcGeMatrix3d().makeTranslation(4, -2, 1)
+    )
+
+    expect(result).toBe(point)
+    expect(point.position).toMatchObject({ x: 5, y: 0, z: 4 })
+  })
+
+  it('draws through renderer.point with database point style', () => {
+    const db = createWorkingDb()
+    db.pdmode = 34
+    db.pdsize = 2.5
+
+    const point = new AcDbPoint()
+    point.position = { x: 9, y: 8, z: 7 }
+
+    const rendered = { id: 'point-rendered' }
+    const renderer = {
+      point: jest.fn(() => rendered)
+    }
+
+    const result = point.subWorldDraw(renderer as never)
+
+    expect(result).toBe(rendered)
+    expect(renderer.point).toHaveBeenCalledTimes(1)
+    expect(renderer.point).toHaveBeenCalledWith(point.position, {
+      displayMode: 34,
+      displaySize: 2.5
+    })
+  })
+
+  it('writes point-specific DXF fields', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 1.25, y: -2, z: 3.5 }
+    point.ownerId = '0'
+    const filer = new AcDbDxfFiler()
+
+    const result = point.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(point)
+    expect(dxf).toContain('100\nAcDbEntity\n')
+    expect(dxf).toContain('100\nAcDbPoint\n')
+    expect(dxf).toContain('10\n1.25\n20\n-2\n30\n3.5\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(() => new AcDbPoint())
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolyFaceMesh.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyFaceMesh.spec.ts
@@ -1,0 +1,255 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbDxfFiler } from '../src/base'
+import { AcDbPolyFaceMesh } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import {
+  appendEntityToModelSpace,
+  getDxfGroupValues,
+  setupWorkingDatabase
+} from '../test-utils/entityTestUtils'
+
+describe('AcDbPolyFaceMesh', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbPolyFaceMesh(
+          [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: 0, z: 0 },
+            { x: 0, y: 1, z: 0 }
+          ],
+          [[1, 2, 3]]
+        )
+    )
+  })
+
+  it('supports type names, counters, closed getter/setter and indexed access', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 1 },
+        { x: 2, y: 3 } as unknown as { x: number; y: number; z: number },
+        { x: -4, y: 5, z: 6 }
+      ],
+      [
+        [1, 2, 3],
+        [2, 3, 1]
+      ]
+    )
+
+    expect(AcDbPolyFaceMesh.typeName).toBe('PolyFaceMesh')
+    expect(mesh.dxfTypeName).toBe('POLYLINE')
+    expect(mesh.numberOfVertices).toBe(3)
+    expect(mesh.numberOfFaces).toBe(2)
+    expect(mesh.closed).toBe(false)
+
+    mesh.closed = true
+    expect(mesh.closed).toBe(false)
+
+    expect(mesh.getVertexAt(1).position).toMatchObject({ x: 2, y: 3, z: 0 })
+    expect(mesh.getFaceAt(0).vertexIndices).toEqual([1, 2, 3])
+
+    expect(() => mesh.getVertexAt(-1)).toThrow('Vertex index out of bounds')
+    expect(() => mesh.getVertexAt(3)).toThrow('Vertex index out of bounds')
+    expect(() => mesh.getFaceAt(-1)).toThrow('Face index out of bounds')
+    expect(() => mesh.getFaceAt(2)).toThrow('Face index out of bounds')
+  })
+
+  it('computes geometric extents for empty and non-empty meshes and returns grip points', () => {
+    const emptyMesh = new AcDbPolyFaceMesh([], [])
+    expect(emptyMesh.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(emptyMesh.geometricExtents.max).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: -2, y: 4, z: 3 },
+        { x: 6, y: -5 } as unknown as { x: number; y: number; z: number },
+        { x: 1, y: 2, z: 10 }
+      ],
+      [[1, 2, 3]]
+    )
+
+    expect(mesh.geometricExtents.min).toMatchObject({ x: -2, y: -5, z: 0 })
+    expect(mesh.geometricExtents.max).toMatchObject({ x: 6, y: 4, z: 10 })
+
+    const grips = mesh.subGetGripPoints()
+    expect(grips).toHaveLength(3)
+    expect(grips[0]).toMatchObject({ x: -2, y: 4, z: 3 })
+    expect(grips[1]).toMatchObject({ x: 6, y: -5, z: 0 })
+  })
+
+  it('returns endpoint osnap points only for EndPoint mode', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 1 },
+        { x: 2, y: 3, z: 4 }
+      ],
+      [[1, 2, 1]]
+    )
+
+    const endPoints: AcGePoint3d[] = []
+    mesh.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(2)
+    expect(endPoints[1]).toMatchObject({ x: 2, y: 3, z: 4 })
+
+    const nonEndPoints: AcGePoint3d[] = []
+    mesh.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      nonEndPoints
+    )
+    expect(nonEndPoints).toHaveLength(0)
+  })
+
+  it('transforms vertices and returns itself for chaining', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 2, z: 3 }
+      ],
+      [[1, 2, 1]]
+    )
+
+    const result = mesh.transformBy(
+      new AcGeMatrix3d().makeTranslation(5, -1, 2)
+    )
+    expect(result).toBe(mesh)
+    expect(mesh.getVertexAt(0).position).toMatchObject({ x: 5, y: -1, z: 2 })
+    expect(mesh.getVertexAt(1).position).toMatchObject({ x: 6, y: 1, z: 5 })
+  })
+
+  it('returns geometry properties accessors for vertices and faces', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 1, y: 2, z: 3 },
+        { x: 4, y: 5, z: 6 }
+      ],
+      [[1, 2, 1]]
+    )
+
+    expect(mesh.properties.type).toBe('PolyFaceMesh')
+    const geometryGroup = mesh.properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(geometryGroup).toBeDefined()
+
+    const verticesProp = geometryGroup?.properties.find(
+      p => p.name === 'vertices'
+    )
+    const facesProp = geometryGroup?.properties.find(p => p.name === 'faces')
+
+    expect(verticesProp?.accessor.get()).toEqual([
+      { x: 1, y: 2, z: 3 },
+      { x: 4, y: 5, z: 6 }
+    ])
+    expect(facesProp?.accessor.get()).toEqual([{ vertexIndices: [1, 2, 1] }])
+  })
+
+  it('draws faces as closed edge lines and ignores invalid/short faces', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 0, y: 1, z: 0 }
+      ],
+      [
+        [1, 2, 3],
+        [1, -3, 4, 99],
+        [1, 2]
+      ]
+    )
+
+    const rendered = { id: 'mesh-rendered' }
+    const renderer = {
+      lines: jest.fn(() => rendered)
+    }
+
+    const result = mesh.subWorldDraw(renderer as never)
+    const linesArg = (renderer.lines as jest.Mock).mock
+      .calls[0][0] as AcGePoint3d[]
+
+    expect(result).toBe(rendered)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(linesArg).toHaveLength(12)
+    expect(linesArg[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(linesArg[1]).toMatchObject({ x: 1, y: 0, z: 0 })
+    expect(linesArg[6]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(linesArg[7]).toMatchObject({ x: 1, y: 1, z: 0 })
+  })
+
+  it('writes polyface mesh markers and flags in dxfOutFields', () => {
+    const db = setupWorkingDatabase()
+    const mesh = appendEntityToModelSpace(
+      db,
+      new AcDbPolyFaceMesh(
+        [
+          { x: 0, y: 0, z: 0 },
+          { x: 1, y: 0, z: 0 },
+          { x: 0, y: 1, z: 0 }
+        ],
+        [[1, 2, 3]]
+      )
+    )
+
+    const filer = new AcDbDxfFiler()
+    const result = mesh.dxfOutFields(filer)
+    const dxfText = filer.toString()
+
+    expect(result).toBe(mesh)
+    expect(getDxfGroupValues(dxfText, 100)).toContain('AcDbEntity')
+    expect(getDxfGroupValues(dxfText, 100)).toContain('AcDbPolyFaceMesh')
+    expect(getDxfGroupValues(dxfText, 66)).toContain('1')
+    expect(getDxfGroupValues(dxfText, 70)).toContain('64')
+  })
+
+  it('writes vertex records, face records and SEQEND in dxfOut', () => {
+    const db = setupWorkingDatabase()
+    const mesh = appendEntityToModelSpace(
+      db,
+      new AcDbPolyFaceMesh(
+        [
+          { x: 1, y: 2, z: 3 },
+          { x: 4, y: 5, z: 6 },
+          { x: 7, y: 8, z: 9 }
+        ],
+        [[1, 2, 3, -4]]
+      )
+    )
+    const filer = new AcDbDxfFiler({ database: db })
+
+    const result = mesh.dxfOut(filer)
+    const dxfText = filer.toString()
+
+    expect(result).toBe(mesh)
+    expect((dxfText.match(/\n0\nVERTEX\n/g) || []).length).toBe(4)
+    expect(
+      (dxfText.match(/\n100\nAcDbPolyFaceMeshVertex\n/g) || []).length
+    ).toBe(4)
+    expect((dxfText.match(/\n70\n64\n/g) || []).length).toBe(4)
+    expect((dxfText.match(/\n70\n128\n/g) || []).length).toBe(1)
+    expect(dxfText).toContain('\n10\n1\n20\n2\n30\n3\n')
+    expect(dxfText).toContain('\n10\n4\n20\n5\n30\n6\n')
+    expect(dxfText).toContain('\n11\n2\n12\n3\n13\n-4\n')
+    expect(dxfText).toContain('\n0\nSEQEND\n')
+  })
+
+  it('writes dxfOut with no vertices/faces using default allXdata parameter', () => {
+    const db = setupWorkingDatabase()
+    const mesh = appendEntityToModelSpace(db, new AcDbPolyFaceMesh([], []))
+    const filer = new AcDbDxfFiler({ database: db })
+
+    mesh.dxfOut(filer)
+    const dxfText = filer.toString()
+
+    expect(dxfText).not.toContain('\n0\nVERTEX\n')
+    expect(dxfText).toContain('\n0\nSEQEND\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolyFaceMeshFace.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyFaceMeshFace.spec.ts
@@ -1,0 +1,39 @@
+import { AcDbPolyFaceMeshFace } from '../src/entity/AcDbPolyFaceMesh'
+
+describe('AcDbPolyFaceMeshFace', () => {
+  it('stores face vertex indices as provided', () => {
+    const face = new AcDbPolyFaceMeshFace([1, 2, 3])
+
+    expect(face.vertexIndices).toEqual([1, 2, 3])
+  })
+
+  it('supports an empty face definition', () => {
+    const face = new AcDbPolyFaceMeshFace([])
+
+    expect(face.vertexIndices).toEqual([])
+  })
+
+  it('preserves index sign and zero values', () => {
+    const face = new AcDbPolyFaceMeshFace([1, -2, 0, 4])
+
+    expect(face.vertexIndices).toEqual([1, -2, 0, 4])
+  })
+
+  it('keeps the same vertexIndices array reference', () => {
+    const indices = [1, 2, 3]
+    const face = new AcDbPolyFaceMeshFace(indices)
+
+    indices.push(4)
+
+    expect(face.vertexIndices).toBe(indices)
+    expect(face.vertexIndices).toEqual([1, 2, 3, 4])
+  })
+
+  it('allows replacing vertexIndices through the public field', () => {
+    const face = new AcDbPolyFaceMeshFace([1, 2, 3])
+
+    face.vertexIndices = [5, 6, 7, 8]
+
+    expect(face.vertexIndices).toEqual([5, 6, 7, 8])
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolyFaceMeshVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyFaceMeshVertex.spec.ts
@@ -1,0 +1,32 @@
+import { AcDbPolyFaceMeshVertex } from '../src/entity/AcDbPolyFaceMesh'
+
+describe('AcDbPolyFaceMeshVertex', () => {
+  it('stores vertex position with explicit z', () => {
+    const vertex = new AcDbPolyFaceMeshVertex({ x: 1, y: 2, z: 3 })
+
+    expect(vertex.position.x).toBe(1)
+    expect(vertex.position.y).toBe(2)
+    expect(vertex.position.z).toBe(3)
+  })
+
+  it('defaults z to 0 when omitted', () => {
+    const vertex = new AcDbPolyFaceMeshVertex({ x: 10, y: 20 } as any)
+
+    expect(vertex.position.x).toBe(10)
+    expect(vertex.position.y).toBe(20)
+    expect(vertex.position.z).toBe(0)
+  })
+
+  it('creates an internal AcGePoint3d instance instead of keeping external reference', () => {
+    const source = { x: 5, y: 6, z: 7 }
+    const vertex = new AcDbPolyFaceMeshVertex(source)
+
+    source.x = 100
+    source.y = 200
+    source.z = 300
+
+    expect(vertex.position.x).toBe(5)
+    expect(vertex.position.y).toBe(6)
+    expect(vertex.position.z).toBe(7)
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
@@ -1,0 +1,266 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbDxfFiler } from '../src/base'
+import { AcDbPolygonMesh } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import {
+  attachEntityToNewModelSpace,
+  getDxfGroupValues,
+  setupWorkingDatabase
+} from '../test-utils/entityTestUtils'
+
+describe('AcDbPolygonMesh', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbPolygonMesh(1, 1, [{ x: 0, y: 0, z: 0 }]))
+  })
+
+  it('covers constructor defaults and basic getters/setters', () => {
+    setupWorkingDatabase()
+
+    const mesh = new AcDbPolygonMesh(
+      2,
+      2,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 1 },
+        { x: 1, y: 1, z: 1 }
+      ],
+      true,
+      false
+    )
+
+    expect(AcDbPolygonMesh.typeName).toBe('PolygonMesh')
+    expect(mesh.dxfTypeName).toBe('POLYLINE')
+    expect(mesh.mCount).toBe(2)
+    expect(mesh.nCount).toBe(2)
+    expect(mesh.closedM).toBe(true)
+    expect(mesh.closedN).toBe(false)
+    expect(mesh.closed).toBe(true)
+    expect(mesh.numberOfVertices).toBe(4)
+    expect(mesh.objectId.startsWith('TEMP_')).toBe(false)
+
+    mesh.closed = false
+    expect(mesh.closed).toBe(false)
+    expect(mesh.closedM).toBe(false)
+  })
+
+  it('supports getVertexAt and getVertexAtMN with bounds checks', () => {
+    const mesh = new AcDbPolygonMesh(2, 2, [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0, y: 1, z: 1 },
+      { x: 1, y: 1, z: 1 }
+    ])
+
+    expect(mesh.getVertexAt(0).position).toEqual(new AcGePoint3d(0, 0, 0))
+    expect(mesh.getVertexAtMN(1, 0).position).toEqual(new AcGePoint3d(0, 1, 1))
+    expect(mesh.getVertexAtMN(1, 1).position).toEqual(new AcGePoint3d(1, 1, 1))
+
+    expect(() => mesh.getVertexAt(-1)).toThrow('Vertex index out of bounds')
+    expect(() => mesh.getVertexAt(4)).toThrow('Vertex index out of bounds')
+    expect(() => mesh.getVertexAtMN(3, 0)).toThrow('Vertex index out of bounds')
+  })
+
+  it('computes geometric extents for populated and empty meshes', () => {
+    const mesh = new AcDbPolygonMesh(2, 2, [
+      { x: -2, y: 5, z: 1 },
+      { x: 3, y: -4, z: 2 },
+      { x: 1, y: 1, z: -6 },
+      { x: 2, y: 2, z: 10 }
+    ])
+    const extents = mesh.geometricExtents
+    expect(extents.min).toMatchObject({ x: -2, y: -4, z: -6 })
+    expect(extents.max).toMatchObject({ x: 3, y: 5, z: 10 })
+
+    const empty = new AcDbPolygonMesh(0, 0, [])
+    expect(empty.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(empty.geometricExtents.max).toMatchObject({ x: 0, y: 0, z: 0 })
+  })
+
+  it('returns grip points and endpoint osnap points only', () => {
+    const mesh = new AcDbPolygonMesh(1, 3, [
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 1 },
+      { x: 2, y: 3, z: 2 }
+    ])
+
+    const grips = mesh.subGetGripPoints()
+    expect(grips).toEqual([
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(2, 0, 1),
+      new AcGePoint3d(2, 3, 2)
+    ])
+
+    const endpointSnaps: AcGePoint3d[] = []
+    mesh.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    expect(endpointSnaps).toEqual(grips)
+
+    const centerSnaps: AcGePoint3d[] = []
+    mesh.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      centerSnaps
+    )
+    expect(centerSnaps).toHaveLength(0)
+  })
+
+  it('transforms vertices and returns self', () => {
+    const mesh = new AcDbPolygonMesh(1, 2, [
+      { x: 1, y: 2, z: 3 },
+      { x: -1, y: 0, z: 5 }
+    ])
+
+    expect(
+      mesh.transformBy(new AcGeMatrix3d().makeTranslation(10, -2, 4))
+    ).toBe(mesh)
+    expect(mesh.getVertexAt(0).position).toEqual(new AcGePoint3d(11, 0, 7))
+    expect(mesh.getVertexAt(1).position).toEqual(new AcGePoint3d(9, -2, 9))
+  })
+
+  it('exposes properties and supports closedM/closedN accessors', () => {
+    const mesh = new AcDbPolygonMesh(
+      2,
+      2,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 },
+        { x: 1, y: 1, z: 0 }
+      ],
+      false,
+      true
+    )
+
+    const props = mesh.properties
+    expect(props.type).toBe(mesh.type)
+
+    const geometryGroup = props.groups.find(g => g.groupName === 'geometry')
+    const othersGroup = props.groups.find(g => g.groupName === 'others')
+
+    expect(geometryGroup).toBeDefined()
+    expect(othersGroup).toBeDefined()
+
+    const mCountProp = geometryGroup!.properties.find(p => p.name === 'mCount')
+    const nCountProp = geometryGroup!.properties.find(p => p.name === 'nCount')
+    const verticesProp = geometryGroup!.properties.find(
+      p => p.name === 'vertices'
+    )
+    const closedMProp = othersGroup!.properties.find(p => p.name === 'closedM')
+    const closedNProp = othersGroup!.properties.find(p => p.name === 'closedN')
+
+    expect(mCountProp?.accessor.get()).toBe(2)
+    expect(nCountProp?.accessor.get()).toBe(2)
+    expect(verticesProp?.accessor.get()).toEqual([
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0, y: 1, z: 0 },
+      { x: 1, y: 1, z: 0 }
+    ])
+    expect(closedMProp?.accessor.get()).toBe(false)
+    expect(closedNProp?.accessor.get()).toBe(true)
+
+    closedMProp?.accessor.set?.(true)
+    closedNProp?.accessor.set?.(false)
+
+    expect(closedMProp?.accessor.get()).toBe(true)
+    expect(closedNProp?.accessor.get()).toBe(false)
+    expect(mesh.closedM).toBe(true)
+    expect(mesh.closedN).toBe(false)
+  })
+
+  it('draws mesh lines for open and closed directions', () => {
+    const vertices = [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0, y: 1, z: 0 },
+      { x: 1, y: 1, z: 0 }
+    ]
+
+    const openMesh = new AcDbPolygonMesh(2, 2, vertices, false, false)
+    const openRenderer = { lines: jest.fn(() => ({ id: 'open' })) }
+    const openResult = openMesh.subWorldDraw(openRenderer as never)
+    expect(openResult).toEqual({ id: 'open' })
+    expect(openRenderer.lines).toHaveBeenCalledTimes(1)
+    const [openLines] = openRenderer.lines.mock.calls[0] as unknown as [
+      AcGePoint3d[]
+    ]
+    expect(openLines).toHaveLength(8)
+
+    const closedMesh = new AcDbPolygonMesh(2, 2, vertices, true, true)
+    const closedRenderer = { lines: jest.fn(() => ({ id: 'closed' })) }
+    const closedResult = closedMesh.subWorldDraw(closedRenderer as never)
+    expect(closedResult).toEqual({ id: 'closed' })
+    expect(closedRenderer.lines).toHaveBeenCalledTimes(1)
+    const [closedLines] = closedRenderer.lines.mock.calls[0] as unknown as [
+      AcGePoint3d[]
+    ]
+    expect(closedLines).toHaveLength(16)
+  })
+
+  it('writes polygon mesh DXF fields and vertex records', () => {
+    const mesh = new AcDbPolygonMesh(
+      2,
+      2,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 1 },
+        { x: 0, y: 1, z: 2 },
+        { x: 1, y: 1, z: 3 }
+      ],
+      true,
+      true
+    )
+    attachEntityToNewModelSpace(mesh)
+
+    const filerFields = new AcDbDxfFiler()
+    expect(mesh.dxfOutFields(filerFields)).toBe(mesh)
+    const fieldsDxf = filerFields.toString()
+    expect(getDxfGroupValues(fieldsDxf, 100)).toContain('AcDbPolygonMesh')
+    expect(getDxfGroupValues(fieldsDxf, 66)).toContain('1')
+    expect(getDxfGroupValues(fieldsDxf, 70)).toContain('49')
+    expect(getDxfGroupValues(fieldsDxf, 71)).toContain('2')
+    expect(getDxfGroupValues(fieldsDxf, 72)).toContain('2')
+
+    const filerOut = new AcDbDxfFiler()
+    expect(mesh.dxfOut(filerOut, true)).toBe(mesh)
+    const outDxf = filerOut.toString()
+
+    expect(
+      getDxfGroupValues(outDxf, 0).filter(v => v === 'VERTEX')
+    ).toHaveLength(4)
+    expect(getDxfGroupValues(outDxf, 0)).toContain('SEQEND')
+    expect(getDxfGroupValues(outDxf, 100)).toContain('AcDbPolygonMeshVertex')
+    expect(
+      getDxfGroupValues(outDxf, 70).filter(v => v === '16').length
+    ).toBeGreaterThanOrEqual(4)
+    expect(getDxfGroupValues(outDxf, 10).slice(-4)).toEqual([
+      '0',
+      '1',
+      '0',
+      '1'
+    ])
+    expect(getDxfGroupValues(outDxf, 20).slice(-4)).toEqual([
+      '0',
+      '0',
+      '1',
+      '1'
+    ])
+    expect(getDxfGroupValues(outDxf, 30).slice(-4)).toEqual([
+      '0',
+      '1',
+      '2',
+      '3'
+    ])
+
+    const filerOutWithoutAllXData = new AcDbDxfFiler()
+    expect(mesh.dxfOut(filerOutWithoutAllXData)).toBe(mesh)
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolygonMeshVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolygonMeshVertex.spec.ts
@@ -1,0 +1,40 @@
+import { AcDbPolygonMeshVertex } from '../src/entity/AcDbPolygonMesh'
+
+describe('AcDbPolygonMeshVertex', () => {
+  it('stores vertex position with explicit z', () => {
+    const vertex = new AcDbPolygonMeshVertex({ x: 1, y: 2, z: 3 })
+
+    expect(vertex.position.x).toBe(1)
+    expect(vertex.position.y).toBe(2)
+    expect(vertex.position.z).toBe(3)
+  })
+
+  it('stores vertex position with default z fallback', () => {
+    const vertex = new AcDbPolygonMeshVertex({ x: 4, y: 5, z: 0 })
+
+    expect(vertex.position.x).toBe(4)
+    expect(vertex.position.y).toBe(5)
+    expect(vertex.position.z).toBe(0)
+  })
+
+  it('defaults z to 0 when omitted', () => {
+    const vertex = new AcDbPolygonMeshVertex({ x: 10, y: 20 } as any)
+
+    expect(vertex.position.x).toBe(10)
+    expect(vertex.position.y).toBe(20)
+    expect(vertex.position.z).toBe(0)
+  })
+
+  it('creates an internal AcGePoint3d instance instead of keeping external reference', () => {
+    const source = { x: 5, y: 6, z: 7 }
+    const vertex = new AcDbPolygonMeshVertex(source)
+
+    source.x = 100
+    source.y = 200
+    source.z = 300
+
+    expect(vertex.position.x).toBe(5)
+    expect(vertex.position.y).toBe(6)
+    expect(vertex.position.z).toBe(7)
+  })
+})

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -1,0 +1,271 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint2d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { TEMP_OBJECT_ID_PREFIX } from '../src/base/AcDbObject'
+import { AcDbDatabase } from '../src/database'
+import { AcDbPolyline } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import {
+  attachEntityToNewModelSpace,
+  getDxfGroupValues
+} from '../test-utils/entityTestUtils'
+
+describe('AcDbPolyline', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbPolyline())
+  })
+  it('covers constructor defaults and basic getters/setters', () => {
+    const polyline = new AcDbPolyline()
+
+    expect(AcDbPolyline.typeName).toBe('Polyline')
+    expect(polyline.dxfTypeName).toBe('LWPOLYLINE')
+    expect(polyline.numberOfVertices).toBe(0)
+    expect(polyline.elevation).toBe(0)
+    expect(polyline.closed).toBe(false)
+
+    polyline.elevation = 8
+    polyline.closed = true
+
+    expect(polyline.elevation).toBe(8)
+    expect(polyline.closed).toBe(true)
+  })
+
+  it('falls back to temporary object id when working database is unavailable', () => {
+    const services = acdbHostApplicationServices() as unknown as {
+      _workingDatabase: AcDbDatabase | null
+    }
+    const previousDb = services._workingDatabase
+    services._workingDatabase = null
+
+    try {
+      const polyline = new AcDbPolyline()
+      expect(polyline.objectId.startsWith(TEMP_OBJECT_ID_PREFIX)).toBe(true)
+    } finally {
+      services._workingDatabase = previousDb
+    }
+  })
+
+  it('supports add/get/remove/reset vertex operations', () => {
+    const polyline = new AcDbPolyline()
+
+    polyline.addVertexAt(0, new AcGePoint2d(1, 2), 0.5, 1.2, 3.4)
+    polyline.addVertexAt(1, new AcGePoint2d(4, 5))
+    polyline.addVertexAt(1, new AcGePoint2d(9, 7), -0.25)
+
+    expect(polyline.numberOfVertices).toBe(3)
+    expect(polyline.getPoint2dAt(0)).toEqual(new AcGePoint2d(1, 2))
+    expect(polyline.getPoint2dAt(1)).toEqual(new AcGePoint2d(9, 7))
+    expect(polyline.getPoint2dAt(2)).toEqual(new AcGePoint2d(4, 5))
+
+    polyline.removeVertexAt(1)
+    expect(polyline.numberOfVertices).toBe(2)
+    expect(polyline.getPoint2dAt(1)).toEqual(new AcGePoint2d(4, 5))
+
+    polyline.reset(true, 1)
+    expect(polyline.numberOfVertices).toBe(1)
+
+    polyline.reset(false)
+    expect(polyline.numberOfVertices).toBe(0)
+  })
+
+  it('returns 3d points and geometric extents at current elevation', () => {
+    const polyline = new AcDbPolyline()
+    polyline.elevation = 6
+    polyline.addVertexAt(0, new AcGePoint2d(-1, 2))
+    polyline.addVertexAt(1, new AcGePoint2d(3, -4))
+
+    expect(polyline.getPoint3dAt(0)).toEqual(new AcGePoint3d(-1, 2, 6))
+    expect(polyline.getPoint3dAt(1)).toEqual(new AcGePoint3d(3, -4, 6))
+
+    const extents = polyline.geometricExtents
+    expect(extents.min).toMatchObject({ x: -1, y: -4, z: 6 })
+    expect(extents.max).toMatchObject({ x: 3, y: 2, z: 6 })
+  })
+
+  it('returns grip points and endpoint osnap points only', () => {
+    const polyline = new AcDbPolyline()
+    polyline.elevation = 2
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(2, 0))
+    polyline.addVertexAt(2, new AcGePoint2d(2, 3))
+
+    const grips = polyline.subGetGripPoints()
+    expect(grips).toEqual([
+      new AcGePoint3d(0, 0, 2),
+      new AcGePoint3d(2, 0, 2),
+      new AcGePoint3d(2, 3, 2)
+    ])
+
+    const endpointSnaps: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    expect(endpointSnaps).toEqual(grips)
+
+    const centerSnaps: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      centerSnaps
+    )
+    expect(centerSnaps).toHaveLength(0)
+  })
+
+  it('transforms points, updates elevation and flips bulges for mirrored transforms', () => {
+    const polyline = new AcDbPolyline()
+    polyline.elevation = 3
+    polyline.addVertexAt(0, new AcGePoint2d(1, 2), 0.5)
+    polyline.addVertexAt(1, new AcGePoint2d(4, 5), -1)
+
+    expect(
+      polyline.transformBy(new AcGeMatrix3d().makeTranslation(10, -2, 4))
+    ).toBe(polyline)
+    expect(polyline.elevation).toBe(7)
+    expect(polyline.getPoint2dAt(0)).toEqual(new AcGePoint2d(11, 0))
+    expect(polyline.getPoint2dAt(1)).toEqual(new AcGePoint2d(14, 3))
+
+    const verticesBeforeMirror = polyline.properties.groups
+      .find(g => g.groupName === 'geometry')
+      ?.properties.find(p => p.name === 'vertices')
+      ?.accessor.get() as Array<{ bulge?: number }>
+    verticesBeforeMirror[0].bulge = undefined
+
+    polyline.transformBy(new AcGeMatrix3d().makeScale(-1, 1, 1))
+
+    const vertices = polyline.properties.groups
+      .find(g => g.groupName === 'geometry')
+      ?.properties.find(p => p.name === 'vertices')
+      ?.accessor.get() as Array<{ bulge?: number }>
+
+    expect(vertices[0].bulge).toBeUndefined()
+    expect(vertices[1].bulge).toBe(1)
+
+    const afterMirrorLength = Number(
+      polyline.properties.groups
+        .find(g => g.groupName === 'geometry')
+        ?.properties.find(p => p.name === 'length')
+        ?.accessor.get() ?? 0
+    )
+    expect(afterMirrorLength).toBeGreaterThan(0)
+  })
+
+  it('exposes properties with working accessors', () => {
+    const polyline = new AcDbPolyline()
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0), 0.25, 2, 3)
+    polyline.addVertexAt(1, new AcGePoint2d(3, 4))
+
+    const props = polyline.properties
+    expect(props.type).toBe(polyline.type)
+
+    const geometryGroup = props.groups.find(g => g.groupName === 'geometry')
+    const othersGroup = props.groups.find(g => g.groupName === 'others')
+
+    expect(geometryGroup).toBeDefined()
+    expect(othersGroup).toBeDefined()
+
+    const verticesProp = geometryGroup!.properties.find(
+      p => p.name === 'vertices'
+    )
+    const elevationProp = geometryGroup!.properties.find(
+      p => p.name === 'elevation'
+    )
+    const lengthProp = geometryGroup!.properties.find(p => p.name === 'length')
+    const closedProp = othersGroup!.properties.find(p => p.name === 'closed')
+
+    const vertices = verticesProp?.accessor.get() as Array<{
+      x: number
+      y: number
+      bulge?: number
+      startWidth?: number
+      endWidth?: number
+    }>
+
+    expect(vertices).toHaveLength(2)
+    expect(vertices[0]).toMatchObject({
+      x: 0,
+      y: 0,
+      bulge: 0.25,
+      startWidth: 2,
+      endWidth: 3
+    })
+    expect(vertices[1]).toMatchObject({
+      x: 3,
+      y: 4,
+      bulge: 0
+    })
+    expect(vertices[1].startWidth).toBeUndefined()
+    expect(vertices[1].endWidth).toBeUndefined()
+
+    expect(Number(lengthProp?.accessor.get())).toBeGreaterThan(5)
+
+    elevationProp?.accessor.set?.(9)
+    closedProp?.accessor.set?.(true)
+
+    expect(elevationProp?.accessor.get()).toBe(9)
+    expect(closedProp?.accessor.get()).toBe(true)
+  })
+
+  it('draws with sampled points using current elevation', () => {
+    const polyline = new AcDbPolyline()
+    polyline.elevation = 5
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(2, 0))
+
+    const giEntity = { id: 'polyline-gi' }
+    const renderer = {
+      lines: jest.fn(() => giEntity)
+    }
+
+    const result = polyline.subWorldDraw(renderer as never)
+    expect(result).toBe(giEntity)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+
+    const [points] = renderer.lines.mock.calls[0] as unknown as [AcGePoint3d[]]
+    expect(points.length).toBeGreaterThan(1)
+    expect(points.every(point => point.z === 5)).toBe(true)
+  })
+
+  it('writes LWPOLYLINE-specific dxf fields and vertices', () => {
+    const polyline = new AcDbPolyline()
+    attachEntityToNewModelSpace(polyline)
+
+    polyline.closed = true
+    polyline.elevation = 12
+    polyline.addVertexAt(0, new AcGePoint2d(1, 2))
+    polyline.addVertexAt(1, new AcGePoint2d(3, 4))
+
+    const filer = new AcDbDxfFiler()
+    expect(polyline.dxfOutFields(filer)).toBe(polyline)
+
+    const dxf = filer.toString()
+    expect(getDxfGroupValues(dxf, 100)).toContain('AcDbPolyline')
+    expect(getDxfGroupValues(dxf, 90)).toContain('2')
+    expect(getDxfGroupValues(dxf, 70)).toContain('1')
+    expect(getDxfGroupValues(dxf, 38)).toContain('12')
+    expect(getDxfGroupValues(dxf, 10)).toEqual(['1', '3'])
+    expect(getDxfGroupValues(dxf, 20)).toEqual(['2', '4'])
+  })
+
+  it('writes closed flag as 0 in dxf fields when polyline is open', () => {
+    const polyline = new AcDbPolyline()
+    attachEntityToNewModelSpace(polyline)
+
+    polyline.closed = false
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+
+    const filer = new AcDbDxfFiler()
+    polyline.dxfOutFields(filer)
+
+    const dxf = filer.toString()
+    expect(getDxfGroupValues(dxf, 70)).toContain('0')
+  })
+})

--- a/packages/data-model/__tests__/AcDbRadialDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbRadialDimension.spec.ts
@@ -1,0 +1,12 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbRadialDimension } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbRadialDimension', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbRadialDimension(new AcGePoint3d(), new AcGePoint3d(1, 0, 0), 1)
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbRasterImage.spec.ts
+++ b/packages/data-model/__tests__/AcDbRasterImage.spec.ts
@@ -1,0 +1,276 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint2d,
+  AcGePoint3d,
+  AcGeVector2d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbRasterImage, AcDbRasterImageClipBoundaryType } from '../src/entity'
+import { AcDbRasterImageDef } from '../src/object/AcDbRasterImageDef'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbRasterImage', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbRasterImage())
+  })
+  const createRenderer = () => ({
+    lines: jest.fn(() => ({ kind: 'lines' })),
+    image: jest.fn(() => ({ kind: 'image' }))
+  })
+
+  const parsePairs = (text: string) => {
+    const lines = text.trim().split('\n')
+    const pairs: Array<{ code: string; value: string }> = []
+    for (let i = 0; i < lines.length; i += 2) {
+      pairs.push({ code: lines[i], value: lines[i + 1] })
+    }
+    return pairs
+  }
+
+  const valuesByCode = (
+    pairs: Array<{ code: string; value: string }>,
+    code: string
+  ) => pairs.filter(pair => pair.code === code).map(pair => pair.value)
+
+  const setupInDatabase = () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+    const image = new AcDbRasterImage()
+    db.tables.blockTable.modelSpace.appendEntity(image)
+    return { db, image }
+  }
+
+  it('exposes dxf type name and all property getter/setters', () => {
+    const { image } = setupInDatabase()
+
+    expect(image.dxfTypeName).toBe('IMAGE')
+
+    image.brightness = 80
+    image.contrast = 70
+    image.fade = 10
+    image.width = 120
+    image.height = 90
+    image.position = new AcGePoint3d(5, 6, 0)
+    image.rotation = Math.PI / 3
+    image.scale = new AcGeVector2d(2, 3)
+    image.imageSize = new AcGePoint2d(400, 300)
+    image.clipBoundaryType = AcDbRasterImageClipBoundaryType.Poly
+    image.clipBoundary = [
+      new AcGePoint2d(0.1, 0.1),
+      new AcGePoint2d(0.9, 0.1),
+      new AcGePoint2d(0.9, 0.9),
+      new AcGePoint2d(0.1, 0.9)
+    ]
+    image.isClipped = true
+    image.isShownClipped = true
+    image.isImageShown = false
+    image.isImageTransparent = true
+    const blob = new Blob(['a'], { type: 'text/plain' })
+    image.image = blob
+    image.imageDefId = 'ABC'
+
+    expect(image.brightness).toBe(80)
+    expect(image.contrast).toBe(70)
+    expect(image.fade).toBe(10)
+    expect(image.width).toBe(120)
+    expect(image.height).toBe(90)
+    expect(image.position.x).toBe(5)
+    expect(image.position.y).toBe(6)
+    expect(image.rotation).toBeCloseTo(Math.PI / 3)
+    expect(image.scale.x).toBe(2)
+    expect(image.scale.y).toBe(3)
+    expect(image.imageSize.x).toBe(400)
+    expect(image.imageSize.y).toBe(300)
+    expect(image.clipBoundaryType).toBe(AcDbRasterImageClipBoundaryType.Poly)
+    expect(image.clipBoundary.length).toBe(4)
+    expect(image.isClipped).toBe(true)
+    expect(image.isShownClipped).toBe(true)
+    expect(image.isImageShown).toBe(false)
+    expect(image.isImageTransparent).toBe(true)
+    expect(image.image).toBe(blob)
+    expect(image.imageDefId).toBe('ABC')
+  })
+
+  it('resolves image file name from image definition dictionary', () => {
+    const { db, image } = setupInDatabase()
+
+    expect(image.imageFileName).toBe('')
+
+    image.imageDefId = 'NOT_EXIST'
+    expect(image.imageFileName).toBe('')
+
+    const imageDef = new AcDbRasterImageDef()
+    imageDef.sourceFileName = 'textures/test.png'
+    db.objects.imageDefinition.setAt('TEST_IMG_DEF', imageDef)
+    image.imageDefId = imageDef.objectId
+    expect(image.imageFileName).toBe('textures/test.png')
+  })
+
+  it('calculates geometric extents', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(10, 20, 0)
+    image.width = 30
+    image.height = 40
+
+    const extents = image.geometricExtents
+    expect(extents.min.x).toBe(10)
+    expect(extents.min.y).toBe(20)
+    expect(extents.max.x).toBe(40)
+    expect(extents.max.y).toBe(60)
+  })
+
+  it('returns grip points with rectangular boundary and clipping boundary', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(1, 2, 0)
+    image.width = 10
+    image.height = 8
+    image.rotation = Math.PI / 4
+
+    const rectangular = image.subGetGripPoints()
+    expect(rectangular.length).toBe(5)
+    expect(rectangular[0].x).toBeCloseTo(1)
+    expect(rectangular[0].y).toBeCloseTo(2)
+    expect(rectangular[4].x).toBeCloseTo(rectangular[0].x)
+    expect(rectangular[4].y).toBeCloseTo(rectangular[0].y)
+
+    image.clipBoundary = [
+      new AcGePoint2d(0.2, 0.2),
+      new AcGePoint2d(0.8, 0.2),
+      new AcGePoint2d(0.8, 0.8),
+      new AcGePoint2d(0.2, 0.8)
+    ]
+    image.isClipped = true
+
+    const clipped = image.subGetGripPoints()
+    expect(clipped.length).toBe(4)
+    expect(clipped[0].z).toBe(0)
+  })
+
+  it('draws via renderer.lines when image data is absent and renderer.image when present', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(0, 0, 0)
+    image.width = 12
+    image.height = 6
+
+    const renderer = createRenderer()
+    const lineDrawable = image.subWorldDraw(renderer as never)
+    expect(lineDrawable).toEqual({ kind: 'lines' })
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.image).not.toHaveBeenCalled()
+
+    image.image = new Blob(['raw'], { type: 'application/octet-stream' })
+    const imageDrawable = image.subWorldDraw(renderer as never)
+    expect(imageDrawable).toEqual({ kind: 'image' })
+    expect(renderer.image).toHaveBeenCalledTimes(1)
+  })
+
+  it('transforms geometry and resets scale', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(0, 0, 0)
+    image.width = 10
+    image.height = 5
+    image.scale = new AcGeVector2d(2, 3)
+    image.rotation = 0
+
+    const result = image.transformBy(new AcGeMatrix3d().makeScale(2, 2, 1))
+    expect(result).toBe(image)
+    expect(image.position.x).toBeCloseTo(0)
+    expect(image.position.y).toBeCloseTo(0)
+    expect(image.rotation).toBeCloseTo(0)
+    expect(image.width).toBeCloseTo(40)
+    expect(image.height).toBeCloseTo(30)
+    expect(image.scale.x).toBe(1)
+    expect(image.scale.y).toBe(1)
+  })
+
+  it('writes dxf fields with fallback imageSize and without clipping vertices', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(3, 4, 0)
+    image.width = 20
+    image.height = 10
+    image.scale = new AcGeVector2d(2, 3)
+    image.rotation = 0
+    image.imageSize = new AcGePoint2d(0, 0)
+    image.isImageShown = true
+    image.isShownClipped = false
+    image.isImageTransparent = false
+    image.isClipped = false
+    image.brightness = 55
+    image.contrast = 44
+    image.fade = 33
+    image.imageDefId = ''
+
+    const filer = new AcDbDxfFiler()
+    const result = image.dxfOutFields(filer)
+    expect(result).toBe(image)
+
+    const pairs = parsePairs(filer.toString())
+    expect(valuesByCode(pairs, '100')).toContain('AcDbRasterImage')
+    expect(valuesByCode(pairs, '10')).toContain('3')
+    expect(valuesByCode(pairs, '20')).toContain('4')
+    expect(valuesByCode(pairs, '13')).toContain('40')
+    expect(valuesByCode(pairs, '23')).toContain('30')
+    expect(valuesByCode(pairs, '70')).toContain('1')
+    expect(valuesByCode(pairs, '280')).toContain('0')
+    expect(valuesByCode(pairs, '281')).toContain('55')
+    expect(valuesByCode(pairs, '282')).toContain('44')
+    expect(valuesByCode(pairs, '283')).toContain('33')
+    expect(valuesByCode(pairs, '91')).toHaveLength(0)
+  })
+
+  it('writes dxf fields with explicit imageSize and clipping vertices', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(0, 0, 0)
+    image.width = 10
+    image.height = 20
+    image.scale = new AcGeVector2d(1, 1)
+    image.rotation = Math.PI / 2
+    image.imageSize = new AcGePoint2d(5, 10)
+    image.isImageShown = false
+    image.isShownClipped = true
+    image.isImageTransparent = true
+    image.isClipped = true
+    image.clipBoundaryType = AcDbRasterImageClipBoundaryType.Poly
+    image.clipBoundary = [
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(1, 0),
+      new AcGePoint2d(1, 1),
+      new AcGePoint2d(0, 1)
+    ]
+
+    const filer = new AcDbDxfFiler()
+    image.dxfOutFields(filer)
+    const pairs = parsePairs(filer.toString())
+    expect(valuesByCode(pairs, '13')).toContain('5')
+    expect(valuesByCode(pairs, '23')).toContain('10')
+    expect(valuesByCode(pairs, '70')).toContain('12')
+    expect(valuesByCode(pairs, '71')).toContain(
+      String(AcDbRasterImageClipBoundaryType.Poly)
+    )
+    expect(valuesByCode(pairs, '280')).toContain('1')
+    expect(valuesByCode(pairs, '91')).toContain('4')
+    expect(valuesByCode(pairs, '14')).toEqual(['0', '1', '1', '0'])
+    expect(valuesByCode(pairs, '24')).toEqual(['0', '0', '1', '1'])
+  })
+
+  it('writes zero pixel vectors when width and height are zero', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(0, 0, 0)
+    image.width = 0
+    image.height = 0
+    image.scale = new AcGeVector2d(1, 1)
+    image.imageSize = new AcGePoint2d(0, 0)
+
+    const filer = new AcDbDxfFiler()
+    image.dxfOutFields(filer)
+    const pairs = parsePairs(filer.toString())
+
+    expect(valuesByCode(pairs, '11')).toContain('0')
+    expect(valuesByCode(pairs, '21')).toContain('0')
+    expect(valuesByCode(pairs, '12')).toContain('0')
+    expect(valuesByCode(pairs, '22')).toContain('0')
+  })
+})

--- a/packages/data-model/__tests__/AcDbRasterImageDef.spec.ts
+++ b/packages/data-model/__tests__/AcDbRasterImageDef.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbRasterImageDef } from '../src/object/AcDbRasterImageDef'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbRasterImageDef', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbRasterImageDef())
+  })
+})

--- a/packages/data-model/__tests__/AcDbRay.spec.ts
+++ b/packages/data-model/__tests__/AcDbRay.spec.ts
@@ -1,0 +1,183 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbRay } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbRay', () => {
+  it('exposes static and DXF type names and open-state flag', () => {
+    const ray = new AcDbRay()
+
+    expect(AcDbRay.typeName).toBe('Ray')
+    expect(ray.dxfTypeName).toBe('RAY')
+    expect(ray.closed).toBe(false)
+  })
+
+  it('supports base point and unit direction getter/setter with copy semantics', () => {
+    const ray = new AcDbRay()
+    const base = new AcGePoint3d(1, 2, 3)
+    const dir = new AcGePoint3d(0, 1, -2)
+
+    ray.basePoint = base
+    ray.unitDir = dir
+    base.set(10, 20, 30)
+    dir.set(-3, -4, -5)
+
+    expect(ray.basePoint).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(ray.unitDir).toMatchObject({ x: 0, y: 1, z: -2 })
+  })
+
+  it('returns geometric extents expanded from base point in both direction offsets', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(1, 2, 3)
+    ray.unitDir = new AcGeVector3d(0, 2, -1)
+
+    const extents = ray.geometricExtents
+
+    expect(extents.min).toMatchObject({ x: 1, y: -18, z: -7 })
+    expect(extents.max).toMatchObject({ x: 1, y: 22, z: 13 })
+  })
+
+  it('exposes editable geometry properties and updates ray coordinates via accessors', () => {
+    const ray = new AcDbRay()
+    const geometryGroup = ray.properties.groups.find(
+      group => group.groupName === 'geometry'
+    )
+
+    expect(ray.properties.type).toBe('Ray')
+    expect(geometryGroup).toBeDefined()
+    expect(geometryGroup?.properties.map(p => p.name)).toEqual([
+      'basePointX',
+      'basePointY',
+      'basePointZ',
+      'unitDirX',
+      'unitDirY',
+      'unitDirZ'
+    ])
+
+    const byName = new Map(
+      geometryGroup!.properties.map(property => [property.name, property])
+    )
+
+    byName.get('basePointX')!.accessor.set!(3.5)
+    byName.get('basePointY')!.accessor.set!(-4.25)
+    byName.get('basePointZ')!.accessor.set!(5.75)
+    byName.get('unitDirX')!.accessor.set!(-1)
+    byName.get('unitDirY')!.accessor.set!(2)
+    byName.get('unitDirZ')!.accessor.set!(0.5)
+
+    expect(byName.get('basePointX')!.accessor.get()).toBe(3.5)
+    expect(byName.get('basePointY')!.accessor.get()).toBe(-4.25)
+    expect(byName.get('basePointZ')!.accessor.get()).toBe(5.75)
+    expect(byName.get('unitDirX')!.accessor.get()).toBe(-1)
+    expect(byName.get('unitDirY')!.accessor.get()).toBe(2)
+    expect(byName.get('unitDirZ')!.accessor.get()).toBe(0.5)
+    expect(ray.basePoint).toMatchObject({ x: 3.5, y: -4.25, z: 5.75 })
+    expect(ray.unitDir).toMatchObject({ x: -1, y: 2, z: 0.5 })
+  })
+
+  it('returns base point as the only grip point', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(6, 7, 8)
+
+    const gripPoints = ray.subGetGripPoints()
+
+    expect(gripPoints).toHaveLength(1)
+    expect(gripPoints[0]).toBe(ray.basePoint)
+  })
+
+  it('adds endpoint osnap for EndPoint mode and ignores unsupported modes', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(9, 8, 7)
+    const endpointSnaps: AcGePoint3d[] = []
+    const unsupportedSnaps: AcGePoint3d[] = []
+
+    ray.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    ray.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedSnaps
+    )
+
+    expect(endpointSnaps).toEqual([ray.basePoint])
+    expect(unsupportedSnaps).toHaveLength(0)
+  })
+
+  it('transforms base point and direction and returns itself', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(1, 2, 3)
+    ray.unitDir = new AcGeVector3d(4, -5, 6)
+    const expectedNormalized = new AcGeVector3d(4, -5, 6).normalize()
+
+    const result = ray.transformBy(new AcGeMatrix3d().makeTranslation(7, -8, 9))
+
+    expect(result).toBe(ray)
+    expect(ray.basePoint).toMatchObject({ x: 8, y: -6, z: 12 })
+    expect(ray.unitDir).toMatchObject({
+      x: expectedNormalized.x,
+      y: expectedNormalized.y,
+      z: expectedNormalized.z
+    })
+  })
+
+  it('draws as a line from base point to far point in direction vector', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(1, -2, 3)
+    ray.unitDir = new AcGeVector3d(0.5, 0, -1)
+
+    const rendered = { id: 'ray-rendered' }
+    const renderer = {
+      lines: jest.fn(() => rendered)
+    }
+
+    const result = ray.subWorldDraw(renderer as never)
+
+    expect(result).toBe(rendered)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.lines).toHaveBeenCalledWith([
+      expect.objectContaining({ x: 1, y: -2, z: 3 }),
+      expect.objectContaining({ x: 500001, y: -2, z: -999997 })
+    ])
+  })
+
+  it('writes ray-specific DXF fields and returns itself', () => {
+    const db = createWorkingDb()
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(1.25, -2.5, 3.75)
+    ray.unitDir = new AcGeVector3d(0.5, 1.5, -2.5)
+    db.tables.blockTable.modelSpace.appendEntity(ray)
+    const filer = new AcDbDxfFiler()
+
+    const result = ray.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(ray)
+    expect(dxf).toContain('100\nAcDbEntity\n')
+    expect(dxf).toContain('100\nAcDbRay\n')
+    expect(dxf).toContain('10\n1.25\n20\n-2.5\n30\n3.75\n')
+    expect(dxf).toContain('11\n0.5\n21\n1.5\n31\n-2.5\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(() => new AcDbRay())
+  })
+})

--- a/packages/data-model/__tests__/AcDbRegAppTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbRegAppTable.spec.ts
@@ -1,0 +1,21 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbRegAppTable } from '../src/database/AcDbRegAppTable'
+import { AcDbRegAppTableRecord } from '../src/database/AcDbRegAppTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbRegAppTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbRegAppTable(new AcDbDatabase()))
+  })
+
+  it('supports inherited symbol table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.appIdTable
+    const record = new AcDbRegAppTableRecord('APP_A')
+    table.add(record)
+
+    expect(table.has('APP_A')).toBe(true)
+    expect(table.remove('APP_A')).toBe(true)
+    expect(table.has('APP_A')).toBe(false)
+  })
+})

--- a/packages/data-model/__tests__/AcDbRegAppTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbRegAppTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbRegAppTableRecord } from '../src/database/AcDbRegAppTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbRegAppTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbRegAppTableRecord('TEST_APP'))
+  })
+})

--- a/packages/data-model/__tests__/AcDbRegenerator.spec.ts
+++ b/packages/data-model/__tests__/AcDbRegenerator.spec.ts
@@ -1,0 +1,104 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbRegenerator } from '../src/converter/AcDbRegenerator'
+import { AcDbLine } from '../src/entity/AcDbLine'
+import { AcDbRasterImageDef } from '../src/object/AcDbRasterImageDef'
+import { AcDbDataGenerator } from '../src/misc/AcDbDataGenerator'
+
+class TestRegenerator extends AcDbRegenerator {
+  parsePublic() {
+    return this.parse()
+  }
+  getFontsPublic() {
+    return this.getFonts()
+  }
+  processEntitiesPublic(
+    source: AcDbDatabase,
+    target: AcDbDatabase,
+    minimumChunkSize: number,
+    startPercentage: { value: number },
+    progress?: (p: number, stage: string, status: string) => Promise<void>
+  ) {
+    return this.processEntities(
+      source,
+      target,
+      minimumChunkSize,
+      startPercentage,
+      progress as any
+    )
+  }
+  processBlocksPublic() {
+    return this.processBlocks()
+  }
+  processHeaderPublic() {
+    return this.processHeader()
+  }
+  processBlockTablesPublic() {
+    return this.processBlockTables()
+  }
+  processObjectsPublic() {
+    return this.processObjects()
+  }
+  processViewportsPublic() {
+    return this.processViewports()
+  }
+  processLayersPublic() {
+    return this.processLayers()
+  }
+  processLineTypesPublic() {
+    return this.processLineTypes()
+  }
+  processTextStylesPublic() {
+    return this.processTextStyles()
+  }
+  processDimStylesPublic() {
+    return this.processDimStyles()
+  }
+}
+
+describe('AcDbRegenerator', () => {
+  it('exposes parse/fonts and processes entity/object/layer events', async () => {
+    const db = new AcDbDatabase()
+    new AcDbDataGenerator(db).createDefaultLayer()
+    const lineA = new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 1, y: 0, z: 0 })
+    const lineB = new AcDbLine({ x: 0, y: 1, z: 0 }, { x: 1, y: 1, z: 0 })
+    db.tables.blockTable.modelSpace.appendEntity([lineA, lineB])
+
+    const imageDef = new AcDbRasterImageDef()
+    db.objects.imageDefinition.setAt(imageDef.objectId, imageDef)
+
+    const reg = new TestRegenerator(db)
+
+    const parsed = await reg.parsePublic()
+    expect(parsed.model).toBe(db)
+    expect(parsed.data.unknownEntityCount).toBe(0)
+    expect(reg.getFontsPublic()).toEqual([])
+
+    const entityEvents: unknown[] = []
+    const objectEvents: unknown[] = []
+    const layerEvents: unknown[] = []
+    db.events.entityAppended.addEventListener(e => entityEvents.push(e))
+    db.events.dictObjetSet.addEventListener(e => objectEvents.push(e))
+    db.events.layerAppended.addEventListener(e => layerEvents.push(e))
+
+    const progressValues: number[] = []
+    await reg.processEntitiesPublic(db, db, 1, { value: 10 }, async p => {
+      progressValues.push(p)
+    })
+
+    reg.processBlocksPublic()
+    reg.processObjectsPublic()
+    reg.processLayersPublic()
+
+    reg.processHeaderPublic()
+    reg.processBlockTablesPublic()
+    reg.processViewportsPublic()
+    reg.processLineTypesPublic()
+    reg.processTextStylesPublic()
+    reg.processDimStylesPublic()
+
+    expect(entityEvents.length).toBeGreaterThan(0)
+    expect(objectEvents.length).toBeGreaterThan(0)
+    expect(layerEvents.length).toBeGreaterThan(0)
+    expect(progressValues.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
+++ b/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
@@ -1,0 +1,40 @@
+jest.mock('../src/database', () => ({
+  AcDbBlockTableRecord: class MockBlockTableRecord {}
+}))
+
+jest.mock('../src/entity', () => ({
+  AcDbEntity: class MockEntity {}
+}))
+
+import { AcDbRenderingCache } from '../src/misc/AcDbRenderingCache'
+
+describe('AcDbRenderingCache', () => {
+  it('manages cached values and draw fallback', () => {
+    const cache = new AcDbRenderingCache()
+    expect(AcDbRenderingCache.instance).toBeInstanceOf(AcDbRenderingCache)
+
+    const key = cache.createKey('B1', 7)
+    expect(key).toBe('B1_7')
+
+    const group = {
+      fastDeepClone() {
+        return { ...this }
+      }
+    } as any
+
+    const stored = cache.set(key, group)
+    expect(stored).not.toBe(group)
+    expect(cache.has(key)).toBe(true)
+    expect(cache.get(key)).toBeDefined()
+
+    const renderer = {
+      group: (items: unknown[]) => ({ items, fastDeepClone: () => ({ items }) })
+    } as any
+
+    const drawn = cache.draw(renderer, null as any, 0)
+    expect(drawn).toBeDefined()
+
+    cache.clear()
+    expect(cache.has(key)).toBe(false)
+  })
+})

--- a/packages/data-model/__tests__/AcDbResultBuffer.spec.ts
+++ b/packages/data-model/__tests__/AcDbResultBuffer.spec.ts
@@ -1,0 +1,34 @@
+import { AcDbResultBuffer } from '../src/base/AcDbResultBuffer'
+
+describe('AcDbResultBuffer', () => {
+  it('supports collection operations and clone isolation', () => {
+    const initial = [
+      { code: 1, value: 'a' },
+      { code: 70, value: 2 }
+    ]
+    const buffer = new AcDbResultBuffer(initial)
+
+    expect(buffer.length).toBe(2)
+    expect(buffer.at(0)).toEqual({ code: 1, value: 'a' })
+    expect(buffer.at(99)).toBeUndefined()
+
+    buffer.add({ code: 2, value: 'b' })
+    buffer.addRange([{ code: 3, value: true }])
+    expect(buffer.length).toBe(4)
+
+    const arr = buffer.toArray()
+    arr[0].value = 'changed'
+    expect(buffer.at(0)?.value).toBe('a')
+
+    const cloned = buffer.clone()
+    cloned.add({ code: 4, value: 'c' })
+    expect(cloned.length).toBe(5)
+    expect(buffer.length).toBe(4)
+
+    const iterated = [...buffer]
+    expect(iterated.length).toBe(4)
+
+    buffer.clear()
+    expect(buffer.length).toBe(0)
+  })
+})

--- a/packages/data-model/__tests__/AcDbSpline.spec.ts
+++ b/packages/data-model/__tests__/AcDbSpline.spec.ts
@@ -1,0 +1,229 @@
+import { AcCmErrors } from '@mlightcad/common'
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import type { AcGeKnotParameterizationType } from '@mlightcad/geometry-engine'
+import { AcGiRenderer } from '@mlightcad/graphic-interface'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbSpline } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbSpline', () => {
+  const controlPoints = [
+    { x: 0, y: 0, z: 0 },
+    { x: 1, y: 1, z: 0 },
+    { x: 2, y: -1, z: 0 },
+    { x: 3, y: 0, z: 0 }
+  ]
+  const knots = [0, 0, 0, 0, 1, 1, 1, 1]
+  let db: AcDbDatabase
+
+  beforeAll(() => {
+    db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+  })
+
+  it('exposes static and DXF type names', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+
+    expect(AcDbSpline.typeName).toBe('Spline')
+    expect(spline.dxfTypeName).toBe('SPLINE')
+  })
+
+  it('supports control-point constructor with geometric extents and closed setter', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const extents = spline.geometricExtents
+
+    expect(extents.min.x).toBeLessThanOrEqual(0)
+    expect(extents.max.x).toBeGreaterThanOrEqual(3)
+
+    spline.closed = true
+    expect(spline.closed).toBe(true)
+  })
+
+  it('supports fit-point constructor and rebuild overloads', () => {
+    const fitPoints = [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0.5, z: 0 },
+      { x: 2, y: 0, z: 0 },
+      { x: 3, y: 0.5, z: 0 }
+    ]
+    const spline = new AcDbSpline(
+      fitPoints,
+      0 as unknown as AcGeKnotParameterizationType
+    )
+
+    spline.rebuild(controlPoints, knots, [1, 2, 3, 4], 3, true)
+    expect(spline.closed).toBe(true)
+
+    spline.rebuild(
+      fitPoints,
+      0 as unknown as AcGeKnotParameterizationType,
+      3,
+      false
+    )
+    expect(spline.closed).toBe(false)
+  })
+
+  it('throws illegal parameters for invalid rebuild argument count', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+
+    expect(() =>
+      (spline as unknown as { rebuild: (...args: unknown[]) => void }).rebuild()
+    ).toThrow(AcCmErrors.ILLEGAL_PARAMETERS)
+    expect(() =>
+      (spline as unknown as { rebuild: (...args: unknown[]) => void }).rebuild(
+        [],
+        [],
+        [],
+        3,
+        false,
+        'extra'
+      )
+    ).toThrow(AcCmErrors.ILLEGAL_PARAMETERS)
+  })
+
+  it('returns endpoint osnap points and ignores unsupported osnap mode', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const endpointSnaps: AcGePoint3d[] = []
+    const unsupportedSnaps: AcGePoint3d[] = []
+
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedSnaps
+    )
+
+    expect(endpointSnaps).toHaveLength(2)
+    expect(endpointSnaps[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(endpointSnaps[1]).toMatchObject({ x: 3, y: 0, z: 0 })
+    expect(unsupportedSnaps).toHaveLength(0)
+  })
+
+  it('transforms by matrix and returns itself', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const before: AcGePoint3d[] = []
+    const after: AcGePoint3d[] = []
+
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      before
+    )
+
+    const result = spline.transformBy(
+      new AcGeMatrix3d().makeTranslation(2, -1, 5)
+    )
+
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      after
+    )
+
+    expect(result).toBe(spline)
+    expect(after[0]).toMatchObject({
+      x: before[0].x + 2,
+      y: before[0].y - 1,
+      z: before[0].z + 5
+    })
+    expect(after[1]).toMatchObject({
+      x: before[1].x + 2,
+      y: before[1].y - 1,
+      z: before[1].z + 5
+    })
+  })
+
+  it('delegates drawing to renderer.lines with sampled points', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const rendered = { id: 'entity' }
+    const renderer = {
+      lines: jest.fn(() => rendered)
+    } as unknown as AcGiRenderer
+
+    const result = spline.subWorldDraw(renderer)
+
+    expect(result).toBe(rendered)
+    expect(
+      (renderer as unknown as { lines: jest.Mock }).lines
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      (renderer as unknown as { lines: jest.Mock }).lines.mock.calls[0][0]
+    ).toHaveLength(100)
+  })
+
+  it('writes spline-specific DXF fields for control points', () => {
+    const spline = new AcDbSpline(
+      controlPoints,
+      knots,
+      [1, 1.5, 2, 2.5],
+      3,
+      true
+    )
+    const filer = new AcDbDxfFiler()
+    db.tables.blockTable.modelSpace.appendEntity(spline)
+
+    const result = spline.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(spline)
+    expect(dxf).toContain('100\nAcDbSpline\n')
+    expect(dxf).toContain('70\n1\n')
+    expect(dxf).toContain('71\n3\n')
+    expect(dxf).toContain('72\n8\n')
+    expect(dxf).toContain('73\n4\n')
+    expect(dxf).toContain('74\n0\n')
+    expect(dxf).toContain('40\n0\n')
+    expect(dxf).toContain('41\n1.5\n')
+    expect(dxf).toContain('10\n0\n20\n0\n30\n0\n')
+  })
+
+  it('writes fit points in DXF when underlying geometry exposes them', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const filer = new AcDbDxfFiler()
+    db.tables.blockTable.modelSpace.appendEntity(spline)
+    ;(spline as unknown as { _geo: unknown })._geo = {
+      degree: 3,
+      knots: [0, 0, 0, 0, 1, 1, 1, 1],
+      weights: [1, 1, 1, 1],
+      controlPoints,
+      fitPoints: [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 }
+      ],
+      closed: false
+    }
+
+    spline.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('74\n2\n')
+    expect(dxf).toContain('11\n0\n21\n0\n31\n0\n')
+    expect(dxf).toContain('11\n1\n21\n1\n31\n0\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbSpline(
+          [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: 0, z: 0 },
+            { x: 2, y: 0, z: 0 },
+            { x: 3, y: 0, z: 0 }
+          ],
+          [0, 0, 0, 0, 1, 1, 1, 1]
+        )
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbSymbolTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbSymbolTable.spec.ts
@@ -1,0 +1,99 @@
+import { AcDbDxfFiler } from '../src/base/AcDbDxfFiler'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbSymbolTable } from '../src/database/AcDbSymbolTable'
+import { AcDbSymbolTableRecord } from '../src/database/AcDbSymbolTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import { setupWorkingDatabase } from '../test-utils/entityTestUtils'
+
+class LowercaseSymbolTable extends AcDbSymbolTable<AcDbSymbolTableRecord> {
+  protected override normalizeName(name: string) {
+    return name.toLowerCase()
+  }
+}
+
+const getGroupValues = (dxfText: string, code: number) => {
+  const lines = dxfText.trim().split(/\r?\n/)
+  const values: string[] = []
+  for (let i = 0; i < lines.length - 1; i += 2) {
+    if (Number(lines[i]) === code) {
+      values.push(lines[i + 1])
+    }
+  }
+  return values
+}
+
+describe('AcDbSymbolTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () => new AcDbSymbolTable<AcDbSymbolTableRecord>(new AcDbDatabase())
+    )
+  })
+
+  it('adds, queries, iterates and removes records by name/id', () => {
+    const db = setupWorkingDatabase()
+    const table = new AcDbSymbolTable<AcDbSymbolTableRecord>(db)
+    const recA = new AcDbSymbolTableRecord({ name: 'A' })
+    const recB = new AcDbSymbolTableRecord({ name: 'B' })
+    recA.objectId = 'AA'
+    recB.objectId = 'AA'
+
+    table.add(recA)
+    table.add(recB)
+
+    expect(recA.objectId).toBe('AA')
+    expect(recB.objectId).not.toBe('AA')
+    expect(recA.database).toBe(db)
+    expect(recA.ownerId).toBe(table.objectId)
+    expect(table.numEntries).toBe(2)
+    expect(table.has('A')).toBe(true)
+    expect(table.has('a')).toBe(false)
+    expect(table.getAt('A')).toBe(recA)
+    expect(table.getIdAt(recA.objectId)).toBe(recA)
+    expect(table.getOwnerIdAt(recA.objectId)).toBe(recA)
+    expect(table.hasId(recA.objectId)).toBe(true)
+
+    const names = Array.from(table.newIterator()).map(item => item.name)
+    expect(names).toEqual(['A', 'B'])
+
+    expect(table.remove('A')).toBe(true)
+    expect(table.remove('A')).toBe(false)
+    expect(table.removeId(recB.objectId)).toBe(true)
+    expect(table.removeId(recB.objectId)).toBe(false)
+    expect(table.getAt('B')).toBeUndefined()
+    expect(table.numEntries).toBe(0)
+
+    table.add(new AcDbSymbolTableRecord({ name: 'C' }))
+    expect(table.numEntries).toBe(1)
+    table.removeAll()
+    expect(table.numEntries).toBe(0)
+  })
+
+  it('applies normalized names when subclass overrides normalizeName', () => {
+    const db = new AcDbDatabase()
+    const table = new LowercaseSymbolTable(db)
+    const rec = new AcDbSymbolTableRecord({ name: 'MiXeD' })
+    table.add(rec)
+
+    expect(table.has('mixed')).toBe(true)
+    expect(table.has('MIXED')).toBe(true)
+    expect(table.getAt('mixed')).toBe(rec)
+    expect(table.remove('MIXED')).toBe(true)
+    expect(table.hasId(rec.objectId)).toBe(false)
+    expect(table.getAt('mixed')).toBeUndefined()
+  })
+
+  it('writes AcDbSymbolTable DXF fields with current entry count', () => {
+    const db = new AcDbDatabase()
+    const table = new AcDbSymbolTable<AcDbSymbolTableRecord>(db)
+    table.add(new AcDbSymbolTableRecord({ name: 'R1' }))
+    table.add(new AcDbSymbolTableRecord({ name: 'R2' }))
+    const filer = new AcDbDxfFiler()
+
+    const result = table.dxfOutFields(filer)
+    const dxfText = filer.toString()
+
+    expect(result).toBe(table)
+    expect(getGroupValues(dxfText, 100)).toContain('AcDbSymbolTable')
+    expect(getGroupValues(dxfText, 70)).toContain('2')
+  })
+})

--- a/packages/data-model/__tests__/AcDbSymbolTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbSymbolTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbSymbolTableRecord } from '../src/database/AcDbSymbolTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbSymbolTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbSymbolTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
@@ -1,0 +1,75 @@
+import { AcCmColor } from '@mlightcad/common'
+
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbSystemVariables } from '../src/database/AcDbSystemVariables'
+import { AcDbSysVarManager } from '../src/database/AcDbSysVarManager'
+
+describe('AcDbSysVarManager', () => {
+  it('gets and sets db/non-db vars with conversion and events', () => {
+    const db = new AcDbDatabase()
+    const manager = AcDbSysVarManager.instance()
+
+    const unknownName = '__unit_test_unknown__'
+    expect(() => manager.getVar(unknownName, db)).toThrow(
+      'System variable __unit_test_unknown__ not found!'
+    )
+
+    const oldPickbox = manager.getVar(AcDbSystemVariables.PICKBOX, db)
+    const events: string[] = []
+    manager.events.sysVarChanged.addEventListener(e => events.push(e.name))
+
+    manager.setVar(AcDbSystemVariables.PICKBOX, '12', db)
+    expect(manager.getVar(AcDbSystemVariables.PICKBOX, db)).toBe(12)
+
+    manager.setVar(AcDbSystemVariables.DYNPROMPT, 'false', db)
+    expect(manager.getVar(AcDbSystemVariables.DYNPROMPT, db)).toBe(false)
+
+    manager.setVar(AcDbSystemVariables.MEASUREMENTCOLOR, 'red', db)
+    expect(
+      manager.getVar(AcDbSystemVariables.MEASUREMENTCOLOR, db)
+    ).toBeInstanceOf(AcCmColor)
+
+    expect(events).toContain(AcDbSystemVariables.PICKBOX.toLowerCase())
+
+    manager.setVar(AcDbSystemVariables.CLAYER, '0', db)
+    expect(manager.getVar(AcDbSystemVariables.CLAYER, db)).toBe('0')
+
+    expect(() =>
+      manager.setVar(AcDbSystemVariables.PICKBOX, 'NaN-input', db)
+    ).toThrow('Invalid number input!')
+    expect(() =>
+      manager.setVar(AcDbSystemVariables.MEASUREMENTCOLOR, 'bad-color', db)
+    ).toThrow('Invalid color value!')
+
+    manager.setVar(AcDbSystemVariables.PICKBOX, oldPickbox as number, db)
+  })
+
+  it('supports registry helpers and defaults', () => {
+    const db = new AcDbDatabase()
+    const manager = AcDbSysVarManager.instance()
+
+    manager.registerVar({
+      name: '__UNIT_BOOL__',
+      type: 'boolean',
+      isDbVar: false,
+      defaultValue: true
+    })
+
+    manager.registerMany([
+      {
+        name: '__UNIT_NUM__',
+        type: 'number',
+        isDbVar: false,
+        defaultValue: 1
+      }
+    ])
+
+    expect(manager.getDescriptor('__UNIT_BOOL__')?.name).toBe('__unit_bool__')
+    expect(manager.getDefaultValue('__UNIT_BOOL__')).toBe(true)
+    expect(manager.getVar('__UNIT_BOOL__', db)).toBe(true)
+    expect(manager.getAllDescriptors().length).toBeGreaterThan(0)
+    expect(() => manager.getDefaultValue('__NOT_FOUND__')).toThrow(
+      'System variable __not_found__ not found!'
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -1,0 +1,488 @@
+import { AcGeBox3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import {
+  AcGiEntity,
+  AcGiMTextAttachmentPoint,
+  AcGiRenderer
+} from '@mlightcad/graphic-interface'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbTable } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createGiEntity = () => {
+  const entity = {
+    objectId: '',
+    ownerId: '',
+    layerName: '',
+    visible: true,
+    applyMatrix: jest.fn(),
+    bakeTransformToChildren: jest.fn(),
+    addChild: jest.fn(),
+    fastDeepClone: jest.fn()
+  }
+  entity.fastDeepClone.mockImplementation(() => createGiEntity())
+  return entity
+}
+
+const createRenderer = () => {
+  const traits: Record<string, unknown> = {}
+  return {
+    subEntityTraits: traits,
+    lines: jest.fn(() => createGiEntity()),
+    circularArc: jest.fn(() => createGiEntity()),
+    ellipticalArc: jest.fn(() => createGiEntity()),
+    lineSegments: jest.fn(() => createGiEntity()),
+    area: jest.fn(() => createGiEntity()),
+    point: jest.fn(() => createGiEntity()),
+    image: jest.fn(() => createGiEntity()),
+    mtext: jest.fn(() => createGiEntity()),
+    setFontMapping: jest.fn(),
+    group: jest.fn((children: unknown[] = []) => {
+      const group = createGiEntity() as Record<string, unknown>
+      group.children = children
+      return group
+    })
+  }
+}
+
+const setWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbTable('TEST', 1, 1))
+  })
+  it('supports all core table getters/setters and cell APIs', () => {
+    const table = new AcDbTable('TABLE_METHODS', 2, 3)
+    expect(AcDbTable.typeName).toBe('Table')
+    expect(table.dxfTypeName).toBe('ACAD_TABLE')
+
+    table.attachmentPoint = AcGiMTextAttachmentPoint.BottomCenter
+    table.numRows = 4
+    table.numColumns = 5
+    expect(table.attachmentPoint).toBe(AcGiMTextAttachmentPoint.BottomCenter)
+    expect(table.numRows).toBe(4)
+    expect(table.numColumns).toBe(5)
+
+    table.setRowHeight(0, 8)
+    table.setUniformRowHeight(6)
+    table.setRowHeight(1, 9)
+    expect(table.rowHeight(0)).toBe(6)
+    expect(table.rowHeight(1)).toBe(9)
+
+    table.setColumnWidth(0, 20)
+    table.setUniformColumnWidth(12)
+    table.setColumnWidth(2, 18)
+    expect(table.columnWidth(0)).toBe(12)
+    expect(table.columnWidth(2)).toBe(18)
+
+    expect(table.cell(-1)).toBeUndefined()
+    expect(table.cell(999)).toBeUndefined()
+    table.setTextString(0, 0, 'A00')
+    expect(table.numContents(0, 0)).toBe(1)
+    expect(table.textString(0, 0)).toBe('A00')
+    expect(table.isEmpty(0, 0)).toBe(false)
+    expect(table.isEmpty(1, 1)).toBe(true)
+    expect(table.textString(99, 99, 0)).toBeUndefined()
+
+    const firstCell = table.cell(0)
+    expect(firstCell).toMatchObject({
+      text: 'A00',
+      attachmentPoint: AcGiMTextAttachmentPoint.BottomCenter,
+      cellType: 1,
+      textHeight: 0
+    })
+
+    table.setCell(0, {
+      text: 'A00-EDITED',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      cellType: 1,
+      textHeight: 2
+    })
+    expect(table.textString(0, 0)).toBe('A00-EDITED')
+
+    table.setTextString(0, 0, 'A00-UPDATED')
+    expect(table.textString(0, 0)).toBe('A00-UPDATED')
+    expect(table.cell(0)?.attachmentPoint).toBe(
+      AcGiMTextAttachmentPoint.MiddleCenter
+    )
+
+    expect(table.geometricExtents).toBeInstanceOf(AcGeBox3d)
+  })
+
+  it('exposes editable runtime properties for table and geometry groups', () => {
+    const table = new AcDbTable('TABLE_PROPERTIES', 2, 2)
+    table.position = new AcGePoint3d(1, 2, 3)
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(20)
+
+    const props = table.properties
+    const tableGroup = props.groups.find(group => group.groupName === 'table')
+    const geometryGroup = props.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(tableGroup).toBeDefined()
+    expect(geometryGroup).toBeDefined()
+
+    const numRowsProp = tableGroup?.properties.find(p => p.name === 'numRows')
+    const numColumnsProp = tableGroup?.properties.find(
+      p => p.name === 'numColumns'
+    )
+    const tableWidthProp = tableGroup?.properties.find(
+      p => p.name === 'tableWidth'
+    )
+    const tableHeightProp = tableGroup?.properties.find(
+      p => p.name === 'tableHeight'
+    )
+    expect(numRowsProp?.accessor.get()).toBe(2)
+    numRowsProp?.accessor.set?.(3)
+    expect(numRowsProp?.accessor.get()).toBe(3)
+    expect(numColumnsProp?.accessor.get()).toBe(2)
+    numColumnsProp?.accessor.set?.(4)
+    expect(numColumnsProp?.accessor.get()).toBe(4)
+    expect(tableWidthProp?.accessor.get()).toBe(40)
+    expect(tableHeightProp?.accessor.get()).toBe(20)
+
+    const positionXProp = geometryGroup?.properties.find(
+      p => p.name === 'positionX'
+    )
+    const positionYProp = geometryGroup?.properties.find(
+      p => p.name === 'positionY'
+    )
+    const positionZProp = geometryGroup?.properties.find(
+      p => p.name === 'positionZ'
+    )
+    positionXProp?.accessor.set?.(11)
+    positionYProp?.accessor.set?.(22)
+    positionZProp?.accessor.set?.(33)
+    expect(positionXProp?.accessor.get()).toBe(11)
+    expect(positionYProp?.accessor.get()).toBe(22)
+    expect(positionZProp?.accessor.get()).toBe(33)
+  })
+
+  it('renders texts and merged-cell borders via subWorldDraw', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const table = new AcDbTable('TABLE_DRAW', 3, 3)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+
+    table.position = new AcGePoint3d(4, 5, 0)
+    table.rotation = Math.PI / 6
+    table.scaleFactors = new AcGePoint3d(2, 2, 1)
+    table.attachmentPoint = 0 as AcGiMTextAttachmentPoint
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(20)
+
+    const alignments = [1, 2, 3, 4, 5, 6, 7, 8, 9] as AcGiMTextAttachmentPoint[]
+    for (let i = 0; i < 9; i++) {
+      table.setCell(i, {
+        text: `R${i}`,
+        attachmentPoint: alignments[i],
+        textStyle: 'Standard',
+        cellType: 1,
+        textHeight: 2
+      })
+    }
+    table.setCell(0, {
+      text: 'MERGED-2X2',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      textStyle: 'Standard',
+      cellType: 1,
+      textHeight: 2,
+      borderWidth: 2,
+      borderHeight: 2
+    })
+    table.setCell(8, {
+      text: 'FALLBACK_ALIGN',
+      attachmentPoint: 0 as AcGiMTextAttachmentPoint,
+      cellType: 1,
+      textHeight: 2
+    })
+
+    const drawn = table.subWorldDraw(
+      renderer as unknown as AcGiRenderer<AcGiEntity>
+    )
+    expect(drawn).toBeDefined()
+    expect(renderer.mtext).toHaveBeenCalled()
+    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
+    const grouped = renderer.group.mock.results[0]?.value
+    expect(grouped.applyMatrix).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses text style fallback order and throws if no style can be resolved', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+
+    const first = new AcDbTable('STYLE_1', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(first)
+    first.setUniformRowHeight(10)
+    first.setUniformColumnWidth(10)
+    first.setCell(0, {
+      text: 'A',
+      textStyle: 'Standard',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 1
+    })
+    expect(() =>
+      first.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).not.toThrow()
+
+    const second = new AcDbTable('STYLE_2', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(second)
+    second.setUniformRowHeight(10)
+    second.setUniformColumnWidth(10)
+    second.setCell(0, {
+      text: 'B',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 1
+    })
+    db.textstyle = 'Standard'
+    expect(() =>
+      second.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).not.toThrow()
+
+    const third = new AcDbTable('STYLE_3', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(third)
+    third.setUniformRowHeight(10)
+    third.setUniformColumnWidth(10)
+    third.setCell(0, {
+      text: 'C',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 1
+    })
+    db.textstyle = 'NOT_EXIST'
+    expect(() =>
+      third.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).not.toThrow()
+
+    const styleTable = third.database.tables.textStyleTable
+    const getAtSpy = jest.spyOn(styleTable, 'getAt').mockReturnValue(undefined)
+    expect(() =>
+      third.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).toThrow('No valid text style found in text style table.')
+    getAtSpy.mockRestore()
+  })
+
+  it('covers remaining text alignment branches in subWorldDraw', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const table = new AcDbTable('TABLE_ALIGN', 1, 3)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(10)
+
+    table.setCell(0, {
+      text: 'TOP_CENTER',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopCenter,
+      textStyle: 'Standard',
+      cellType: 1,
+      textHeight: 1
+    })
+    table.setCell(1, {
+      text: 'MIDDLE_LEFT',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleLeft,
+      textStyle: 'Standard',
+      cellType: 1,
+      textHeight: 1
+    })
+    table.setCell(2, {
+      text: 'BOTTOM_RIGHT',
+      attachmentPoint: AcGiMTextAttachmentPoint.BottomRight,
+      textStyle: 'Standard',
+      cellType: 1,
+      textHeight: 1
+    })
+
+    table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    expect(renderer.mtext).toHaveBeenCalledTimes(3)
+  })
+
+  it('writes expected DXF fields for pre-2007 text serialization', () => {
+    const db = setWorkingDb()
+    const table = new AcDbTable('TABLE_DXF_OLD', 1, 2)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.attachmentPoint = AcGiMTextAttachmentPoint.TopCenter
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(20)
+    table.tableDataVersion = 1
+    table.tableValueFlag = 123
+    table.setCell(0, {
+      text: 'SHORT_TEXT',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 2
+    })
+    table.setCell(1, {
+      text: 'X'.repeat(600),
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 2,
+      overrideFlag: 7
+    })
+
+    const filer = new AcDbDxfFiler().setVersion(26)
+    const result = table.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(table)
+    expect(dxf).toContain('AcDbTable')
+    expect(dxf).toContain('\n177\n7\n')
+    expect(dxf).toContain('\n2\n')
+    expect(dxf).toContain('\n1\n')
+    expect(dxf).not.toContain('\n301\n')
+  })
+
+  it('writes expected DXF fields for 2007+ table options and cell variants', () => {
+    const db = setWorkingDb()
+    const table = new AcDbTable('TABLE_DXF_NEW', 2, 2)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(5)
+    table.setUniformColumnWidth(10)
+
+    table.tableDataVersion = 9
+    table.tableStyleId = 'TS_1'
+    table.owningBlockRecordId = 'BTR_OWNER'
+    table.tableOverrideFlag = 22
+    table.borderColorOverrideFlag = 33
+    table.borderLineweightOverrideFlag = 44
+    table.borderVisibilityOverrideFlag = 55
+    table.flowDirection = 1
+    table.horizontalCellMargin = 2
+    table.verticalCellMargin = 3
+    table.suppressTitle = true
+    table.suppressHeader = false
+    table.tableBorderColors = {
+      left: 1,
+      top: 2,
+      insideHorizontal: 3,
+      bottom: 4,
+      insideVertical: 5,
+      right: 6
+    }
+    table.cellTypeOverrides = [
+      {
+        textStyle: 'Standard',
+        textHeight: 2.5,
+        alignment: 5,
+        backgroundColor: 7,
+        contentColor: 8,
+        backgroundColorEnabled: true,
+        borderLineweights: {
+          top: 0,
+          right: 5,
+          bottom: 9,
+          left: 13,
+          insideHorizontal: 15,
+          insideVertical: 18
+        },
+        borderVisibility: {
+          top: true,
+          right: true,
+          bottom: false,
+          left: false,
+          insideHorizontal: true,
+          insideVertical: false
+        }
+      }
+    ]
+    table.rowDataTypes = [1, 2, 3]
+    table.rowUnitTypes = [4, 5, 6]
+    table.rowFormats = ['%g', '%f']
+
+    table.setCell(0, {
+      text: 'FIELD_TEXT',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleLeft,
+      cellType: 1,
+      textHeight: 2,
+      fieldObjetId: 'FIELD_1',
+      topBorderVisibility: true,
+      rightBorderVisibility: false,
+      bottomBorderVisibility: true,
+      leftBorderVisibility: false
+    })
+    table.setCell(1, {
+      text: 'Y'.repeat(700),
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      cellType: 1,
+      textHeight: 2,
+      overrideFlag: 88,
+      extendedCellFlags: 3,
+      textStyle: 'Standard',
+      cellValueBlockBegin: 'MY_CELL'
+    })
+    table.setCell(2, {
+      text: 'BLOCK_CONTENT',
+      attachmentPoint: AcGiMTextAttachmentPoint.BottomRight,
+      cellType: 2,
+      textHeight: 2,
+      blockTableRecordId: 'BLOCK_1',
+      blockScale: 1.5,
+      blockAttrNum: 2,
+      attrDefineId: ['A1', 'A2'],
+      attrText: ['T1', 'T2']
+    })
+    table.setCell(3, {
+      text: 'BLOCK_CONTENT_SINGLE_ATTR',
+      attachmentPoint: AcGiMTextAttachmentPoint.BottomLeft,
+      cellType: 2,
+      textHeight: 2,
+      blockTableRecordId: 'BLOCK_2',
+      blockScale: 1.2,
+      blockAttrNum: 1,
+      attrText: 'ONLY_ONE'
+    })
+
+    const filer = new AcDbDxfFiler().setVersion(27)
+    const result = table.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(table)
+    expect(dxf).toContain('AcDbTable')
+    expect(dxf).toContain('\n301\nMY_CELL\n')
+    expect(dxf).toContain('\n303\n')
+    expect(dxf).toContain('\n302\n')
+    expect(dxf).toContain('ACVALUE_END')
+    expect(dxf).toContain('\n91\n88\n')
+    expect(dxf).toContain('\n92\n3\n')
+    expect(dxf).toContain('\n340\n')
+    expect(dxf).toContain('\n331\nA1\n')
+    expect(dxf).toContain('\n300\nT1\n')
+    expect(dxf).toContain('\n300\nONLY_ONE\n')
+    expect(dxf).toContain('\n344\n')
+    expect(dxf).toContain('\n280\n1\n')
+    expect(dxf).toContain('\n281\n0\n')
+    expect(dxf).toContain('\n97\n1\n')
+    expect(dxf).toContain('\n98\n4\n')
+    expect(dxf).toContain('\n4\n%g\n')
+  })
+
+  it('writes short text cell blocks in 2007+ DXF with default cell block marker', () => {
+    const db = setWorkingDb()
+    const table = new AcDbTable('TABLE_DXF_NEW_SHORT', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(5)
+    table.setUniformColumnWidth(10)
+    table.setCell(0, {
+      text: 'SHORT_2007',
+      attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+      cellType: 1,
+      textHeight: 1
+    })
+
+    const filer = new AcDbDxfFiler().setVersion(27)
+    table.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('\n301\nCELL_VALUE\n')
+    expect(dxf).toContain('\n302\nSHORT_2007\n')
+    expect(dxf).toContain('\n304\nACVALUE_END\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbText.spec.ts
+++ b/packages/data-model/__tests__/AcDbText.spec.ts
@@ -1,0 +1,265 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbOsnapMode } from '../src/misc'
+import {
+  AcDbText,
+  AcDbTextHorizontalMode,
+  AcDbTextVerticalMode
+} from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbText', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbText())
+  })
+  it('provides default values and dxf type', () => {
+    const text = new AcDbText()
+
+    expect(AcDbText.typeName).toBe('Text')
+    expect(text.dxfTypeName).toBe('TEXT')
+    expect(text.textString).toBe('')
+    expect(text.thickness).toBe(1)
+    expect(text.height).toBe(0)
+    expect(text.position).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(text.rotation).toBe(0)
+    expect(text.oblique).toBe(0)
+    expect(text.horizontalMode).toBe(AcDbTextHorizontalMode.LEFT)
+    expect(text.verticalMode).toBe(AcDbTextVerticalMode.MIDDLE)
+    expect(text.styleName).toBe('')
+    expect(text.widthFactor).toBe(1)
+  })
+
+  it('supports all property getters and setters', () => {
+    const text = new AcDbText()
+    const sourcePos = new AcGePoint3d(1, 2, 3)
+    text.textString = 'Hello'
+    text.thickness = 2
+    text.height = 3.5
+    text.position = sourcePos
+    text.rotation = Math.PI / 6
+    text.oblique = Math.PI / 12
+    text.horizontalMode = AcDbTextHorizontalMode.CENTER
+    text.verticalMode = AcDbTextVerticalMode.TOP
+    text.styleName = 'Standard'
+    text.widthFactor = 0.8
+
+    sourcePos.x = 99
+
+    expect(text.textString).toBe('Hello')
+    expect(text.thickness).toBe(2)
+    expect(text.height).toBe(3.5)
+    expect(text.position).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(text.rotation).toBeCloseTo(Math.PI / 6, 8)
+    expect(text.oblique).toBeCloseTo(Math.PI / 12, 8)
+    expect(text.horizontalMode).toBe(AcDbTextHorizontalMode.CENTER)
+    expect(text.verticalMode).toBe(AcDbTextVerticalMode.TOP)
+    expect(text.styleName).toBe('Standard')
+    expect(text.widthFactor).toBe(0.8)
+  })
+
+  it('returns an AcGeBox3d from geometricExtents', () => {
+    const text = new AcDbText()
+
+    expect(text.geometricExtents).toBeInstanceOf(AcGeBox3d)
+  })
+
+  it('returns insertion osnap point only for insertion mode', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(3, 4, 5)
+    const snapPoints: AcGePoint3d[] = []
+
+    text.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapPoints
+    )
+    expect(snapPoints).toHaveLength(0)
+
+    text.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapPoints
+    )
+    expect(snapPoints).toHaveLength(1)
+    expect(snapPoints[0]).toMatchObject({ x: 3, y: 4, z: 5 })
+  })
+
+  it('transforms text with normal scale and rotation updates', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(1, 0, 0)
+    text.rotation = 0
+    text.height = 2
+    text.widthFactor = 1
+    text.thickness = 4
+
+    const result = text.transformBy(
+      new AcGeMatrix3d()
+        .makeRotationZ(Math.PI / 2)
+        .multiply(new AcGeMatrix3d().makeScale(2, 3, 5))
+    )
+
+    expect(result).toBe(text)
+    expect(text.position.x).toBeCloseTo(0, 8)
+    expect(text.position.y).toBeCloseTo(2, 8)
+    expect(text.position.z).toBeCloseTo(0, 8)
+    expect(text.rotation).toBeCloseTo(Math.PI / 2, 8)
+    expect(text.height).toBeCloseTo(6, 8)
+    expect(text.widthFactor).toBeCloseTo(2 / 3, 8)
+    expect(text.thickness).toBeCloseTo(20, 8)
+  })
+
+  it('keeps rotation and thickness when corresponding transformed axes collapse', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(1, 2, 3)
+    text.rotation = 0
+    text.height = 5
+    text.widthFactor = 0.5
+    text.thickness = 7
+
+    text.transformBy(new AcGeMatrix3d().makeScale(0, 2, 0))
+
+    expect(text.rotation).toBeCloseTo(0, 8)
+    expect(text.height).toBeCloseTo(10, 8)
+    expect(text.widthFactor).toBeCloseTo(0.5, 8)
+    expect(text.thickness).toBeCloseTo(7, 8)
+  })
+
+  it('exposes mutable runtime properties', () => {
+    const text = new AcDbText()
+    const props = text.properties
+
+    expect(props.type).toBe(text.type)
+    const textGroup = props.groups.find(group => group.groupName === 'text')
+    const geometryGroup = props.groups.find(
+      group => group.groupName === 'geometry'
+    )
+    expect(textGroup).toBeDefined()
+    expect(geometryGroup).toBeDefined()
+
+    const byName = Object.fromEntries(
+      [
+        ...(textGroup?.properties ?? []),
+        ...(geometryGroup?.properties ?? [])
+      ].map(p => [p.name, p])
+    )
+
+    byName.contents.accessor.set?.('A')
+    byName.styleName.accessor.set?.('Standard')
+    byName.textHeight.accessor.set?.(9)
+    byName.rotation.accessor.set?.(1.25)
+    byName.widthFactor.accessor.set?.(0.7)
+    byName.oblique.accessor.set?.(0.2)
+    byName.positionX.accessor.set?.(10)
+    byName.positionY.accessor.set?.(20)
+    byName.positionZ.accessor.set?.(30)
+
+    expect(byName.contents.accessor.get()).toBe('A')
+    expect(byName.styleName.accessor.get()).toBe('Standard')
+    expect(byName.textHeight.accessor.get()).toBe(9)
+    expect(byName.rotation.accessor.get()).toBe(1.25)
+    expect(byName.widthFactor.accessor.get()).toBe(0.7)
+    expect(byName.oblique.accessor.get()).toBe(0.2)
+    expect(byName.positionX.accessor.get()).toBe(10)
+    expect(byName.positionY.accessor.get()).toBe(20)
+    expect(byName.positionZ.accessor.get()).toBe(30)
+    expect(text.position).toMatchObject({ x: 10, y: 20, z: 30 })
+  })
+
+  it('renders by forwarding MText data and resolved text style', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+    const text = new AcDbText()
+    text.database = db
+    text.textString = 'render'
+    text.height = 2.2
+    text.widthFactor = 0.6
+    text.position = new AcGePoint3d(7, 8, 9)
+    text.rotation = 1.2
+    text.styleName = 'NotExists'
+
+    const giEntity = { objectId: 'R' }
+    const renderer = {
+      mtext: jest.fn(() => giEntity)
+    } as unknown as {
+      mtext: jest.Mock
+    }
+
+    const result = text.subWorldDraw(renderer as never, true)
+
+    expect(result).toBe(giEntity)
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    const [mtextData, textStyle, delay] = renderer.mtext.mock.calls[0]
+    expect(mtextData).toMatchObject({
+      text: 'render',
+      height: 2.2,
+      width: Infinity,
+      widthFactor: 0.6,
+      position: text.position,
+      rotation: 1.2
+    })
+    expect(textStyle).toBeDefined()
+    expect(delay).toBe(true)
+  })
+
+  it('throws when subWorldDraw cannot resolve a text style', () => {
+    const text = new AcDbText()
+    text.database = new AcDbDatabase()
+    const renderer = {
+      mtext: jest.fn()
+    } as unknown as {
+      mtext: jest.Mock
+    }
+
+    expect(() => text.subWorldDraw(renderer as never)).toThrow(
+      'No valid text style found in text style table.'
+    )
+    expect(renderer.mtext).not.toHaveBeenCalled()
+  })
+
+  it('writes expected DXF fields for text entity', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const text = new AcDbText()
+    text.database = db
+    text.position = new AcGePoint3d(1, 2, 3)
+    text.thickness = 4
+    text.height = 5
+    text.textString = 'DXF_TEXT'
+    text.rotation = Math.PI / 2
+    text.widthFactor = 0.75
+    text.oblique = Math.PI / 6
+    text.styleName = 'Standard'
+    text.horizontalMode = AcDbTextHorizontalMode.RIGHT
+    text.verticalMode = AcDbTextVerticalMode.TOP
+    db.tables.blockTable.modelSpace.appendEntity(text)
+
+    const filer = new AcDbDxfFiler({ precision: 6 })
+    const result = text.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(text)
+    expect(dxf).toContain('100\nAcDbText\n')
+    expect(dxf).toContain('10\n1\n20\n2\n30\n3\n')
+    expect(dxf).toContain('39\n4\n')
+    expect(dxf).toContain('40\n5\n')
+    expect(dxf).toContain('1\nDXF_TEXT\n')
+    expect(dxf).toContain('50\n90\n')
+    expect(dxf).toContain('41\n0.75\n')
+    expect(dxf).toContain('51\n30\n')
+    expect(dxf).toContain('7\nStandard\n')
+    expect(dxf).toContain('72\n2\n')
+    expect(dxf).toContain('73\n3\n')
+    expect(dxf).toContain('11\n1\n21\n2\n31\n3\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbTextStyleTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextStyleTable.spec.ts
@@ -1,0 +1,50 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbTextStyleTable } from '../src/database/AcDbTextStyleTable'
+import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+import type { AcGiTextStyle } from '@mlightcad/graphic-interface'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbTextStyleTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbTextStyleTable(new AcDbDatabase()))
+  })
+
+  it('collects normalized unique font names from file and big-font fields', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.textStyleTable
+    const makeStyle = (name: string, font: string) =>
+      ({
+        name,
+        fixedTextHeight: 0,
+        widthFactor: 1,
+        obliqueAngle: 0,
+        textGenerationFlag: 0,
+        lastHeight: 0,
+        font,
+        bigFont: '',
+        extendedFont: ''
+      }) as AcGiTextStyle
+
+    const style1 = new AcDbTextStyleTableRecord(makeStyle('S1', 'Arial.ttf'))
+    style1.bigFontFileName = 'Gbcbig.SHX'
+    const style2 = new AcDbTextStyleTableRecord(makeStyle('S2', 'simhei'))
+    style2.bigFontFileName = ''
+    const style3 = new AcDbTextStyleTableRecord(makeStyle('S3', 'ARIAL.TTF'))
+    style3.fileName = ''
+    style3.bigFontFileName = 'SIMHEI'
+
+    table.add(style1)
+    table.add(style2)
+    table.add(style3)
+
+    const fonts = table.fonts
+    expect(fonts).toEqual(expect.arrayContaining(['arial', 'gbcbig', 'simhei']))
+    expect(fonts).toHaveLength(3)
+  })
+
+  it('returns empty fonts when no styles exist', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.textStyleTable
+    expect(table.fonts).toEqual([])
+  })
+})

--- a/packages/data-model/__tests__/AcDbTextStyleTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextStyleTableRecord.spec.ts
@@ -1,0 +1,22 @@
+import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+import type { AcGiTextStyle } from '@mlightcad/graphic-interface'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbTextStyleTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(
+      () =>
+        new AcDbTextStyleTableRecord({
+          name: 'Standard',
+          fixedTextHeight: 0,
+          widthFactor: 1,
+          obliqueAngle: 0,
+          textGenerationFlag: 0,
+          lastHeight: 0.2,
+          font: 'SimKai',
+          bigFont: '',
+          extendedFont: 'SimKai'
+        } as AcGiTextStyle)
+    )
+  })
+})

--- a/packages/data-model/__tests__/AcDbTrace.spec.ts
+++ b/packages/data-model/__tests__/AcDbTrace.spec.ts
@@ -1,0 +1,141 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbTrace } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbTrace', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbTrace())
+  })
+
+  it('exposes type names and default values', () => {
+    const trace = new AcDbTrace()
+
+    expect(AcDbTrace.typeName).toBe('Trace')
+    expect(trace.dxfTypeName).toBe('TRACE')
+    expect(trace.elevation).toBe(0)
+    expect(trace.thickness).toBe(1)
+    expect(trace.closed).toBe(true)
+  })
+
+  it('supports elevation/thickness and point accessors', () => {
+    const trace = new AcDbTrace()
+    trace.elevation = 12
+    trace.thickness = 2.5
+
+    trace.setPointAt(0, { x: 1, y: 2, z: 3 })
+    trace.setPointAt(1, { x: 4, y: 5, z: 6 })
+    trace.setPointAt(2, { x: 7, y: 8, z: 9 })
+    trace.setPointAt(3, { x: 10, y: 11, z: 12 })
+
+    expect(trace.elevation).toBe(12)
+    expect(trace.thickness).toBe(2.5)
+    expect(trace.getPointAt(0)).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(trace.getPointAt(3)).toMatchObject({ x: 10, y: 11, z: 12 })
+    expect(trace.getPointAt(-100)).toBe(trace.getPointAt(0))
+    expect(trace.getPointAt(100)).toBe(trace.getPointAt(3))
+  })
+
+  it('handles setPointAt out-of-range branches', () => {
+    const trace = new AcDbTrace()
+
+    trace.setPointAt(3, { x: 3, y: 3, z: 3 })
+    trace.setPointAt(10, { x: 9, y: 9, z: 9 })
+    expect(trace.getPointAt(3)).toMatchObject({ x: 9, y: 9, z: 9 })
+
+    expect(() => trace.setPointAt(-1, { x: 1, y: 1, z: 1 })).toThrow()
+  })
+
+  it('computes geometric extents, grip points and osnap points', () => {
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, { x: -2, y: -1, z: 0 })
+    trace.setPointAt(1, { x: 3, y: -1, z: 1 })
+    trace.setPointAt(2, { x: 4, y: 5, z: 2 })
+    trace.setPointAt(3, { x: -1, y: 6, z: 3 })
+
+    const extents = trace.geometricExtents
+    expect(extents.min).toMatchObject({ x: -2, y: -1, z: 0 })
+    expect(extents.max).toMatchObject({ x: 4, y: 6, z: 3 })
+
+    const grips = trace.subGetGripPoints()
+    expect(grips).toHaveLength(4)
+    expect(grips[0]).toBe(trace.getPointAt(0))
+
+    const endpointSnaps: AcGePoint3d[] = []
+    trace.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endpointSnaps
+    )
+    expect(endpointSnaps).toHaveLength(4)
+
+    const otherSnaps: AcGePoint3d[] = []
+    trace.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      otherSnaps
+    )
+    expect(otherSnaps).toHaveLength(0)
+  })
+
+  it('transforms itself and draws as filled area', () => {
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, { x: 0, y: 0, z: 1 })
+    trace.setPointAt(1, { x: 2, y: 0, z: 1 })
+    trace.setPointAt(2, { x: 2, y: 1, z: 1 })
+    trace.setPointAt(3, { x: 0, y: 1, z: 1 })
+
+    expect(
+      trace.transformBy(new AcGeMatrix3d().makeTranslation(5, -2, 3))
+    ).toBe(trace)
+    expect(trace.getPointAt(0)).toMatchObject({ x: 5, y: -2, z: 4 })
+    expect(trace.elevation).toBe(4)
+
+    const traits = { fillType: undefined as unknown }
+    const rendered = { id: 'trace-area' }
+    const renderer = {
+      subEntityTraits: traits,
+      area: jest.fn(() => rendered)
+    }
+
+    expect(trace.subWorldDraw(renderer as never)).toBe(rendered)
+    expect(renderer.area).toHaveBeenCalledTimes(1)
+    expect(traits.fillType).toMatchObject({ solidFill: true, patternAngle: 0 })
+  })
+
+  it('writes DXF fields for trace geometry and returns self', () => {
+    const db = createDb()
+    const trace = new AcDbTrace()
+    trace.elevation = 8
+    trace.thickness = 0.75
+    trace.setPointAt(0, { x: 1, y: 2, z: 3 })
+    trace.setPointAt(1, { x: 4, y: 5, z: 6 })
+    trace.setPointAt(2, { x: 7, y: 8, z: 9 })
+    trace.setPointAt(3, { x: 10, y: 11, z: 12 })
+    db.tables.blockTable.modelSpace.appendEntity(trace)
+
+    const filer = new AcDbDxfFiler()
+    expect(trace.dxfOutFields(filer)).toBe(trace)
+
+    const out = filer.toString()
+    expect(out).toContain('100\nAcDbTrace\n')
+    expect(out).toContain('38\n8\n')
+    expect(out).toContain('39\n0.75\n')
+    expect(out).toContain('10\n1\n20\n2\n30\n3\n')
+    expect(out).toContain('11\n4\n21\n5\n31\n6\n')
+    expect(out).toContain('12\n7\n22\n8\n32\n9\n')
+    expect(out).toContain('13\n10\n23\n11\n33\n12\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbTransaction.spec.ts
+++ b/packages/data-model/__tests__/AcDbTransaction.spec.ts
@@ -1,0 +1,59 @@
+import { AcDbObject, AcDbOpenMode } from '../src/base'
+import { AcDbTransaction } from '../src/database/transaction/AcDbTransaction'
+
+class TestTransaction extends AcDbTransaction {
+  private readonly store = new Map<string, AcDbObject>()
+
+  register(obj: AcDbObject) {
+    this.store.set(obj.objectId, obj)
+    return obj
+  }
+
+  protected override lookupObject<T extends AcDbObject>(objectId: string): T {
+    const obj = this.store.get(objectId)
+    if (!obj) {
+      throw new Error(`missing ${objectId}`)
+    }
+    return obj as T
+  }
+}
+
+describe('AcDbTransaction', () => {
+  it('tracks opened object and write rollback', () => {
+    const tr = new TestTransaction()
+    const obj = tr.register(new AcDbObject())
+
+    const opened = tr.getObject<AcDbObject>(
+      obj.objectId,
+      AcDbOpenMode.kForWrite
+    )
+    expect(opened).toBe(obj)
+
+    opened!.ownerId = 'changed-owner'
+    expect(() => tr.abort()).not.toThrow()
+  })
+
+  it('returns undefined when opening the same object twice and clears on commit', () => {
+    const tr = new TestTransaction()
+    const obj = tr.register(new AcDbObject())
+
+    expect(tr.getObject<AcDbObject>(obj.objectId, AcDbOpenMode.kForRead)).toBe(
+      obj
+    )
+    expect(
+      tr.getObject<AcDbObject>(obj.objectId, AcDbOpenMode.kForRead)
+    ).toBeUndefined()
+
+    tr.commit()
+    expect(tr.getObject<AcDbObject>(obj.objectId, AcDbOpenMode.kForRead)).toBe(
+      obj
+    )
+  })
+
+  it('throws when lookup is not implemented/found', () => {
+    const tr = new TestTransaction()
+    expect(() =>
+      tr.getObject<AcDbObject>('missing', AcDbOpenMode.kForRead)
+    ).toThrow('missing missing')
+  })
+})

--- a/packages/data-model/__tests__/AcDbTransactionManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbTransactionManager.spec.ts
@@ -1,0 +1,31 @@
+import { AcDbTransactionManager } from '../src/database/transaction/AcDbTransactionManager'
+
+describe('AcDbTransactionManager', () => {
+  it('starts and tracks current transaction', () => {
+    const manager = new AcDbTransactionManager()
+    expect(manager.hasTransaction()).toBe(false)
+
+    const tr = manager.startTransaction()
+    expect(manager.hasTransaction()).toBe(true)
+    expect(manager.currentTransaction()).toBe(tr)
+  })
+
+  it('commits and aborts with error paths', () => {
+    const manager = new AcDbTransactionManager()
+
+    expect(() => manager.commitTransaction()).toThrow(
+      'No active transaction to commit.'
+    )
+    expect(() => manager.abortTransaction()).toThrow(
+      'No active transaction to abort.'
+    )
+
+    manager.startTransaction()
+    manager.commitTransaction()
+    expect(manager.hasTransaction()).toBe(false)
+
+    manager.startTransaction()
+    manager.abortTransaction()
+    expect(manager.hasTransaction()).toBe(false)
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewTable.spec.ts
@@ -1,0 +1,22 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbViewTable } from '../src/database/AcDbViewTable'
+import { AcDbViewTableRecord } from '../src/database/AcDbViewTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbViewTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbViewTable(new AcDbDatabase()))
+  })
+
+  it('supports inherited symbol table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.viewTable
+    const record = new AcDbViewTableRecord()
+    record.name = 'Front'
+    table.add(record)
+
+    expect(table.getAt('Front')).toBe(record)
+    expect(table.removeId(record.objectId)).toBe(true)
+    expect(table.getAt('Front')).toBeUndefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbViewTableRecord } from '../src/database/AcDbViewTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbViewTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbViewTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -1,0 +1,167 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import { AcDbViewport } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbViewport', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbViewport())
+  })
+
+  it('supports default values and all public getters/setters', () => {
+    const viewport = new AcDbViewport()
+
+    expect(AcDbViewport.typeName).toBe('Viewport')
+    expect(viewport.dxfTypeName).toBe('VIEWPORT')
+    expect(viewport.number).toBe(-1)
+    expect(viewport.height).toBe(0)
+    expect(viewport.width).toBe(0)
+    expect(viewport.viewHeight).toBe(0)
+    expect(viewport.centerPoint).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(viewport.viewCenter).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    viewport.number = 2
+    viewport.height = 8
+    viewport.width = 12
+    viewport.viewHeight = 24
+    viewport.centerPoint = new AcGePoint3d(10, 20, 0)
+    viewport.viewCenter = new AcGePoint3d(5, 6, 0)
+
+    expect(viewport.number).toBe(2)
+    expect(viewport.height).toBe(8)
+    expect(viewport.width).toBe(12)
+    expect(viewport.viewHeight).toBe(24)
+    expect(viewport.centerPoint).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(viewport.viewCenter).toMatchObject({ x: 5, y: 6, z: 0 })
+  })
+
+  it('returns geometricExtents and maps itself to AcGiViewport', () => {
+    const db = createDb()
+    const viewport = new AcDbViewport()
+    viewport.number = 3
+    viewport.width = 10
+    viewport.height = 6
+    viewport.viewHeight = 20
+    viewport.centerPoint = new AcGePoint3d(2, 4, 0)
+    viewport.viewCenter = new AcGePoint3d(1, 1, 0)
+    db.tables.blockTable.modelSpace.appendEntity(viewport)
+
+    expect(viewport.geometricExtents).toBeInstanceOf(AcGeBox3d)
+
+    const giViewport = viewport.toGiViewport()
+    expect(giViewport.id).toBe(viewport.objectId)
+    expect(giViewport.groupId).toBe(db.tables.blockTable.modelSpace.objectId)
+    expect(giViewport.number).toBe(3)
+    expect(giViewport.width).toBe(10)
+    expect(giViewport.height).toBe(6)
+    expect(giViewport.viewHeight).toBe(20)
+    expect(giViewport.centerPoint).toMatchObject({ x: 2, y: 4, z: 0 })
+    expect(giViewport.viewCenter).toMatchObject({ x: 1, y: 1, z: 0 })
+  })
+
+  it('transforms center/size/viewHeight and returns self', () => {
+    const viewport = new AcDbViewport()
+    viewport.centerPoint = new AcGePoint3d(1, 2, 0)
+    viewport.width = 2
+    viewport.height = 4
+    viewport.viewHeight = 12
+
+    expect(viewport.transformBy(new AcGeMatrix3d().makeScale(3, 2, 1))).toBe(
+      viewport
+    )
+    expect(viewport.centerPoint).toMatchObject({ x: 3, y: 4, z: 0 })
+    expect(viewport.width).toBeCloseTo(6)
+    expect(viewport.height).toBeCloseTo(8)
+    expect(viewport.viewHeight).toBeCloseTo(24)
+  })
+
+  it('keeps viewHeight unchanged when height is zero during transform', () => {
+    const viewport = new AcDbViewport()
+    viewport.centerPoint = new AcGePoint3d(1, 1, 0)
+    viewport.width = 5
+    viewport.height = 0
+    viewport.viewHeight = 7
+
+    viewport.transformBy(new AcGeMatrix3d().makeScale(2, 9, 1))
+
+    expect(viewport.width).toBeCloseTo(10)
+    expect(viewport.height).toBeCloseTo(0)
+    expect(viewport.viewHeight).toBe(7)
+  })
+
+  it('draws rectangle in paper space for active viewport only', () => {
+    const db = createDb()
+
+    const paperSpace = new AcDbBlockTableRecord()
+    paperSpace.name = '*Paper_Space0'
+    db.tables.blockTable.add(paperSpace)
+
+    const viewport = new AcDbViewport()
+    viewport.number = 2
+    viewport.centerPoint = new AcGePoint3d(10, 20, 0)
+    viewport.width = 8
+    viewport.height = 6
+    paperSpace.appendEntity(viewport)
+
+    const renderer = {
+      lines: jest.fn((points: AcGePoint3d[]) => ({ points })),
+      group: jest.fn((children: unknown[]) => ({ children }))
+    }
+
+    const drawn = viewport.subWorldDraw(renderer as never)
+    expect(renderer.lines).toHaveBeenCalledTimes(4)
+    expect(renderer.group).toHaveBeenCalledTimes(1)
+    expect(drawn).toBeDefined()
+
+    const firstEdge = renderer.lines.mock.calls[0][0] as AcGePoint3d[]
+    expect(firstEdge[0]).toMatchObject({ x: 6, y: 17, z: 0 })
+    expect(firstEdge[1]).toMatchObject({ x: 14, y: 17, z: 0 })
+
+    const inactive = new AcDbViewport()
+    inactive.number = 1
+    paperSpace.appendEntity(inactive)
+    expect(inactive.subWorldDraw(renderer as never)).toBeUndefined()
+
+    const inModelSpace = new AcDbViewport()
+    inModelSpace.number = 2
+    db.tables.blockTable.modelSpace.appendEntity(inModelSpace)
+    expect(inModelSpace.subWorldDraw(renderer as never)).toBeUndefined()
+  })
+
+  it('writes viewport DXF fields and returns self', () => {
+    const db = createDb()
+    const viewport = new AcDbViewport()
+    viewport.number = 4
+    viewport.centerPoint = new AcGePoint3d(1, 2, 3)
+    viewport.width = 11
+    viewport.height = 22
+    viewport.viewCenter = new AcGePoint3d(4, 5, 6)
+    viewport.viewHeight = 33
+    db.tables.blockTable.modelSpace.appendEntity(viewport)
+
+    const filer = new AcDbDxfFiler()
+    expect(viewport.dxfOutFields(filer)).toBe(viewport)
+    const out = filer.toString()
+
+    expect(out).toContain('100\nAcDbViewport\n')
+    expect(out).toContain('10\n1\n20\n2\n30\n3\n')
+    expect(out).toContain('40\n22\n')
+    expect(out).toContain('41\n11\n')
+    expect(out).toContain('12\n4\n22\n5\n32\n6\n')
+    expect(out).toContain('45\n33\n')
+    expect(out).toContain('69\n4\n')
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewportTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewportTable.spec.ts
@@ -1,0 +1,22 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbViewportTable } from '../src/database/AcDbViewportTable'
+import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbViewportTable', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbViewportTable(new AcDbDatabase()))
+  })
+
+  it('supports inherited symbol table operations', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.viewportTable
+    const record = new AcDbViewportTableRecord()
+    record.name = '*Active'
+    table.add(record)
+
+    expect(table.has('*Active')).toBe(true)
+    expect(table.remove('*Active')).toBe(true)
+    expect(table.getAt('*Active')).toBeUndefined()
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewportTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewportTableRecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbViewportTableRecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbViewportTableRecord())
+  })
+})

--- a/packages/data-model/__tests__/AcDbWipeout.spec.ts
+++ b/packages/data-model/__tests__/AcDbWipeout.spec.ts
@@ -1,0 +1,107 @@
+import { AcGePoint2d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbWipeout } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbWipeout', () => {
+  it('exposes static and DXF type names', () => {
+    const wipeout = new AcDbWipeout()
+
+    expect(AcDbWipeout.typeName).toBe('Wipeout')
+    expect(wipeout.dxfTypeName).toBe('WIPEOUT')
+  })
+
+  it('draws an area from the rectangular boundary path when not clipped', () => {
+    const wipeout = new AcDbWipeout()
+    wipeout.position = new AcGePoint3d(10, 20, 3)
+    wipeout.width = 4
+    wipeout.height = 3
+
+    const rendered = { id: 'wipeout-rendered' }
+    const renderer = {
+      area: jest.fn(() => rendered)
+    }
+
+    const result = wipeout.subWorldDraw(renderer as never)
+    const areaArg = (renderer.area as jest.Mock).mock.calls[0][0] as {
+      loops: Array<{
+        getPoints: (numPoints: number) => Array<{ x: number; y: number }>
+      }>
+    }
+    const boundary = areaArg.loops[0].getPoints(4)
+
+    expect(result).toBe(rendered)
+    expect(renderer.area).toHaveBeenCalledTimes(1)
+    expect(boundary).toHaveLength(5)
+    expect(boundary[0]).toMatchObject({ x: 10, y: 20 })
+    expect(boundary[1]).toMatchObject({ x: 14, y: 20 })
+    expect(boundary[2]).toMatchObject({ x: 14, y: 23 })
+    expect(boundary[3]).toMatchObject({ x: 10, y: 23 })
+    expect(boundary[4]).toMatchObject({ x: 10, y: 20 })
+  })
+
+  it('draws an area from clip boundary vertices when clipped', () => {
+    const wipeout = new AcDbWipeout()
+    wipeout.position = new AcGePoint3d(100, 200, 0)
+    wipeout.width = 10
+    wipeout.height = 20
+    wipeout.isClipped = true
+    wipeout.clipBoundary = [
+      new AcGePoint2d(2, 3),
+      new AcGePoint2d(4, 3),
+      new AcGePoint2d(4, 5),
+      new AcGePoint2d(2, 5)
+    ]
+
+    const renderer = {
+      area: jest.fn(() => 'ok')
+    }
+
+    wipeout.subWorldDraw(renderer as never)
+    const areaArg = (renderer.area as jest.Mock).mock.calls[0][0] as {
+      loops: Array<{
+        getPoints: (numPoints: number) => Array<{ x: number; y: number }>
+      }>
+    }
+    const boundary = areaArg.loops[0].getPoints(4)
+
+    expect(boundary).toHaveLength(4)
+    expect(boundary[0]).toMatchObject({ x: 100, y: 200 })
+    expect(boundary[1]).toMatchObject({ x: 120, y: 200 })
+    expect(boundary[2]).toMatchObject({ x: 120, y: 240 })
+    expect(boundary[3]).toMatchObject({ x: 100, y: 240 })
+  })
+
+  it('writes wipeout DXF fields using raster-image subclass marker', () => {
+    createWorkingDb()
+    const wipeout = new AcDbWipeout()
+    wipeout.ownerId = 'ABC'
+    wipeout.position = new AcGePoint3d(1, 2, 3)
+    wipeout.width = 5
+    wipeout.height = 6
+    wipeout.imageSize = new AcGePoint2d(5, 6)
+
+    const filer = new AcDbDxfFiler()
+    const result = wipeout.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(result).toBe(wipeout)
+    expect(dxf).toContain('100\nAcDbEntity\n')
+    expect(dxf).toContain('100\nAcDbRasterImage\n')
+    expect(dxf).not.toContain('AcDbWipeout')
+    expect(dxf).toContain('10\n1\n20\n2\n30\n3\n')
+    expect(dxf).toContain('13\n5\n23\n6\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbWipeout())
+  })
+})

--- a/packages/data-model/__tests__/AcDbWorkerApi.spec.ts
+++ b/packages/data-model/__tests__/AcDbWorkerApi.spec.ts
@@ -1,0 +1,9 @@
+import { AcDbWorkerApi } from '../src/converter/worker/AcDbWorkerManager'
+
+describe('AcDbWorkerApi', () => {
+  it('can be constructed', () => {
+    const api = new AcDbWorkerApi({ workerUrl: 'mock-worker.js' })
+    expect(api).toBeInstanceOf(AcDbWorkerApi)
+    api.destroy()
+  })
+})

--- a/packages/data-model/__tests__/AcDbWorkerManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbWorkerManager.spec.ts
@@ -1,0 +1,111 @@
+import {
+  AcDbWorkerApi,
+  AcDbWorkerManager,
+  createWorkerApi
+} from '../src/converter/worker/AcDbWorkerManager'
+
+class FakeWorker {
+  static created = 0
+  private readonly listeners: Record<string, Array<(event: any) => void>> = {
+    message: [],
+    error: []
+  }
+
+  constructor(_url: string | URL) {
+    FakeWorker.created += 1
+  }
+
+  addEventListener(type: 'message' | 'error', cb: (event: any) => void) {
+    this.listeners[type].push(cb)
+  }
+
+  postMessage(payload: { id: string; input: unknown }) {
+    if (payload.input === 'trigger-error') {
+      const evt = { message: 'boom' }
+      this.listeners.error.forEach(cb => cb(evt))
+      return
+    }
+    if (payload.input === 'no-response') {
+      return
+    }
+    const evt = {
+      data: {
+        id: payload.id,
+        success: payload.input !== 'fail-result',
+        data: payload.input,
+        error: payload.input === 'fail-result' ? 'failed' : undefined
+      }
+    }
+    this.listeners.message.forEach(cb => cb(evt))
+  }
+
+  terminate() {
+    // no-op
+  }
+}
+
+describe('AcDbWorkerManager / AcDbWorkerApi', () => {
+  const originalWorker = (globalThis as unknown as { Worker?: unknown }).Worker
+
+  beforeEach(() => {
+    ;(globalThis as unknown as { Worker: unknown }).Worker =
+      FakeWorker as unknown
+    FakeWorker.created = 0
+  })
+
+  afterAll(() => {
+    ;(globalThis as unknown as { Worker?: unknown }).Worker = originalWorker
+  })
+
+  it('executes tasks and returns result/error payloads', async () => {
+    const manager = new AcDbWorkerManager({
+      workerUrl: 'mock-worker.js',
+      timeout: 20,
+      maxConcurrentWorkers: 1
+    })
+
+    expect(manager.detectWorkerSupport()).toBe(true)
+
+    const ok = await manager.execute<string, string>('hello')
+    expect(ok.success).toBe(true)
+    expect(ok.data).toBe('hello')
+
+    const failed = await manager.execute<string, string>('fail-result')
+    expect(failed.success).toBe(false)
+    expect(failed.error).toBe('failed')
+
+    const workerError = await manager.execute<string, string>('trigger-error')
+    expect(workerError.success).toBe(false)
+    expect(workerError.error).toContain('Worker error: boom')
+
+    const timeout = await manager.execute<string, string>('no-response')
+    expect(timeout.success).toBe(false)
+    expect(timeout.error).toContain('timed out')
+
+    const stats = manager.getStats()
+    expect(stats.totalWorkers).toBeGreaterThan(0)
+
+    manager.destroy()
+    expect(manager.getStats().totalWorkers).toBe(0)
+  })
+
+  it('reuses wrapper API', async () => {
+    const api = new AcDbWorkerApi({ workerUrl: 'mock-worker.js' })
+    const result = await api.execute<string, string>('wrapped')
+    expect(result.success).toBe(true)
+    expect(result.data).toBe('wrapped')
+
+    const viaFactory = createWorkerApi({ workerUrl: 'mock-worker.js' })
+    expect(viaFactory.getStats().config.workerUrl).toBe('mock-worker.js')
+
+    api.destroy()
+    viaFactory.destroy()
+  })
+
+  it('reports no support when Worker is unavailable', () => {
+    ;(globalThis as unknown as { Worker?: unknown }).Worker = undefined
+    const manager = new AcDbWorkerManager({ workerUrl: 'mock-worker.js' })
+    expect(manager.detectWorkerSupport()).toBe(false)
+    manager.destroy()
+  })
+})

--- a/packages/data-model/__tests__/AcDbXline.spec.ts
+++ b/packages/data-model/__tests__/AcDbXline.spec.ts
@@ -1,0 +1,158 @@
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbXline } from '../src/entity'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbXline', () => {
+  it('exposes expected type names and default state', () => {
+    const xline = new AcDbXline()
+
+    expect(AcDbXline.typeName).toBe('Xline')
+    expect(xline.dxfTypeName).toBe('XLINE')
+    expect(xline.closed).toBe(false)
+    expect(xline.basePoint).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(xline.unitDir).toMatchObject({ x: 0, y: 0, z: 0 })
+  })
+
+  it('supports basePoint/unitDir setters via copy semantics', () => {
+    const xline = new AcDbXline()
+    const base = new AcGePoint3d(2, 3, 4)
+    const dir = new AcGeVector3d(5, -6, 7)
+
+    xline.basePoint = base
+    xline.unitDir = dir
+    base.set(100, 100, 100)
+    dir.set(100, 100, 100)
+
+    expect(xline.basePoint).toMatchObject({ x: 2, y: 3, z: 4 })
+    expect(xline.unitDir).toMatchObject({ x: 5, y: -6, z: 7 })
+  })
+
+  it('returns geometricExtents around +/-10 units from basePoint along unitDir', () => {
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(1, 2, 3)
+    xline.unitDir = new AcGeVector3d(2, -1, 0.5)
+
+    const extents = xline.geometricExtents
+
+    expect(extents.min).toMatchObject({ x: -19, y: -8, z: -2 })
+    expect(extents.max).toMatchObject({ x: 21, y: 12, z: 8 })
+  })
+
+  it('exposes editable geometry properties via runtime accessors', () => {
+    const xline = new AcDbXline()
+    const geometryGroup = xline.properties.groups.find(
+      g => g.groupName === 'geometry'
+    )
+
+    expect(xline.properties.type).toBe('Xline')
+    expect(geometryGroup).toBeDefined()
+    expect(geometryGroup?.properties.map(p => p.name)).toEqual([
+      'basePointX',
+      'basePointY',
+      'basePointZ',
+      'unitDirX',
+      'unitDirY',
+      'unitDirZ'
+    ])
+
+    const basePointX = geometryGroup?.properties.find(
+      p => p.name === 'basePointX'
+    )
+    const basePointY = geometryGroup?.properties.find(
+      p => p.name === 'basePointY'
+    )
+    const basePointZ = geometryGroup?.properties.find(
+      p => p.name === 'basePointZ'
+    )
+    const unitDirX = geometryGroup?.properties.find(p => p.name === 'unitDirX')
+    const unitDirY = geometryGroup?.properties.find(p => p.name === 'unitDirY')
+    const unitDirZ = geometryGroup?.properties.find(p => p.name === 'unitDirZ')
+
+    basePointX?.accessor.set?.(-1.25)
+    basePointY?.accessor.set?.(2.5)
+    basePointZ?.accessor.set?.(3.75)
+    unitDirX?.accessor.set?.(4.25)
+    unitDirY?.accessor.set?.(-5.5)
+    unitDirZ?.accessor.set?.(6.75)
+
+    expect(basePointX?.accessor.get()).toBe(-1.25)
+    expect(basePointY?.accessor.get()).toBe(2.5)
+    expect(basePointZ?.accessor.get()).toBe(3.75)
+    expect(unitDirX?.accessor.get()).toBe(4.25)
+    expect(unitDirY?.accessor.get()).toBe(-5.5)
+    expect(unitDirZ?.accessor.get()).toBe(6.75)
+  })
+
+  it('returns basePoint as the only grip point', () => {
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(7, 8, 9)
+
+    const gripPoints = xline.subGetGripPoints()
+
+    expect(gripPoints).toHaveLength(1)
+    expect(gripPoints[0]).toBe(xline.basePoint)
+    expect(gripPoints[0]).toMatchObject({ x: 7, y: 8, z: 9 })
+  })
+
+  it('transforms itself and draws through renderer.lines', () => {
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(1, 0, 0)
+    xline.unitDir = new AcGeVector3d(1, 0, 0)
+
+    const matrix = new AcGeMatrix3d().makeRotationZ(Math.PI / 2)
+    const drawResult = { id: 'xline-rendered' }
+    const renderer = {
+      lines: jest.fn<unknown, [AcGePoint3d[]]>(() => drawResult)
+    }
+
+    expect(xline.transformBy(matrix)).toBe(xline)
+    expect(xline.basePoint.x).toBeCloseTo(0)
+    expect(xline.basePoint.y).toBeCloseTo(1)
+    expect(xline.unitDir.x).toBeCloseTo(0)
+    expect(xline.unitDir.y).toBeCloseTo(1)
+
+    expect(xline.subWorldDraw(renderer as never)).toBe(drawResult)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+
+    const points = renderer.lines.mock.calls[0]![0]
+    expect(points).toHaveLength(2)
+    expect(points[0].x).toBeCloseTo(0)
+    expect(points[0].y).toBeCloseTo(-999999)
+    expect(points[1].x).toBeCloseTo(0)
+    expect(points[1].y).toBeCloseTo(1000001)
+  })
+
+  it('writes xline-specific DXF fields and returns itself', () => {
+    const db = createWorkingDb()
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(1.25, -2.5, 3.75)
+    xline.unitDir = new AcGeVector3d(0.5, -0.25, 1.5)
+    db.tables.blockTable.modelSpace.appendEntity(xline)
+    const filer = new AcDbDxfFiler()
+
+    expect(xline.dxfOutFields(filer)).toBe(xline)
+
+    const out = filer.toString()
+    expect(out).toContain('100\nAcDbEntity\n')
+    expect(out).toContain('100\nAcDbXline\n')
+    expect(out).toContain('10\n1.25\n20\n-2.5\n30\n3.75\n')
+    expect(out).toContain('11\n0.5\n21\n-0.25\n31\n1.5\n')
+  })
+  it('creates a detached clone with a new objectId', () => {
+    createWorkingDb()
+    expectDetachedClone(() => new AcDbXline())
+  })
+})

--- a/packages/data-model/__tests__/AcDbXrecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbXrecord.spec.ts
@@ -1,0 +1,8 @@
+import { AcDbXrecord } from '../src/object/AcDbXrecord'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+describe('AcDbXrecord', () => {
+  it('creates a detached clone with a new objectId', () => {
+    expectDetachedClone(() => new AcDbXrecord())
+  })
+})

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -474,6 +474,97 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
   close() {}
 
   /**
+   * Creates a deep clone of this object.
+   *
+   * The cloned object is a detached in-memory object:
+   * - It has a new temporary objectId
+   * - It is not attached to any database instance
+   */
+  clone(): this {
+    const cloned = Object.create(Object.getPrototypeOf(this)) as this
+    const source = this as unknown as Record<string, unknown>
+    const target = cloned as unknown as Record<string, unknown>
+
+    for (const key of Object.keys(source)) {
+      if (key === '_database') {
+        continue
+      }
+      target[key] = this.cloneValue(source[key])
+    }
+
+    cloned.objectId = this.generateTemporaryHandle()
+    return cloned
+  }
+
+  /**
+   * Deep clones one internal field value while preserving known class types.
+   */
+  private cloneValue(value: unknown): unknown {
+    if (value == null || typeof value !== 'object') {
+      return value
+    }
+
+    if (value instanceof Date) {
+      return new Date(value.getTime())
+    }
+
+    if (value instanceof RegExp) {
+      return new RegExp(value.source, value.flags)
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => this.cloneValue(item))
+    }
+
+    if (value instanceof Map) {
+      const clonedMap = new Map<unknown, unknown>()
+      for (const [key, item] of value.entries()) {
+        clonedMap.set(this.cloneValue(key), this.cloneValue(item))
+      }
+      return clonedMap
+    }
+
+    if (value instanceof Set) {
+      const clonedSet = new Set<unknown>()
+      for (const item of value.values()) {
+        clonedSet.add(this.cloneValue(item))
+      }
+      return clonedSet
+    }
+
+    if (ArrayBuffer.isView(value)) {
+      if (value instanceof DataView) {
+        return new DataView(value.buffer.slice(0))
+      }
+      const ctor = value.constructor as {
+        new (array: ArrayBufferView): ArrayBufferView
+      }
+      return new ctor(value)
+    }
+
+    if (value instanceof ArrayBuffer) {
+      return value.slice(0)
+    }
+
+    if (
+      'clone' in value &&
+      typeof (value as { clone?: unknown }).clone === 'function'
+    ) {
+      return (value as { clone: () => unknown }).clone()
+    }
+
+    const clonedObj = Object.create(Object.getPrototypeOf(value)) as Record<
+      string,
+      unknown
+    >
+    const objectValue = value as Record<string, unknown>
+    for (const key of Object.keys(objectValue)) {
+      clonedObj[key] = this.cloneValue(objectValue[key])
+    }
+    return clonedObj
+  }
+
+  /**
    * Writes the common DXF wrapper for this object and then delegates the
    * object-specific payload to {@link dxfOutFields}.
    *

--- a/packages/data-model/src/database/AcDbSymbolTable.ts
+++ b/packages/data-model/src/database/AcDbSymbolTable.ts
@@ -100,7 +100,7 @@ export class AcDbSymbolTable<
     const record = this._recordsByName.get(normalizedName)
     if (record) {
       this._recordsById.delete(record.objectId)
-      this._recordsByName.delete(name)
+      this._recordsByName.delete(normalizedName)
       return true
     }
     return false
@@ -123,7 +123,7 @@ export class AcDbSymbolTable<
   removeId(id: AcDbObjectId) {
     const record = this._recordsById.get(id)
     if (record) {
-      this._recordsByName.delete(record.name)
+      this._recordsByName.delete(this.normalizeName(record.name))
       this._recordsById.delete(id)
       return true
     }

--- a/packages/data-model/src/object/AcDbXrecord.ts
+++ b/packages/data-model/src/object/AcDbXrecord.ts
@@ -64,10 +64,8 @@ export class AcDbXrecord extends AcDbObject {
    * @remarks
    * The cloned Xrecord contains a cloned ResultBuffer.
    */
-  clone(): AcDbXrecord {
-    const xrec = new AcDbXrecord()
-    xrec._data = this._data?.clone() ?? null
-    return xrec
+  override clone(): this {
+    return super.clone()
   }
 
   /**

--- a/packages/data-model/test-utils/cloneTestUtils.ts
+++ b/packages/data-model/test-utils/cloneTestUtils.ts
@@ -1,0 +1,15 @@
+import { AcDbObject, TEMP_OBJECT_ID_PREFIX } from '../src/base/AcDbObject'
+
+export function expectDetachedClone<T extends AcDbObject>(factory: () => T) {
+  const source = factory()
+  const sourceId = source.objectId
+
+  const cloned = source.clone() as T
+
+  expect(cloned).not.toBe(source)
+  expect(cloned.objectId).not.toBe(sourceId)
+  expect(cloned.objectId.startsWith(TEMP_OBJECT_ID_PREFIX)).toBe(true)
+  expect((cloned as unknown as { _database?: unknown })._database).toBe(
+    undefined
+  )
+}

--- a/packages/data-model/test-utils/entityTestUtils.ts
+++ b/packages/data-model/test-utils/entityTestUtils.ts
@@ -1,0 +1,35 @@
+import { acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbEntity } from '../src/entity'
+
+export const setupWorkingDatabase = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+export const appendEntityToModelSpace = <T extends AcDbEntity>(
+  db: AcDbDatabase,
+  entity: T
+) => {
+  db.tables.blockTable.modelSpace.appendEntity(entity)
+  return entity
+}
+
+export const attachEntityToNewModelSpace = <T extends AcDbEntity>(
+  entity: T
+) => {
+  const db = setupWorkingDatabase()
+  appendEntityToModelSpace(db, entity)
+  return db
+}
+
+export const getDxfGroupValues = (dxfText: string, code: number) => {
+  const lines = dxfText.trim().split(/\r?\n/)
+  const values: string[] = []
+  for (let i = 0; i < lines.length - 1; i += 2) {
+    if (Number(lines[i]) === code) values.push(lines[i + 1])
+  }
+  return values
+}

--- a/packages/geometry-engine/__tests__/AcGeArea2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeArea2d.spec.ts
@@ -1,4 +1,10 @@
-import { AcGeArea2d, AcGeLine2d, AcGeLoop2d, AcGePolyline2d } from '../src'
+import {
+  AcGeArea2d,
+  AcGeLine2d,
+  AcGeLoop2d,
+  AcGeMatrix2d,
+  AcGePolyline2d
+} from '../src'
 
 describe('AcGeArea2d', () => {
   it('computes polygon area', () => {
@@ -58,5 +64,23 @@ describe('AcGeArea2d', () => {
     )
     area.add(degenerate)
     expect(area.area).toBe(0)
+  })
+
+  it('clones area with independent loops', () => {
+    const sourceLoop = new AcGeLoop2d([
+      new AcGeLine2d({ x: 0, y: 0 }, { x: 1, y: 0 }),
+      new AcGeLine2d({ x: 1, y: 0 }, { x: 1, y: 1 }),
+      new AcGeLine2d({ x: 1, y: 1 }, { x: 0, y: 1 }),
+      new AcGeLine2d({ x: 0, y: 1 }, { x: 0, y: 0 })
+    ])
+    const area = new AcGeArea2d()
+    area.add(sourceLoop)
+
+    const cloned = area.clone()
+    expect(cloned).not.toBe(area)
+    expect(cloned.loops.length).toBe(1)
+
+    cloned.transform(new AcGeMatrix2d().makeTranslation(5, 0))
+    expect((area.loops[0] as AcGeLoop2d).startPoint.x).toBeCloseTo(0, 8)
   })
 })

--- a/packages/geometry-engine/__tests__/AcGeCatmullRomCurve3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeCatmullRomCurve3d.spec.ts
@@ -86,4 +86,26 @@ describe('AcGeCatmullRomCurve3d', () => {
     expect(curve.tension).toBe(0.5)
     expect(curve.length).toBe(0)
   })
+
+  it('clones curve with deep-copied points', () => {
+    const curve = new AcGeCatmullRomCurve3d(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 2, y: 0, z: 0 }
+      ],
+      true,
+      'catmullrom',
+      0.3
+    )
+    const cloned = curve.clone()
+
+    expect(cloned).not.toBe(curve)
+    expect(cloned.closed).toBe(true)
+    expect(cloned.curveType).toBe('catmullrom')
+    expect(cloned.tension).toBeCloseTo(0.3, 8)
+
+    cloned.points[0].x = 99
+    expect(curve.points[0].x).toBe(0)
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeCurve2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeCurve2d.spec.ts
@@ -14,6 +14,10 @@ class TestCurve2d extends AcGeCurve2d {
     return this
   }
 
+  clone(): this {
+    return new TestCurve2d() as this
+  }
+
   protected calculateBoundingBox() {
     return new AcGeBox2d({ x: 0, y: 0 }, { x: 1, y: 0 })
   }

--- a/packages/geometry-engine/__tests__/AcGeCurve3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeCurve3d.spec.ts
@@ -22,6 +22,10 @@ class TestCurve3d extends AcGeCurve3d {
     return this
   }
 
+  clone(): this {
+    return new TestCurve3d() as this
+  }
+
   protected calculateBoundingBox() {
     return new AcGeBox3d({ x: 0, y: 0, z: 0 }, { x: 1, y: 0, z: 0 })
   }

--- a/packages/geometry-engine/__tests__/AcGeLoop2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeLoop2d.spec.ts
@@ -151,4 +151,18 @@ describe('AcGeLoop2d', () => {
     const reversedNoWeights = reverseEdge(splineNoWeights) as AcGeSpline3d
     expect(reversedNoWeights.weights.length).toBeGreaterThan(0)
   })
+
+  it('clones loop with independent edge instances', () => {
+    const loop = new AcGeLoop2d([
+      new AcGeLine2d({ x: 0, y: 0 }, { x: 2, y: 0 }),
+      new AcGeLine2d({ x: 2, y: 0 }, { x: 2, y: 2 })
+    ])
+
+    const cloned = loop.clone()
+    expect(cloned).not.toBe(loop)
+    expect(cloned.curves.length).toBe(loop.curves.length)
+
+    cloned.transform(new AcGeMatrix2d().makeTranslation(3, 0))
+    expect(loop.startPoint.x).toBeCloseTo(0, 8)
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeNurbsCurve.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeNurbsCurve.spec.ts
@@ -16,4 +16,23 @@ describe('AcGeNurbsCurve', () => {
     expect(nurbs.degree()).toBe(3)
     expect(nurbs.getPoints(10)).toHaveLength(11)
   })
+
+  it('clones curve with independent internal arrays', () => {
+    const nurbs = AcGeNurbsCurve.byKnotsControlPointsWeights(
+      2,
+      [0, 0, 0, 1, 1, 1],
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 2, y: 0, z: 0 }
+      ],
+      [1, 2, 3]
+    )
+
+    const cloned = nurbs.clone()
+    expect(cloned).not.toBe(nurbs)
+    expect(cloned.degree()).toBe(2)
+    expect(cloned.knots()).toEqual([0, 0, 0, 1, 1, 1])
+    expect(cloned.weights()).toEqual([1, 2, 3])
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
@@ -68,4 +68,21 @@ describe('Test AcGePolyline2d', () => {
     )
     expect(open.endPoint.toArray()).toEqual([2, 3])
   })
+
+  it('clones polyline vertices deeply', () => {
+    const polyline = new AcGePolyline2d(
+      [
+        { x: 0, y: 0, bulge: 1 },
+        { x: 1, y: 0, bulge: 0.5 }
+      ],
+      false
+    )
+    const cloned = polyline.clone()
+
+    expect(cloned).not.toBe(polyline)
+    expect(cloned.vertices).toEqual(polyline.vertices)
+
+    cloned.vertices[0].x = 9
+    expect(polyline.vertices[0].x).toBe(0)
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeShape3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeShape3d.spec.ts
@@ -2,6 +2,10 @@ import { AcGeBox3d, AcGeMatrix3d } from '../src'
 import { AcGeShape3d } from '../src/geometry/AcGeShape3d'
 
 class TestShape3d extends AcGeShape3d {
+  clone(): this {
+    return new TestShape3d() as this
+  }
+
   transform(_matrix: AcGeMatrix3d) {
     return this
   }

--- a/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
@@ -745,4 +745,46 @@ describe('AcGeSpline3d', () => {
       }).toThrow('At least 4 points are required for a degree 3 closed spline')
     })
   })
+
+  describe('Clone', () => {
+    it('clones control-point spline deeply', () => {
+      const spline = new AcGeSpline3d(
+        [
+          { x: 0, y: 0, z: 0 },
+          { x: 1, y: 1, z: 0 },
+          { x: 2, y: 0, z: 0 },
+          { x: 3, y: 1, z: 0 }
+        ],
+        [0, 0, 0, 0, 1, 1, 1, 1]
+      )
+
+      const cloned = spline.clone()
+      expect(cloned).not.toBe(spline)
+      expect(cloned.controlPoints).toEqual(spline.controlPoints)
+
+      const changed = cloned.getControlPointAt(0)
+      changed.x = 99
+      expect(spline.getControlPointAt(0).x).toBe(0)
+    })
+
+    it('clones fit-point spline and keeps constructor mode', () => {
+      const spline = new AcGeSpline3d(
+        [
+          { x: 0, y: 0, z: 0 },
+          { x: 1, y: 1, z: 0 },
+          { x: 2, y: 0, z: 0 },
+          { x: 3, y: 1, z: 0 }
+        ],
+        'Uniform',
+        3,
+        false,
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 }
+      )
+
+      const cloned = spline.clone()
+      expect(cloned.fitPoints).toEqual(spline.fitPoints)
+      expect(cloned.knotParameterization).toBe('Uniform')
+    })
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeTol.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeTol.spec.ts
@@ -11,4 +11,17 @@ describe('AcGeTol', () => {
     expect(AcGeTol.less(1, 2)).toBe(true)
     expect(AcGeTol.less(2, 1)).toBe(false)
   })
+
+  it('clones tolerance values', () => {
+    const tol = new AcGeTol()
+    tol.equalPointTol = 1e-3
+    tol.equalVectorTol = 1e-4
+
+    const cloned = tol.clone()
+    cloned.equalPointTol = 2e-3
+
+    expect(cloned).not.toBe(tol)
+    expect(cloned.equalVectorTol).toBe(1e-4)
+    expect(tol.equalPointTol).toBe(1e-3)
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeVector2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeVector2d.spec.ts
@@ -29,4 +29,13 @@ describe('AcGeVector2d', () => {
     ])
     expect(points).toEqual([1, 2, 3, 4])
   })
+
+  it('AcGePoint2d clone keeps point type and value', () => {
+    const point = new AcGePoint2d(3, 5)
+    const cloned = point.clone()
+
+    expect(cloned).toBeInstanceOf(AcGePoint2d)
+    expect(cloned).not.toBe(point)
+    expect(cloned.toArray()).toEqual([3, 5])
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeVector3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeVector3d.spec.ts
@@ -42,4 +42,13 @@ describe('AcGeVector3d', () => {
 
     expect([...new AcGeVector3d(4, 5, 6)]).toEqual([4, 5, 6])
   })
+
+  it('AcGePoint3d clone keeps point type and value', () => {
+    const point = new AcGePoint3d(7, 8, 9)
+    const cloned = point.clone()
+
+    expect(cloned).toBeInstanceOf(AcGePoint3d)
+    expect(cloned).not.toBe(point)
+    expect(cloned.toArray()).toEqual([7, 8, 9])
+  })
 })

--- a/packages/geometry-engine/src/geometry/AcGeArea2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeArea2d.ts
@@ -76,6 +76,17 @@ export class AcGeArea2d extends AcGeShape2d {
   }
 
   /**
+   * Return a deep-cloned copy of this area.
+   */
+  clone() {
+    const area = new AcGeArea2d()
+    this._loops.forEach(loop => {
+      area.add(loop.clone())
+    })
+    return area
+  }
+
+  /**
    * Return boundary points of this area
    * @param numPoints Input the nubmer of points returned for arc segmentation
    * @returns Return points

--- a/packages/geometry-engine/src/geometry/AcGeCatmullRomCurve3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCatmullRomCurve3d.ts
@@ -373,6 +373,18 @@ export class AcGeCatmullRomCurve3d extends AcGeCurve3d {
   }
 
   /**
+   * Return a deep-cloned copy of this curve.
+   */
+  clone() {
+    return new AcGeCatmullRomCurve3d(
+      this._points.map(point => point.clone()),
+      this._closed,
+      this._curveType,
+      this._tension
+    )
+  }
+
+  /**
    * Transforms the curve by applying the input matrix.
    * @param matrix Input transformation matrix
    * @return Return this curve

--- a/packages/geometry-engine/src/geometry/AcGeCurve2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCurve2d.ts
@@ -221,4 +221,9 @@ export abstract class AcGeCurve2d extends AcGeShape2d {
     const t = this.getUtoTmapping(u)
     return this.getTangent(t)
   }
+
+  /**
+   * Return a deep-cloned copy of this curve.
+   */
+  abstract clone(): AcGeCurve2d
 }

--- a/packages/geometry-engine/src/geometry/AcGeCurve3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCurve3d.ts
@@ -27,4 +27,9 @@ export abstract class AcGeCurve3d extends AcGeShape3d {
    * Length of this curve.
    */
   abstract get length(): number
+
+  /**
+   * Return a deep-cloned copy of this curve.
+   */
+  abstract clone(): AcGeCurve3d
 }

--- a/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
@@ -194,6 +194,13 @@ export class AcGeLoop2d extends AcGeCurve2d {
   }
 
   /**
+   * Return a deep-cloned copy of this loop.
+   */
+  clone() {
+    return new AcGeLoop2d(this._curves.map(curve => curve.clone()))
+  }
+
+  /**
    * @inheritdoc
    */
   get closed(): boolean {

--- a/packages/geometry-engine/src/geometry/AcGeNurbsCurve.ts
+++ b/packages/geometry-engine/src/geometry/AcGeNurbsCurve.ts
@@ -63,6 +63,18 @@ export class AcGeNurbsCurve {
   }
 
   /**
+   * Return a deep-cloned copy of this NURBS curve.
+   */
+  clone() {
+    return new AcGeNurbsCurve(
+      this._degree,
+      this._knots,
+      this._controlPoints,
+      this._weights
+    )
+  }
+
+  /**
    * Calculate a point on the curve at parameter u
    */
   point(u: number): number[] {

--- a/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
@@ -222,6 +222,16 @@ export class AcGePolyline2d<
   }
 
   /**
+   * Return a deep-cloned copy of this polyline.
+   */
+  clone() {
+    return new AcGePolyline2d<T>(
+      this._vertices.map(vertex => ({ ...vertex })),
+      this._closed
+    )
+  }
+
+  /**
    * Return an array of points to draw this polyline.
    * @param numPoints Input the nubmer of points returned for arc segmentation
    * @param elevation Input z value of points returned

--- a/packages/geometry-engine/src/geometry/AcGeShape.ts
+++ b/packages/geometry-engine/src/geometry/AcGeShape.ts
@@ -11,4 +11,9 @@ export abstract class AcGeShape {
   get boundingBoxNeedUpdate() {
     return this._boundingBoxNeedsUpdate
   }
+
+  /**
+   * Return a deep-cloned copy of this shape.
+   */
+  abstract clone(): AcGeShape
 }

--- a/packages/geometry-engine/src/geometry/AcGeShape2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeShape2d.ts
@@ -24,6 +24,11 @@ export abstract class AcGeShape2d extends AcGeShape {
   abstract transform(matrix: AcGeMatrix2d): this
 
   /**
+   * Return a deep-cloned copy of this 2d shape.
+   */
+  abstract clone(): AcGeShape2d
+
+  /**
    * The bounding box of this shape. Because it is a time-consuming operation to calculate the bounding
    * box of one shape, the bounding box value is cached. It will be calculated again lazily once there
    * are any changes to properties of this shape.

--- a/packages/geometry-engine/src/geometry/AcGeShape3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeShape3d.ts
@@ -25,6 +25,11 @@ export abstract class AcGeShape3d extends AcGeShape {
   abstract transform(matrix: AcGeMatrix3d): this
 
   /**
+   * Return a deep-cloned copy of this 3d shape.
+   */
+  abstract clone(): AcGeShape3d
+
+  /**
    * The bounding box of this shape. Because it is a time-consuming operation to calculate the bounding
    * box of one shape, the bounding box value is cached. It will be calculated again lazily once there
    * are any changes to properties of this shape.

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -453,6 +453,50 @@ export class AcGeSpline3d extends AcGeCurve3d {
   }
 
   /**
+   * Return a deep-cloned copy of this spline.
+   */
+  clone() {
+    if (this._fitPoints && this._knotParameterization) {
+      return new AcGeSpline3d(
+        this._fitPoints.map(point => ({
+          x: point.x,
+          y: point.y,
+          z: point.z || 0
+        })),
+        this._knotParameterization,
+        this._degree,
+        this._closed,
+        this._startTangent
+          ? {
+              x: this._startTangent.x,
+              y: this._startTangent.y,
+              z: this._startTangent.z || 0
+            }
+          : undefined,
+        this._endTangent
+          ? {
+              x: this._endTangent.x,
+              y: this._endTangent.y,
+              z: this._endTangent.z || 0
+            }
+          : undefined
+      )
+    }
+
+    return new AcGeSpline3d(
+      this._controlPoints.map(point => ({
+        x: point.x,
+        y: point.y,
+        z: point.z || 0
+      })),
+      this._nurbsCurve.knots(),
+      this._nurbsCurve.weights(),
+      this._degree,
+      this._closed
+    )
+  }
+
+  /**
    * Convert input points to points in NURBS format
    * @param points Input points to convert
    * @returns Return converted points

--- a/packages/geometry-engine/src/math/AcGePoint2d.ts
+++ b/packages/geometry-engine/src/math/AcGePoint2d.ts
@@ -10,6 +10,13 @@ export type AcGePoint2dLike = AcGeVector2dLike
  */
 export class AcGePoint2d extends AcGeVector2d {
   /**
+   * Return a new 2d point with the same x and y values as this one.
+   */
+  clone() {
+    return new AcGePoint2d(this.x, this.y)
+  }
+
+  /**
    * Convert one point array to one number array
    * @param array Input one point array
    * @returns Return converted number array

--- a/packages/geometry-engine/src/math/AcGePoint3d.ts
+++ b/packages/geometry-engine/src/math/AcGePoint3d.ts
@@ -10,6 +10,13 @@ export type AcGePoint3dLike = AcGeVector3dLike
  */
 export class AcGePoint3d extends AcGeVector3d {
   /**
+   * Return a new 3d point with the same x, y and z values as this one.
+   */
+  clone() {
+    return new AcGePoint3d(this.x, this.y, this.z)
+  }
+
+  /**
    * Convert one point array to one number array
    * @param array Input one point array
    * @param includeZ Include z cooridinate in returned number array if it is true.

--- a/packages/geometry-engine/src/util/AcGeTol.ts
+++ b/packages/geometry-engine/src/util/AcGeTol.ts
@@ -50,6 +50,16 @@ export class AcGeTol {
   }
 
   /**
+   * Return a cloned tolerance object.
+   */
+  clone() {
+    const cloned = new AcGeTol()
+    cloned.equalPointTol = this.equalPointTol
+    cloned.equalVectorTol = this.equalVectorTol
+    return cloned
+  }
+
+  /**
    * Return true if two points are equal with the specified tolerance.
    * @param p1 Input the first 2d point
    * @param p2 Input the second 2d point


### PR DESCRIPTION
## Summary
- Introduce deep-clone support across geometry primitives and abstract shape/curve base classes.
- Add extensive unit tests for `data-model` entities and `geometry-engine` cloning/behavior paths.
- Improve test utilities to support broader entity validation and DXF output checks.

## Why
- The codebase lacked consistent clone contracts for geometry abstractions, making copy semantics unclear.
- Many entity modules had limited regression coverage, especially around DXF serialization, transforms, and property accessors.
- This change reduces risk of mutation side effects and improves confidence in core modeling behavior.

## What Changed
- Added/standardized `clone()` APIs in geometry core types, including:
  - `AcGeShape`, `AcGeShape2d`, `AcGeShape3d`, `AcGeCurve2d`, `AcGeCurve3d`
  - Concrete implementations such as `AcGeArea2d`, `AcGeLoop2d`, `AcGePolyline2d`, `AcGeCatmullRomCurve3d`, `AcGeSpline3d`, `AcGeNurbsCurve`, `AcGePoint2d`, `AcGePoint3d`, `AcGeTol`
- Added large-scale `data-model` tests for entities/tables/records, including constructor behavior, getters/setters, transforms, snapping/grips, runtime properties, and DXF output.
- Expanded `geometry-engine` tests to validate clone behavior and independence of cloned instances.
- Updated shared test helpers (e.g., cloning/entity utilities) to support the expanded test scenarios.

## Risks / Notes
- Abstract `clone()` requirements added to base classes may require downstream/custom subclasses to implement clone methods.
- This is a wide-scope change set (100+ files), so reviewers may prefer focusing first on base API changes and then test additions.
