### PR TITLE
feat: resolve dimension osnaps and extents from anonymous dim blocks

### DIFF
--- a/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
@@ -1,6 +1,16 @@
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
-import { AcDbAlignedDimension } from '../src/entity'
+import { acdbHostApplicationServices } from '../src/base'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import { AcDbAlignedDimension, AcDbLine } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
 
 describe('AcDbAlignedDimension', () => {
   it('creates a detached clone with a new objectId', () => {
@@ -12,5 +22,74 @@ describe('AcDbAlignedDimension', () => {
           new AcGePoint3d(0, 1, 0)
         )
     )
+  })
+
+  it('resolves osnap points through its anonymous dimension block', () => {
+    const db = createDb()
+
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_TEST'
+    const line = new AcDbLine(
+      new AcGePoint3d(1, 2, 0),
+      new AcGePoint3d(4, 2, 0)
+    )
+    dimBlock.appendEntity(line)
+    db.tables.blockTable.add(dimBlock)
+
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.dimBlockId = '*D_TEST'
+    dim.dimBlockPosition = new AcGePoint3d(10, 20, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    const snapsByGsMark: AcGePoint3d[] = []
+    dim.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapsByGsMark,
+      line.objectId
+    )
+
+    expect(snapsByGsMark).toHaveLength(2)
+    expect(snapsByGsMark[0]).toMatchObject({ x: 11, y: 22, z: 0 })
+    expect(snapsByGsMark[1]).toMatchObject({ x: 14, y: 22, z: 0 })
+
+    const snapsWithoutGsMark: AcGePoint3d[] = []
+    dim.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapsWithoutGsMark
+    )
+    expect(snapsWithoutGsMark.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('returns transformed geometric extents from dimension block', () => {
+    const db = createDb()
+
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_EXTENTS'
+    dimBlock.appendEntity(
+      new AcDbLine(new AcGePoint3d(1, 2, 0), new AcGePoint3d(4, 6, 0))
+    )
+    db.tables.blockTable.add(dimBlock)
+
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.dimBlockId = '*D_EXTENTS'
+    dim.dimBlockPosition = new AcGePoint3d(10, 20, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    const extents = dim.geometricExtents
+    expect(extents.isEmpty()).toBe(false)
+    expect(extents.min).toMatchObject({ x: 11, y: 22, z: 0 })
+    expect(extents.max).toMatchObject({ x: 14, y: 26, z: 0 })
   })
 })

--- a/packages/data-model/__tests__/AcDbEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntity.spec.ts
@@ -129,7 +129,10 @@ describe('AcDbEntity.color resolution', () => {
     db.clayer = '0'
     db.cecolor = new AcCmColor().setRGBValue(0x336699)
 
-    const line = new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(1, 0, 0))
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0)
+    )
     line.layer = '0'
     line.color.setByBlock()
 
@@ -144,7 +147,10 @@ describe('AcDbEntity.color resolution', () => {
     db.clayer = 'CURRENT_LAYER'
     db.cecolor = new AcCmColor().setByLayer()
 
-    const line = new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(1, 0, 0))
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0)
+    )
     line.layer = 'ENTITY_LAYER'
     line.color.setByBlock()
 
@@ -158,7 +164,10 @@ describe('AcDbEntity.color resolution', () => {
     db.clayer = 'CURRENT_LAYER'
     db.cecolor = new AcCmColor().setRGBValue(0xff00ff)
 
-    const line = new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(1, 0, 0))
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0)
+    )
     line.layer = 'ENTITY_LAYER'
     line.color.setByLayer()
 

--- a/packages/data-model/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntityConverter.spec.ts
@@ -1,7 +1,11 @@
 import { AcDbEntityConverter } from '../src/converter/AcDbEntitiyConverter'
 import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
