### PR TITLE
fix: preserve DWG truecolor when entity has both RGB and ACI index

### DIFF
--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -869,7 +869,20 @@ export class AcDbEntityConverter {
       dbEntity.color.setRGBValue(entity.color)
     }
     if (entity.colorIndex != null) {
-      dbEntity.color.colorIndex = entity.colorIndex
+      // ACI color precedence rule:
+      // - If the libredwg binding already resolved a concrete RGB for the
+      //   entity (entity.color != null), that RGB reflects the DWG's own
+      //   color table — trust it and do NOT overwrite with ACI resolution
+      //   from our default palette (which loses custom-palette mappings,
+      //   e.g. ACI 254 → #d8f5c2 in the source DWG vs. near-black in our
+      //   default palette).
+      // - Exception: colorIndex === 7 is semantically special (the
+      //   "foreground" color that flips with COLORTHEME). Preserve it as
+      //   ByACI(7) so that AcCmColor.isForeground stays true and text
+      //   keeps inverting with the theme.
+      if (entity.color == null || entity.colorIndex === 7) {
+        dbEntity.color.colorIndex = entity.colorIndex
+      }
     }
     if (entity.colorName) {
       dbEntity.color.colorName = entity.colorName


### PR DESCRIPTION
## Summary
  - When the libredwg binding resolves a concrete RGB on `entity.color` (truecolor or custom color-table entry), the subsequent `dbEntity.color.colorIndex = entity.colorIndex` assignment overwrote that RGB by re-resolving the index against our default ACI palette.
  - On drawings that rely on a custom palette (e.g. ACI 254 → `#d8f5c2` in the source DWG vs. near-black in our default palette), the rendered color was wrong.
  - ACI 7 is kept as an index because it is the "foreground" pseudo-color that must flip with the COLORTHEME sysvar — preserving the index keeps `AcCmColor.isForeground` true so text/linework continue inverting with the theme.

  ## Test plan
  - [ ] Open a DWG whose source uses a custom color table (e.g. ACI 254 mapped to a light-green such as `#d8f5c2`). Before the fix: renders near-black. After: renders the DWG's actual color.
  - [ ] Open any DWG relying on ByACI(7) for text/linework. Toggle COLORTHEME between dark (0) and light (1). Glyphs still flip (white ↔ black).
  - [ ] Existing unit tests in `packages/data-model/__tests__/AcDbEntityConverter.spec.ts` still pass.