### PR TITLE
fix: fix block reference osnap resolution for transformed and nested entities

### DIFF
--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -144,6 +144,71 @@ describe('AcDbBlockReference', () => {
     expect(infiniteLoopGuardSnaps).toHaveLength(0)
   })
 
+  it('transforms pick point to block space before querying sub-entity osnap', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    block.appendEntity(line)
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(10, 0, 0)
+    blockRef.rotation = Math.PI / 2
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const nearestSnaps: AcGePoint3d[] = []
+    blockRef.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(11, 3, 0),
+      new AcGePoint3d(),
+      nearestSnaps,
+      line.objectId
+    )
+
+    expect(nearestSnaps).toHaveLength(1)
+    expect(nearestSnaps[0].x).toBeCloseTo(10)
+    expect(nearestSnaps[0].y).toBeCloseTo(3)
+    expect(nearestSnaps[0].z).toBeCloseTo(0)
+  })
+
+  it('resolves osnap points through nested block references', () => {
+    const db = createDb()
+    const leafBlock = createNamedBlock(db, 'LEAF_BLOCK')
+    const parentBlock = createNamedBlock(db, 'PARENT_BLOCK')
+
+    const nestedLine = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    leafBlock.appendEntity(nestedLine)
+
+    const nestedRef = new AcDbBlockReference('LEAF_BLOCK')
+    nestedRef.position = new AcGePoint3d(2, 0, 0)
+    parentBlock.appendEntity(nestedRef)
+
+    const topRef = new AcDbBlockReference('PARENT_BLOCK')
+    topRef.position = new AcGePoint3d(10, 0, 0)
+    topRef.rotation = Math.PI / 2
+    db.tables.blockTable.modelSpace.appendEntity(topRef)
+
+    const nestedSnaps: AcGePoint3d[] = []
+    topRef.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      nestedSnaps,
+      nestedLine.objectId
+    )
+
+    expect(nestedSnaps).toHaveLength(2)
+    expect(nestedSnaps[0].x).toBeCloseTo(10)
+    expect(nestedSnaps[0].y).toBeCloseTo(2)
+    expect(nestedSnaps[1].x).toBeCloseTo(10)
+    expect(nestedSnaps[1].y).toBeCloseTo(12)
+  })
+
   it('transforms insertion, scale, rotation, normal and attribute geometry', () => {
     const db = createDb()
     createNamedBlock(db, 'TEST_BLOCK')

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -207,6 +207,14 @@ export class AcDbBlockReference extends AcDbEntity {
     this._normal.copy(value).normalize()
   }
 
+  /**
+   * Gets the name of the block definition referenced by this INSERT entity.
+   *
+   * The returned value is the block table record key used to resolve
+   * {@link blockTableRecord} from the current database.
+   *
+   * @returns The referenced block name.
+   */
   get blockName() {
     return this._blockName
   }
@@ -385,7 +393,7 @@ export class AcDbBlockReference extends AcDbEntity {
   }
 
   /**
-   * Gets the object snap points for this mtext.
+   * Gets the object snap points for this block reference.
    *
    * Object snap points are precise points that can be used for positioning
    * when drawing or editing. This method provides snap points based on the
@@ -400,29 +408,53 @@ export class AcDbBlockReference extends AcDbEntity {
    * to set GS marker of the subentity involved in the object snap operation. For
    * now, we don't provide such a GS marker mechanism yet. So passed id of subentity
    * as GS marker. Maybe this behavior will change in the future.
+   * @param insertionMat - Cumulative insertion transform matrix from parent
+   * block references.
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
     pickPoint: AcGePoint3dLike,
     lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[],
-    gsMark?: AcDbObjectId
+    gsMark?: AcDbObjectId,
+    insertionMat?: AcGeMatrix3d
   ) {
+    const parentInsertionMat = insertionMat ?? new AcGeMatrix3d()
+
     if (AcDbOsnapMode.Insertion === osnapMode) {
-      snapPoints.push(this._position)
+      snapPoints.push(this.getInsertionPoint(parentInsertionMat))
     } else if (gsMark) {
       this.subEntityGetOsnapPoints(
         osnapMode,
         pickPoint,
         lastPoint,
         snapPoints,
-        gsMark
+        gsMark,
+        parentInsertionMat
       )
     }
   }
 
   /**
-   * Transforms this block reference by the specified matrix.
+   * Transforms this block reference by an arbitrary world-space matrix.
+   *
+   * Unlike simple entities that can transform raw geometry directly, an INSERT
+   * stores placement as decomposed parameters (`position`, `rotation`,
+   * `scaleFactors`, and `normal`). This method applies the input matrix to a
+   * derived local frame, then reconstructs those parameters from the transformed
+   * frame so the reference remains representable as an INSERT.
+   *
+   * Recomposition pipeline:
+   *
+   * 1. Build local axes from current `rotation`, `normal`, and `scaleFactors`
+   * 2. Transform axis endpoints and origin by `matrix`
+   * 3. Recompute normal from transformed X/Y axes (with a degenerate fallback)
+   * 4. Project transformed X axis into the new OCS to recover `rotation`
+   * 5. Recover axis lengths as new `scaleFactors`
+   * 6. Transform all attached attributes with the same matrix
+   *
+   * @param matrix - Transformation matrix in WCS.
+   * @returns The current block reference instance.
    */
   transformBy(matrix: AcGeMatrix3d) {
     const extrusion = new AcGeMatrix3d().setFromExtrusionDirection(this._normal)
@@ -693,18 +725,17 @@ export class AcDbBlockReference extends AcDbEntity {
   }
 
   /**
-   * Writes the INSERT entity record and any attached ATTRIB/SEQEND records.
+   * Writes this INSERT entity to DXF, including its attribute sequence.
+   *
+   * The output order follows DXF conventions:
+   *
+   * 1. Emit INSERT common/object fields via the base implementation
+   * 2. Emit one `ATTRIB` section for each attached attribute
+   * 3. Emit a terminating `SEQEND` record when attributes were written
    *
    * @param filer - DXF output writer.
    * @param allXdata - When true, emits all XData attached to this entity.
-   * @returns The entity instance (for chaining).
-   */
-  /**
-   * Writes this object to the DXF output.
-   *
-   * @param filer - DXF output writer.
-   * @param allXdata - When true, emits all XData attached to this object.
-   * @returns The instance (for chaining).
+   * @returns The current entity instance.
    */
   override dxfOut(filer: AcDbDxfFiler, allXdata = false) {
     super.dxfOut(filer, allXdata)
@@ -723,37 +754,134 @@ export class AcDbBlockReference extends AcDbEntity {
     return this
   }
 
+  /**
+   * Recursively resolves object snap points from nested block references.
+   *
+   * This helper traverses child entities under the current block reference to
+   * locate the sub-entity identified by `gsMark`. When found, it converts
+   * pick/last points into the target local space, asks that entity for snap
+   * points, then maps results back to the caller space as needed.
+   *
+   * The method tracks visited block references to prevent infinite recursion in
+   * cyclic block graphs.
+   *
+   * @param osnapMode - Requested osnap mode.
+   * @param pickPoint - User pick point in caller space.
+   * @param lastPoint - Previous point in caller space.
+   * @param snapPoints - Output collection to append resolved snap points into.
+   * @param gsMark - Object id of the target sub-entity.
+   * @param parentInsertionMat - Cumulative transform from ancestor INSERTs.
+   * @param visitedRefs - Internal recursion guard set.
+   * @returns `true` when the target sub-entity is found and processed, else `false`.
+   */
   private subEntityGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
     pickPoint: AcGePoint3dLike,
     lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[],
-    gsMark: AcDbObjectId
+    gsMark: AcDbObjectId,
+    parentInsertionMat: AcGeMatrix3d,
+    visitedRefs = new Set<AcDbObjectId>()
   ) {
     // Avoid an infinite loop
-    if (gsMark === this.objectId) return
+    if (gsMark === this.objectId || visitedRefs.has(this.objectId)) return false
 
-    const blockTable = this.database?.tables.blockTable
-    if (blockTable != null) {
-      const entity = blockTable.getEntityById(gsMark)
-      if (entity) {
-        const points: AcGePoint3d[] = []
-        entity.subGetOsnapPoints(
-          osnapMode,
-          pickPoint,
-          lastPoint,
-          points,
-          gsMark
-        )
+    visitedRefs.add(this.objectId)
 
-        // Apply matrix to all snap points
-        const matrix = this.blockTransform
-        points.forEach(point => {
-          const tmp = point.clone().applyMatrix4(matrix)
-          snapPoints.push(tmp)
-        })
+    try {
+      const blockTableRecord = this.blockTableRecord
+      if (blockTableRecord == null) return false
+
+      const thisInsertionMat = new AcGeMatrix3d().multiplyMatrices(
+        parentInsertionMat,
+        this.getFullInsertionTransform()
+      )
+
+      for (const entity of blockTableRecord.newIterator()) {
+        if (entity.objectId === gsMark) {
+          const localPickPoint = new AcGePoint3d(pickPoint).applyMatrix4(
+            thisInsertionMat.clone().invert()
+          )
+          const localLastPoint = new AcGePoint3d(lastPoint).applyMatrix4(
+            thisInsertionMat.clone().invert()
+          )
+          const localSnapPoints: AcGePoint3d[] = []
+
+          entity.subGetOsnapPoints(
+            osnapMode,
+            localPickPoint,
+            localLastPoint,
+            localSnapPoints,
+            gsMark,
+            thisInsertionMat
+          )
+
+          if (entity instanceof AcDbBlockReference) {
+            localSnapPoints.forEach(point => {
+              snapPoints.push(point.clone())
+            })
+          } else {
+            localSnapPoints.forEach(point => {
+              snapPoints.push(
+                new AcGePoint3d(point).applyMatrix4(thisInsertionMat)
+              )
+            })
+          }
+
+          return true
+        }
+
+        if (entity instanceof AcDbBlockReference) {
+          const found = entity.subEntityGetOsnapPoints(
+            osnapMode,
+            pickPoint,
+            lastPoint,
+            snapPoints,
+            gsMark,
+            thisInsertionMat,
+            visitedRefs
+          )
+          if (found) return true
+        }
       }
+
+      return false
+    } finally {
+      visitedRefs.delete(this.objectId)
     }
+  }
+
+  /**
+   * Computes the insertion osnap point in caller space.
+   *
+   * The insertion point is the block definition base point transformed by the
+   * full cumulative insertion transform (ancestor transform + this reference's
+   * own full insertion transform including extrusion).
+   *
+   * @param parentInsertionMat - Cumulative transform from parent block references.
+   * @returns The insertion point in the caller coordinate space.
+   */
+  private getInsertionPoint(parentInsertionMat: AcGeMatrix3d) {
+    const blockBasePoint = this.blockTableRecord?.origin ?? AcGePoint3d.ORIGIN
+    const insertionMat = new AcGeMatrix3d().multiplyMatrices(
+      parentInsertionMat,
+      this.getFullInsertionTransform()
+    )
+    return new AcGePoint3d(blockBasePoint).applyMatrix4(insertionMat)
+  }
+
+  /**
+   * Builds the full INSERT transform for this block reference.
+   *
+   * {@link blockTransform} contains translation/rotation/scale in OCS only.
+   * This method prepends the extrusion transform derived from {@link normal} so
+   * the returned matrix maps block-local geometry all the way into WCS.
+   *
+   * @returns Full block insertion transform including OCS extrusion.
+   */
+  private getFullInsertionTransform() {
+    const extrusion = new AcGeMatrix3d().setFromExtrusionDirection(this._normal)
+    return new AcGeMatrix3d().multiplyMatrices(extrusion, this.blockTransform)
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -490,6 +490,8 @@ export abstract class AcDbEntity extends AcDbObject {
    * to set GS marker of the subentity involved in the object snap operation. For
    * now, we don't provide such a GS marker mechanism yet. So passed id of subentity
    * as GS marker. Maybe this behavior will change in the future.
+   * @param insertionMat - Cumulative insertion transform matrix from nested block
+   * references. This parameter is primarily used by INSERT entities.
    *
    * @example
    * ```typescript
@@ -507,7 +509,9 @@ export abstract class AcDbEntity extends AcDbObject {
     // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
     snapPoints: AcGePoint3dLike[],
     // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
-    gsMark?: AcDbObjectId
+    gsMark?: AcDbObjectId,
+    // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
+    insertionMat?: AcGeMatrix3d
   ) {}
 
   /**


### PR DESCRIPTION
## Summary
- Correct `AcDbBlockReference` osnap behavior by applying cumulative insertion transforms when resolving snap points.
- Add recursive nested block-reference lookup for `gsMark` so osnap points can be resolved through multiple block levels.
- Add focused tests for transformed pick-point handling and nested block-reference osnap resolution.

## Why
- Osnap queries on block references need consistent world/block-space conversion to return correct points.
- Nested block references were not reliably resolving target sub-entity snap points, especially with transforms.

## What Changed
- Updated `AcDbBlockReference.subGetOsnapPoints` to accept an optional cumulative `insertionMat` and use transformed insertion-point output.
- Reworked `subEntityGetOsnapPoints` to:
  - Traverse nested block references.
  - Track visited references to avoid recursion loops.
  - Convert pick/last points into local block space before sub-entity osnap queries.
  - Apply the correct transform path when returning snap points.
- Added helper methods to centralize insertion transform logic:
  - `getInsertionPoint(parentInsertionMat)`
  - `getFullInsertionTransform()`
- Extended base entity API/docs (`AcDbEntity.subGetOsnapPoints`) to include optional `insertionMat`.
- Added tests in `AcDbBlockReference.spec.ts` for:
  - Pick-point transform to block space before osnap query.
  - Osnap resolution through nested block references.

## Risks / Notes
- API signature change (`subGetOsnapPoints` optional `insertionMat`) is backward-compatible but may require follow-up updates for custom overrides to leverage nested transform context.
- Recursive traversal depends on correct objectId identity and block graph integrity; additional stress tests for deep nesting/cycles may be useful.
