### PR TITLE
feat: add SVG linetype previews and demo rendering in example app

### DIFF
--- a/packages/data-model/__tests__/AcDbLinetypeTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbLinetypeTableRecord.spec.ts
@@ -14,4 +14,51 @@ describe('AcDbLinetypeTableRecord', () => {
         } as AcGiBaseLineStyle)
     )
   })
+
+  it('renders solid linetype preview as a single SVG line', () => {
+    const record = new AcDbLinetypeTableRecord({
+      name: 'CONTINUOUS',
+      standardFlag: 0,
+      description: 'Solid line',
+      totalPatternLength: 0
+    } as AcGiBaseLineStyle)
+
+    const svg = record.toPreviewSvgString({
+      width: 120,
+      height: 24,
+      padding: 6,
+      stroke: '#000000'
+    })
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('width="120"')
+    expect(svg).toContain('height="24"')
+    expect((svg.match(/<line /g) ?? []).length).toBe(1)
+    expect((svg.match(/<circle /g) ?? []).length).toBe(0)
+  })
+
+  it('renders dashed and dotted linetype preview with multiple segments', () => {
+    const record = new AcDbLinetypeTableRecord({
+      name: 'CENTER',
+      standardFlag: 0,
+      description: 'Center line',
+      totalPatternLength: 0.9,
+      pattern: [
+        { elementLength: 0.5, elementTypeFlag: 0 },
+        { elementLength: -0.3, elementTypeFlag: 0 },
+        { elementLength: 0, elementTypeFlag: 0 },
+        { elementLength: -0.1, elementTypeFlag: 0 }
+      ]
+    } as AcGiBaseLineStyle)
+
+    const svg = record.toPreviewSvgString({
+      width: 180,
+      height: 30,
+      padding: 10,
+      repeats: 3
+    })
+
+    expect((svg.match(/<line /g) ?? []).length).toBeGreaterThan(1)
+    expect((svg.match(/<circle /g) ?? []).length).toBeGreaterThan(0)
+  })
 })

--- a/packages/data-model/src/database/AcDbLinetypeTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLinetypeTableRecord.ts
@@ -3,6 +3,39 @@ import { AcGiBaseLineStyle } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base'
 import { AcDbSymbolTableRecord } from './AcDbSymbolTableRecord'
 
