### PR TITLE
feat: add CELTYPE support across database and DXF/DWG converters

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfOut.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfOut.spec.ts
@@ -101,6 +101,7 @@ describe('AcDbDatabase.dxfOut', () => {
 
     expect(dxf).toContain('9\n$ACADVER\n1\nAC1014\n')
     expect(dxf).toContain('9\n$CLAYER\n8\n0\n')
+    expect(dxf).toContain('9\n$CELTYPE\n6\nByLayer\n')
     expect(dxf).toContain('0\nTABLE\n2\nLAYER\n')
     expect(dxf).toContain('0\nLAYER\n')
     expect(dxf).toContain('2\n0\n')
@@ -230,6 +231,17 @@ describe('AcDbDatabase.dxfOut', () => {
 
     const seqendRecord = findRecord(entityRecords, 'SEQEND')
     expect(seqendRecord).toBeDefined()
+  })
+
+  it('uses the database CELTYPE for new entities without an explicit linetype', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    db.celtype = 'Continuous'
+
+    const line = new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 10, y: 5, z: 0 })
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    expect(line.lineType).toBe('Continuous')
   })
 
   it('writes additional paper space layouts as BLOCK_RECORD, BLOCK, and LAYOUT objects', () => {

--- a/packages/data-model/__tests__/AcDbDxfRead.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfRead.spec.ts
@@ -244,18 +244,20 @@ describe('DXF read and parse regressions', () => {
     expect(modelLine).toBeUndefined()
   })
 
-  it('reads header values such as LTSCALE and CELTSCALE from DXF', async () => {
+  it('reads header values such as LTSCALE, CELTSCALE, and CELTYPE from DXF', async () => {
     const sourceDb = setWorkingDatabase(new AcDbDatabase())
     sourceDb.createDefaultData()
 
     let dxf = sourceDb.dxfOut(undefined, 6)
     dxf = replaceHeaderDouble(dxf, '$LTSCALE', 2.5)
+    dxf = addHeaderVariable(dxf, '$CLAYER', '$CELTYPE', '6', 'BYLAYER')
     dxf = addHeaderVariable(dxf, '$LTSCALE', '$CELTSCALE', '40', '0.25')
 
     const targetDb = await readDxf(dxf)
 
     expect(targetDb.ltscale).toBe(2.5)
     expect(targetDb.celtscale).toBe(0.25)
+    expect(targetDb.celtype).toBe('ByLayer')
     expect(targetDb.textstyle).toBe('Standard')
   })
 })

--- a/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
@@ -34,6 +34,9 @@ describe('AcDbSysVarManager', () => {
     manager.setVar(AcDbSystemVariables.CLAYER, '0', db)
     expect(manager.getVar(AcDbSystemVariables.CLAYER, db)).toBe('0')
 
+    manager.setVar(AcDbSystemVariables.CELTYPE, 'BYLAYER', db)
+    expect(manager.getVar(AcDbSystemVariables.CELTYPE, db)).toBe('ByLayer')
+
     expect(() =>
       manager.setVar(AcDbSystemVariables.PICKBOX, 'NaN-input', db)
     ).toThrow('Invalid number input!')
@@ -67,6 +70,7 @@ describe('AcDbSysVarManager', () => {
     expect(manager.getDescriptor('__UNIT_BOOL__')?.name).toBe('__unit_bool__')
     expect(manager.getDefaultValue('__UNIT_BOOL__')).toBe(true)
     expect(manager.getVar('__UNIT_BOOL__', db)).toBe(true)
+    expect(manager.getDefaultValue(AcDbSystemVariables.CELTYPE)).toBe('ByLayer')
     expect(manager.getAllDescriptors().length).toBeGreaterThan(0)
     expect(() => manager.getDefaultValue('__NOT_FOUND__')).toThrow(
       'System variable __not_found__ not found!'

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -48,7 +48,7 @@ import {
   AcDbDatabaseConverter
 } from '../database/AcDbDatabaseConverter'
 import { AcDbAttribute, AcDbBlockReference, AcDbEntity } from '../entity'
-import { DEFAULT_TEXT_STYLE } from '../misc'
+import { ByLayer, DEFAULT_TEXT_STYLE } from '../misc'
 import { AcDbBatchProcessing } from './AcDbBatchProcessing'
 import { AcDbDxfParser } from './AcDbDxfParser'
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
@@ -447,6 +447,7 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
     db.angBase = header['$ANGBASE'] || 0
     db.angDir = header['$ANGDIR'] || 0
     if (header['$AUNITS'] != null) db.aunits = header['$AUNITS']
+    db.celtype = header['$CELTYPE'] || ByLayer
     db.celtscale = header['$CELTSCALE'] || 1
     db.ltscale = header['$LTSCALE'] || 1
     if (header['$EXTMAX']) db.extmax = header['$EXTMAX']

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -534,7 +534,8 @@ export class AcDbEntityConverter {
     dbEntity.hatchStyle = hatch.hatchStyle as unknown as AcDbHatchStyle
     dbEntity.patternName = hatch.patternName
     dbEntity.patternType = hatch.patternType as unknown as AcDbHatchPatternType
-    dbEntity.patternAngle = hatch.patternAngle == null ? 0 : AcGeMathUtil.degToRad(hatch.patternAngle)
+    dbEntity.patternAngle =
+      hatch.patternAngle == null ? 0 : AcGeMathUtil.degToRad(hatch.patternAngle)
     dbEntity.patternScale = hatch.patternScale == null ? 0 : hatch.patternScale
 
     const paths = hatch.boundaryPaths

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -302,6 +302,8 @@ export class AcDbDatabase extends AcDbObject {
   private _cecolor: AcCmColor
   /** Current entity linetype scale */
   private _celtscale: number
+  /** Current entity linetype name */
+  private _celtype: string
   /** Current entity line weight value */
   private _celweight: AcGiLineWeight
   /** Current layer for the database */
@@ -374,6 +376,7 @@ export class AcDbDatabase extends AcDbObject {
     this._aunits = AcDbAngleUnits.DecimalDegrees
     this._celtscale = 1
     this._cecolor = new AcCmColor()
+    this._celtype = ByLayer
     this._celweight = AcGiLineWeight.ByLayer
     this._clayer = '0'
     this._textstyle = DEFAULT_TEXT_STYLE
@@ -752,6 +755,24 @@ export class AcDbDatabase extends AcDbObject {
       value ?? 1,
       nextValue => {
         this._celtscale = nextValue
+      }
+    )
+  }
+
+  /**
+   * The linetype of new objects as they are created.
+   */
+  get celtype(): string {
+    return this._celtype
+  }
+  set celtype(value: string) {
+    const nextValue = this.normalizeLinetypeName(value ?? ByLayer)
+    this.updateSysVar(
+      AcDbSystemVariables.CELTYPE,
+      this._celtype,
+      nextValue,
+      normalizedValue => {
+        this._celtype = normalizedValue
       }
     )
   }
@@ -1349,6 +1370,8 @@ export class AcDbDatabase extends AcDbObject {
     filer.writeInt16(70, this.lwdisplay ? 1 : 0)
     filer.writeString(9, '$CLAYER')
     filer.writeString(8, this.clayer)
+    filer.writeString(9, '$CELTYPE')
+    filer.writeString(6, this.celtype)
     filer.writeString(9, '$TEXTSTYLE')
     filer.writeString(7, this.textstyle)
     filer.writeString(9, '$ANGBASE')
@@ -1652,6 +1675,20 @@ export class AcDbDatabase extends AcDbObject {
     }
 
     return !Object.is(currentValue, nextValue)
+  }
+
+  /**
+   * Normalizes special linetype aliases to the internal canonical names.
+   */
+  private normalizeLinetypeName(value: string) {
+    const normalizedValue = value.trim()
+    if (normalizedValue.toUpperCase() === 'BYLAYER') {
+      return ByLayer
+    }
+    if (normalizedValue.toUpperCase() === 'BYBLOCK') {
+      return ByBlock
+    }
+    return normalizedValue
   }
 
   /**

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -2,7 +2,7 @@ import { AcCmColor, AcCmColorMethod, AcCmEventManager } from '@mlightcad/common'
 import { AcGePointLike } from '@mlightcad/geometry-engine'
 import { AcGiLineWeight } from '@mlightcad/graphic-interface'
 
-import { DEFAULT_TEXT_STYLE } from '../misc'
+import { ByLayer, DEFAULT_TEXT_STYLE } from '../misc'
 import type { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSystemVariables } from './AcDbSystemVariables'
 
@@ -104,6 +104,12 @@ export class AcDbSysVarManager {
       type: 'number',
       isDbVar: true,
       defaultValue: -1
+    })
+    this.registerVar({
+      name: AcDbSystemVariables.CELTYPE,
+      type: 'string',
+      isDbVar: true,
+      defaultValue: ByLayer
     })
     this.registerVar({
       name: AcDbSystemVariables.CELWEIGHT,

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -25,6 +25,8 @@ export const AcDbSystemVariables = {
   AUNITS: 'AUNITS',
   /** Current color applied to newly created entities. */
   CECOLOR: 'CECOLOR',
+  /** Current linetype name used when creating new entities. */
+  CELTYPE: 'CELTYPE',
   /** Current entity linetype scale multiplier for newly created entities. */
   CELTSCALE: 'CELTSCALE',
   /** Current lineweight applied to newly created entities. */

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -49,7 +49,7 @@ export abstract class AcDbEntity extends AcDbObject {
   /** The color of this entity */
   private _color?: AcCmColor
   /** The linetype name for this entity */
-  private _lineType: string = ByLayer
+  private _lineType?: string
   /** The line weight for this entity */
   private _lineWeight?: AcGiLineWeight
   /** The linetype scale factor for this entity */
@@ -205,6 +205,9 @@ export abstract class AcDbEntity extends AcDbObject {
    * ```
    */
   get lineType() {
+    if (this._lineType == null) {
+      this._lineType = this.database?.celtype ?? ByLayer
+    }
     return this._lineType
   }
 
@@ -219,7 +222,15 @@ export abstract class AcDbEntity extends AcDbObject {
    * ```
    */
   set lineType(value: string) {
-    this._lineType = value || ByLayer
+    if (!value) {
+      this._lineType = ByLayer
+    } else if (value.toUpperCase() === 'BYLAYER') {
+      this._lineType = ByLayer
+    } else if (value.toUpperCase() === 'BYBLOCK') {
+      this._lineType = ByBlock
+    } else {
+      this._lineType = value
+    }
   }
 
   /**
@@ -404,6 +415,10 @@ export abstract class AcDbEntity extends AcDbObject {
       if (this.database.cecolor) {
         this._color.copy(this.database.cecolor)
       }
+    }
+
+    if (this._lineType == null) {
+      this._lineType = this.database.celtype ?? ByLayer
     }
 
     if (this._linetypeScale == null) {

--- a/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
+++ b/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
@@ -21,6 +21,7 @@ import {
   AcGiBaseLineStyle,
   AcGiLineTypePatternElement,
   AcGiTextStyle,
+  ByLayer,
   DEFAULT_TEXT_STYLE
 } from '@mlightcad/data-model'
 import {
@@ -347,6 +348,10 @@ export class AcDbLibdxfrwConverter extends AcDbDatabaseConverter<DRW_Database> {
     variant = header.getVar('$AUNITS')
     // Initial value:	0
     db.aunits = variant ? variant.getInt() : 0
+
+    variant = header.getVar('$CELTYPE')
+    // Initial value: BYLAYER
+    db.celtype = variant ? variant.getString() : ByLayer
 
     variant = header.getVar('$INSUNITS')
     // Initial value:	1 (imperial) or 4 (metric)

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -28,6 +28,7 @@ import {
   AcGiDefaultLightingType,
   AcGiOrthographicType,
   AcGiRenderMode,
+  ByLayer,
   createWorkerApi,
   DEFAULT_TEXT_STYLE
 } from '@mlightcad/data-model'
@@ -506,6 +507,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     db.angBase = header.ANGBASE ?? 0
     db.angDir = header.ANGDIR ?? 0
     db.aunits = header.AUNITS ?? 0
+    db.celtype = header.CELTYPE ?? ByLayer
     db.celtscale = header.CELTSCALE ?? 1
     db.ltscale = header.LTSCALE ?? 1
     if (header.EXTMAX!) db.extmax = header.EXTMAX


### PR DESCRIPTION
## Summary

This PR adds support for the `CELTYPE` system variable across the data model and converter pipeline, so the current entity linetype can be read, stored, exported, and applied consistently.

## Changes

- add `CELTYPE` to the database system variable definitions and manager
- store `celtype` on `AcDbDatabase` with normalization for special values like `BYLAYER` and `BYBLOCK`
- write `$CELTYPE` to DXF header output
- read `$CELTYPE` from DXF input
- read `CELTYPE` from both `libdxfrw` and `libredwg` converters
- make new entities inherit the database `celtype` when no explicit linetype is set

## Tests

- add DXF export coverage for `$CELTYPE`
- add DXF read coverage for `CELTYPE`
- add sysvar manager coverage for `CELTYPE`
- add entity behavior coverage to verify new entities use the database default linetype

## Why

Previously, the current entity linetype was not fully preserved through import/export and entity creation flows. This change makes linetype defaults behave more consistently with CAD expectations and keeps `CELTYPE` aligned across parsing, serialization, and runtime entity creation.