-import { AcDbAlignedDimension, AcDbPolyline, AcDbRotatedDimension } from '../src/entity'
+import {
+  AcDbAlignedDimension,
+  AcDbPolyline,
+  AcDbRotatedDimension
+} from '../src/entity'
 
 describe('AcDbEntityConverter', () => {
   it('returns null for unsupported type', () => {

--- a/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
@@ -1,6 +1,5 @@
 import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 import {
-  AcGeBox3d,
   AcGeLine3d,
   AcGeMatrix3d,
   AcGePoint3d,
@@ -281,8 +280,7 @@ export class AcDbAlignedDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    return this.getDimBlockGeometricExtents()
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -1,4 +1,5 @@
 import {
+  AcGeBox3d,
   AcGeLine3d,
   AcGeMatrix3d,
   AcGePoint2dLike,
@@ -18,6 +19,8 @@ import { AcDbObjectId } from '../../base'
 import { AcDbDxfFiler } from '../../base'
 import { AcDbDimStyleTableRecord } from '../../database'
 import { AcDbRenderingCache } from '../../misc'
+import { AcDbOsnapMode } from '../../misc'
+import { AcDbBlockReference } from '../AcDbBlockReference'
 import { AcDbEntity } from '../AcDbEntity'
 import { AcDbLine } from '../AcDbLine'
 
@@ -370,29 +373,124 @@ export abstract class AcDbDimension extends AcDbEntity {
   }
 
   /**
+   * Resolves osnap points through the anonymous dimension block.
+   *
+   * Dimensions are rendered from `dimBlockId` contents, so osnap queries need
+   * to delegate to the block entities and map points between block-local space
+   * and WCS.
+   */
+  override subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[],
+    gsMark?: AcDbObjectId
+  ) {
+    const blockTableRecord = this.getDimBlockTableRecord()
+    if (!blockTableRecord) return
+
+    const blockTransform = this.getFullDimBlockTransform()
+    const localPickPoint = new AcGePoint3d(pickPoint).applyMatrix4(
+      blockTransform.clone().invert()
+    )
+    const localLastPoint = new AcGePoint3d(lastPoint).applyMatrix4(
+      blockTransform.clone().invert()
+    )
+
+    const appendEntitySnapPoints = (
+      entity: AcDbEntity,
+      subEntityId?: AcDbObjectId
+    ) => {
+      const localSnapPoints: AcGePoint3d[] = []
+      entity.subGetOsnapPoints(
+        osnapMode,
+        localPickPoint,
+        localLastPoint,
+        localSnapPoints,
+        subEntityId,
+        blockTransform
+      )
+
+      if (entity instanceof AcDbBlockReference) {
+        localSnapPoints.forEach(point => snapPoints.push(point.clone()))
+      } else {
+        localSnapPoints.forEach(point =>
+          snapPoints.push(new AcGePoint3d(point).applyMatrix4(blockTransform))
+        )
+      }
+    }
+
+    if (gsMark) {
+      const target = blockTableRecord.getIdAt(gsMark)
+      if (target) {
+        appendEntitySnapPoints(target, gsMark)
+        if (snapPoints.length > 0) return
+      }
+    }
+
+    for (const entity of blockTableRecord.newIterator()) {
+      appendEntitySnapPoints(entity)
+    }
+  }
+
+  /**
    * @inheritdoc
    */
   subWorldDraw(renderer: AcGiRenderer) {
-    if (this.dimBlockId) {
-      const blockTableRecord = this.database.tables.blockTable.getAt(
-        this.dimBlockId
+    const blockTableRecord = this.getDimBlockTableRecord()
+    if (blockTableRecord) {
+      const matrix = this.computeDimBlockTransform()
+      const group = AcDbRenderingCache.instance.draw(
+        renderer,
+        blockTableRecord,
+        this.rgbColor,
+        [],
+        false,
+        matrix,
+        this._normal
       )
-      if (blockTableRecord) {
-        const matrix = this.computeDimBlockTransform()
-        const group = AcDbRenderingCache.instance.draw(
-          renderer,
-          blockTableRecord,
-          this.rgbColor,
-          [],
-          false,
-          matrix,
-          this._normal
-        )
-        return group
-      }
+      return group
     }
     const group = renderer.group([])
     return group
+  }
+
+  /**
+   * Computes transformed geometric extents from the anonymous dimension block.
+   */
+  protected getDimBlockGeometricExtents(): AcGeBox3d {
+    const box = new AcGeBox3d()
+    const blockTableRecord = this.getDimBlockTableRecord()
+    if (!blockTableRecord) return box
+
+    for (const entity of blockTableRecord.newIterator()) {
+      box.union(entity.geometricExtents)
+    }
+
+    box.applyMatrix4(this.getFullDimBlockTransform())
+    return box
+  }
+
+  /**
+   * Looks up the anonymous block referenced by `dimBlockId`.
+   */
+  protected getDimBlockTableRecord() {
+    return this.dimBlockId
+      ? this.database.tables.blockTable.getAt(this.dimBlockId)
+      : undefined
+  }
+
+  /**
+   * Builds the complete dimension-block transform (OCS transform + extrusion).
+   */
+  protected getFullDimBlockTransform() {
+    const dimBlockTransform = this.computeDimBlockTransform()
+    if (this._normal.x === 0 && this._normal.y === 0 && this._normal.z === 1) {
+      return dimBlockTransform
+    }
+
+    const extrusion = new AcGeMatrix3d().setFromExtrusionDirection(this._normal)
+    return new AcGeMatrix3d().multiplyMatrices(extrusion, dimBlockTransform)
   }
 
   protected get arrowScaleFactor() {


### PR DESCRIPTION
## Summary
- Added dimension-level osnap resolution that delegates to entities inside the anonymous dimension block (`dimBlockId`) and maps points between block-local space and WCS.
- Implemented reusable helpers on `AcDbDimension` to fetch the dim block record, compute full block transform (including extrusion), and derive transformed geometric extents from block contents.
- Updated `AcDbAlignedDimension.geometricExtents` to return block-derived extents instead of an empty placeholder.

## Why
- Dimensions are rendered from anonymous block geometry, so osnap and extents should be computed from that same geometry for correct interaction and bounds behavior.
- `AcDbAlignedDimension` previously returned an empty extents box, which could break selection/culling/zoom behaviors that depend on extents.

## What Changed
- In `AcDbDimension`:
- Added `subGetOsnapPoints` override that:
- Resolves target entities by `gsMark` when provided, with fallback to iterating all block entities.
- Converts pick/last points into block-local coordinates.
- Transforms returned snap points back into world space.
- Added `getDimBlockGeometricExtents()` to union child entity extents and apply the full dimension-block transform.
- Added `getDimBlockTableRecord()` and `getFullDimBlockTransform()` helpers to centralize block lookup and transform composition.
- Refactored `subWorldDraw` to reuse the new dim block lookup helper.
- In `AcDbAlignedDimension`:
- Replaced TODO extents implementation with `this.getDimBlockGeometricExtents()`.
- In tests (`AcDbAlignedDimension.spec.ts`):
- Added coverage for osnap resolution via anonymous dim block, including `gsMark`-targeted lookup.
- Added coverage for transformed geometric extents derived from block geometry.

## Testing
- [x] `pnpm test -- packages/data-model/__tests__/AcDbAlignedDimension.spec.ts`

## Risks / Notes
- Osnap behavior now depends on valid anonymous dimension block setup (`dimBlockId` and block entities) at query time.
- If downstream code expects deduplicated snap points, additional normalization may be needed in a follow-up.