+export interface AcDbLinetypePreviewSvgOptions {
+  /**
+   * Width of preview SVG.
+   * @default 220
+   */
+  width?: number
+  /**
+   * Height of preview SVG.
+   * @default 36
+   */
+  height?: number
+  /**
+   * Left/right horizontal padding in pixels.
+   * @default 8
+   */
+  padding?: number
+  /**
+   * Stroke width in pixels.
+   * @default 2
+   */
+  strokeWidth?: number
+  /**
+   * Stroke color.
+   * @default 'currentColor'
+   */
+  stroke?: string
+  /**
+   * How many pattern cycles to display in preview width.
+   * @default 4
+   */
+  repeats?: number
+}
+
 /**
  * Represents a record in the line type table within the AutoCAD drawing database.
  *
@@ -102,6 +135,130 @@ export class AcDbLinetypeTableRecord extends AcDbSymbolTableRecord {
       )
     }
     return this._linetype.pattern![index].elementLength
+  }
+
+  /**
+   * Converts this linetype preview to an SVG string.
+   *
+   * The preview is rendered as a horizontal line centered in the SVG viewport.
+   * Positive pattern elements are drawn as visible strokes, negative elements
+   * are treated as gaps, and zero-length elements are rendered as dots.
+   *
+   * @param options - Preview rendering options
+   * @returns SVG string for linetype preview
+   */
+  toPreviewSvgString(options?: AcDbLinetypePreviewSvgOptions) {
+    const width = Math.max(options?.width ?? 220, 1)
+    const height = Math.max(options?.height ?? 36, 1)
+    const padding = Math.min(
+      Math.max(options?.padding ?? 8, 0),
+      Math.floor(width / 2)
+    )
+    const strokeWidth = Math.max(options?.strokeWidth ?? 2, 0.5)
+    const stroke = this.escapeSvgAttribute(options?.stroke ?? 'currentColor')
+    const repeats = Math.max(options?.repeats ?? 4, 1)
+    const y = height / 2
+    const startX = padding
+    const endX = Math.max(width - padding, startX + 1)
+    const previewWidth = endX - startX
+    const pattern = this._linetype.pattern ?? []
+
+    if (
+      pattern.length === 0 ||
+      this.patternLength <= 0 ||
+      !pattern.some(item => item.elementLength !== 0)
+    ) {
+      return this.buildSvgString({
+        width,
+        height,
+        stroke,
+        strokeWidth,
+        lineSegments: [[startX, endX]],
+        dots: [],
+        y
+      })
+    }
+
+    const lineSegments: Array<[number, number]> = []
+    const dots: number[] = []
+    const unitToPx = previewWidth / (this.patternLength * repeats)
+    const minSegmentPx = 0.5
+    const dotStep = Math.max(strokeWidth * 2, 2)
+    let currentX = startX
+
+    while (currentX < endX) {
+      for (const item of pattern) {
+        if (currentX >= endX) break
+
+        const length = item.elementLength
+        if (length === 0) {
+          dots.push(currentX)
+          currentX = Math.min(currentX + dotStep, endX)
+          continue
+        }
+
+        const segmentLengthPx = Math.max(
+          Math.abs(length) * unitToPx,
+          minSegmentPx
+        )
+        const nextX = Math.min(currentX + segmentLengthPx, endX)
+        if (length > 0 && nextX > currentX) {
+          lineSegments.push([currentX, nextX])
+        }
+        currentX = nextX
+      }
+    }
+
+    return this.buildSvgString({
+      width,
+      height,
+      stroke,
+      strokeWidth,
+      lineSegments,
+      dots,
+      y
+    })
+  }
+
+  private buildSvgString(input: {
+    width: number
+    height: number
+    stroke: string
+    strokeWidth: number
+    lineSegments: Array<[number, number]>
+    dots: number[]
+    y: number
+  }) {
+    const { width, height, stroke, strokeWidth, lineSegments, dots, y } = input
+    const lines = lineSegments
+      .map(
+        ([x1, x2]) =>
+          `<line x1="${x1.toFixed(2)}" y1="${y.toFixed(2)}" x2="${x2.toFixed(
+            2
+          )}" y2="${y.toFixed(2)}" stroke="${stroke}" stroke-width="${strokeWidth.toFixed(
+            2
+          )}" stroke-linecap="round" />`
+      )
+      .join('')
+    const circles = dots
+      .map(
+        x =>
+          `<circle cx="${x.toFixed(2)}" cy="${y.toFixed(
+            2
+          )}" r="${(strokeWidth / 2).toFixed(2)}" fill="${stroke}" />`
+      )
+      .join('')
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${this.escapeSvgAttribute(this.name)} linetype preview">${lines}${circles}</svg>`
+  }
+
+  private escapeSvgAttribute(value: string) {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/'/g, '&#39;')
   }
 
   /**

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -14,6 +14,7 @@ const runButton = document.getElementById('runButton') as HTMLButtonElement
 const status = document.getElementById('status') as HTMLDivElement
 const output = document.getElementById('output') as HTMLPreElement
 const exportButton = document.createElement('button')
+const linetypePreviewPanel = document.createElement('section')
 
 exportButton.type = 'button'
 exportButton.textContent = 'Export DXF'
@@ -21,6 +22,10 @@ exportButton.hidden = true
 exportButton.disabled = true
 exportButton.style.marginLeft = '8px'
 runButton.insertAdjacentElement('afterend', exportButton)
+output.insertAdjacentElement('afterend', linetypePreviewPanel)
+
+linetypePreviewPanel.style.marginTop = '16px'
+linetypePreviewPanel.style.display = 'none'
 
 type ParseMode = 'compare' | 'main' | 'worker'
 
@@ -142,6 +147,69 @@ const renderLayers = (layerInfo?: { count: number; names: string[] }) => {
   return lines
 }
 
+const renderLinetypePreviews = (database: AcDbDatabase | null) => {
+  linetypePreviewPanel.innerHTML = ''
+  if (!database) {
+    linetypePreviewPanel.style.display = 'none'
+    return
+  }
+
+  const records = database.tables.linetypeTable
+    .newIterator()
+    .toArray()
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const title = document.createElement('h3')
+  title.textContent = `Linetypes (${records.length})`
+  title.style.margin = '0 0 8px 0'
+  title.style.fontSize = '16px'
+  linetypePreviewPanel.appendChild(title)
+
+  const list = document.createElement('div')
+  list.style.display = 'grid'
+  list.style.gridTemplateColumns = '1fr'
+  list.style.gap = '8px'
+
+  for (const record of records) {
+    const row = document.createElement('div')
+    row.style.display = 'grid'
+    row.style.gridTemplateColumns = '220px auto'
+    row.style.alignItems = 'center'
+    row.style.gap = '12px'
+    row.style.padding = '6px 8px'
+    row.style.border = '1px solid #dadada'
+    row.style.borderRadius = '6px'
+
+    const label = document.createElement('div')
+    label.textContent = record.comments
+      ? `${record.name} - ${record.comments}`
+      : record.name
+    label.title = record.name
+    label.style.fontFamily = 'monospace'
+    label.style.fontSize = '13px'
+    label.style.whiteSpace = 'nowrap'
+    label.style.overflow = 'hidden'
+    label.style.textOverflow = 'ellipsis'
+
+    const preview = document.createElement('div')
+    preview.innerHTML = record.toPreviewSvgString({
+      width: 150,
+      height: 10,
+      padding: 8,
+      strokeWidth: 2,
+      stroke: '#202124',
+      repeats: 4
+    })
+
+    row.appendChild(label)
+    row.appendChild(preview)
+    list.appendChild(row)
+  }
+
+  linetypePreviewPanel.appendChild(list)
+  linetypePreviewPanel.style.display = 'block'
+}
+
 const updateModeOptions = (fileType: AcDbFileType) => {
   const compareOption = modeSelect.querySelector(
     'option[value="compare"]'
@@ -162,6 +230,7 @@ const updateModeOptions = (fileType: AcDbFileType) => {
 const runParse = async () => {
   if (!lastFile || !lastBuffer) {
     output.textContent = 'Please select a DWG or DXF file first.'
+    renderLinetypePreviews(null)
     return
   }
 
@@ -263,6 +332,7 @@ const runParse = async () => {
     lastParsedDatabase = parsedDatabase
     setStatus('')
     output.textContent = lines.join('\n')
+    renderLinetypePreviews(lastParsedDatabase)
     runButton.disabled = false
     modeSelect.disabled = false
     fileInput.disabled = false
@@ -275,6 +345,7 @@ fileInput.addEventListener('change', async () => {
   if (!file) return
   lastFile = file
   lastParsedDatabase = null
+  renderLinetypePreviews(null)
   updateModeOptions(getFileType(file.name))
   updateExportButton()
   output.textContent = 'Loading file...\n'


### PR DESCRIPTION
## Summary
- Add `toPreviewSvgString` to `AcDbLinetypeTableRecord` to render linetype patterns as inline SVG.
- Add configurable preview options (`width`, `height`, `padding`, `strokeWidth`, `stroke`, `repeats`) and SVG attribute escaping.
- Extend the example app to display a linetype preview panel after parsing files.
- Add unit tests for solid and dashed/dotted linetype SVG output behavior.

## Why
- Linetype records currently expose pattern data but do not provide a built-in visual preview.
- A direct preview improves developer ergonomics and helps verify linetype parsing/rendering quickly in the example UI.

## What Changed
- `packages/data-model/src/database/AcDbLinetypeTableRecord.ts`
- Introduced `AcDbLinetypePreviewSvgOptions`.
- Implemented preview rendering logic for continuous, dashed/gap, and dot elements.
- Added internal SVG builder and XML attribute escaping helpers.
- `packages/data-model/__tests__/AcDbLinetypeTableRecord.spec.ts`
- Added tests validating SVG dimensions and rendered primitives (`line`/`circle`) for representative linetypes.
- `packages/example/src/main.ts`
- Added a linetype preview section and render lifecycle hooks.
- Render linetype rows (name/description + SVG preview) after successful parse and clear on reset/no-file paths.

## Testing
- [x] Added/updated automated tests for `AcDbLinetypeTableRecord` preview generation

## Risks / Notes
- Preview scaling depends on `patternLength` and `repeats`; uncommon linetype definitions may need tuning for visual density.
- Example UI currently uses inline styles and fixed row geometry; follow-up polish may be needed for responsive layouts.
