### PR TITLE
fix: fix closed wide LWPOLYLINE rendering by building ring areas from outer/inner loops

### DIFF
--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -4,7 +4,7 @@ import {
   AcGePoint3d
 } from '@mlightcad/geometry-engine'
 
-import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
 import { TEMP_OBJECT_ID_PREFIX } from '../src/base/AcDbObject'
 import { AcDbDatabase } from '../src/database'
 import { AcDbPolyline } from '../src/entity'
@@ -264,13 +264,51 @@ describe('AcDbPolyline', () => {
     }
 
     const result = polyline.subWorldDraw(renderer as never)
+    const areaArg = (renderer.area as jest.Mock).mock.calls[0][0] as {
+      area: number
+      loops: Array<{
+        getPoints: (numPoints: number) => Array<{ x: number; y: number }>
+      }>
+    }
+    const boundaries = areaArg.loops.map(loop => loop.getPoints(4))
+    const loopBoxes = boundaries
+      .map(points => ({
+        minX: Math.min(...points.map(point => point.x)),
+        maxX: Math.max(...points.map(point => point.x)),
+        minY: Math.min(...points.map(point => point.y)),
+        maxY: Math.max(...points.map(point => point.y))
+      }))
+      .sort(
+        (a, b) =>
+          (b.maxX - b.minX) * (b.maxY - b.minY) -
+          (a.maxX - a.minX) * (a.maxY - a.minY)
+      )
+
     expect(result).toBe(giEntity)
     expect(renderer.area).toHaveBeenCalledTimes(1)
     expect(renderer.lines).not.toHaveBeenCalled()
+    expect(areaArg.loops).toHaveLength(2)
+    expect(areaArg.area).toBeCloseTo(60, 8)
+    expect(loopBoxes[0]).toMatchObject({
+      minX: -1,
+      maxX: 11,
+      minY: -1,
+      maxY: 6
+    })
+    expect(loopBoxes[1]).toMatchObject({
+      minX: 1,
+      maxX: 9,
+      minY: 1,
+      maxY: 4
+    })
     expect(renderer.subEntityTraits.fillType).toMatchObject({
       solidFill: true,
       patternAngle: 0
     })
+    expect(
+      (renderer.subEntityTraits.fillType as { isHatchFill?: boolean })
+        .isHatchFill
+    ).toBeUndefined()
   })
 
   it('renders variable-width polyline as filled area', () => {
@@ -297,6 +335,10 @@ describe('AcDbPolyline', () => {
     expect(result).toBe(giEntity)
     expect(renderer.area).toHaveBeenCalledTimes(1)
     expect(renderer.lines).not.toHaveBeenCalled()
+    expect(
+      (renderer.subEntityTraits.fillType as { isHatchFill?: boolean })
+        .isHatchFill
+    ).toBeUndefined()
   })
 
   it('writes LWPOLYLINE-specific dxf fields and vertices', () => {

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -60,7 +60,8 @@ import {
   AcGeSpline3d,
   AcGeVector2d,
   AcGeVector3d,
-  transformOcsPointToWcs} from '@mlightcad/geometry-engine'
+  transformOcsPointToWcs
+} from '@mlightcad/geometry-engine'
 import {
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -8,7 +8,8 @@ import {
   AcGeVector3dLike,
   getOcsAngle,
   getOcsReferenceVector,
-  transformWcsPointToOcs} from '@mlightcad/geometry-engine'
+  transformWcsPointToOcs
+} from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -8,7 +8,8 @@ import {
   AcGeVector3dLike,
   getOcsReferenceVector,
   TAU,
-  transformWcsPointToOcs} from '@mlightcad/geometry-engine'
+  transformWcsPointToOcs
+} from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -476,13 +476,8 @@ export class AcDbPolyline extends AcDbCurve {
     const centerline = this._geo.getPoints(100)
     const widthProfile = this.createWidthProfile()
     if (widthProfile != null) {
-      const loop = createWidePolylineLoop(widthProfile, this.closed)
-      if (
-        loop.length >= 3 &&
-        Math.abs(calculateSignedArea(loop)) > WIDTH_EPSILON
-      ) {
-        const area = new AcGeArea2d()
-        area.add(new AcGePolyline2d(loop, true))
+      const area = createWidePolylineArea(widthProfile, this.closed)
+      if (area != null) {
         const traits = renderer.subEntityTraits
         traits.fillType = {
           solidFill: true,
@@ -620,28 +615,56 @@ interface WidePolylinePoint {
 }
 
 /**
- * Generates a closed polygon loop representing a variable-width polyline.
+ * Builds a renderable filled area for a wide polyline.
  *
- * The algorithm offsets each centerline sample to both left and right sides
- * using locally computed join directions, then stitches:
- * - left side in forward order
- * - right side in reverse order
- *
- * The resulting loop can be consumed by area/fill rendering.
+ * Open wide polylines are represented as a single stitched shell loop. Closed
+ * wide polylines are represented as two loops (outer + inner hole) so the
+ * stroke ring does not degenerate into a self-intersecting polygon.
  *
  * @param points - Centerline samples with per-point widths.
  * @param closed - Whether the source polyline is topologically closed.
- * @returns A polygon loop vertex array, or an empty array if insufficient
- * valid offset points are produced.
+ * @returns An area ready for fill rendering, or `null` when no valid area can
+ * be constructed.
  */
-function createWidePolylineLoop(
-  points: WidePolylinePoint[],
-  closed: boolean
-): AcGePolyline2dVertex[] {
-  if (points.length < 2) return []
+function createWidePolylineArea(points: WidePolylinePoint[], closed: boolean) {
+  if (points.length < 2) return null
   const centerline = normalizeCenterline(points, closed)
-  if (centerline.length < 2) return []
+  if (centerline.length < 2) return null
 
+  const { left, right } = createWidePolylineBoundaries(centerline, closed)
+  if (left.length < 2 || right.length < 2) return null
+
+  const area = new AcGeArea2d()
+  if (closed) {
+    if (!isRenderableLoop(left) || !isRenderableLoop(right)) {
+      return null
+    }
+    const leftArea = Math.abs(calculateSignedArea(left))
+    const rightArea = Math.abs(calculateSignedArea(right))
+    const [outer, inner] = leftArea >= rightArea ? [left, right] : [right, left]
+    area.add(new AcGePolyline2d(outer, true))
+    area.add(new AcGePolyline2d(inner, true))
+    return area
+  }
+
+  const loop = [...left, ...right.reverse()]
+  if (!isRenderableLoop(loop)) return null
+  area.add(new AcGePolyline2d(loop, true))
+  return area
+}
+
+/**
+ * Computes offset boundaries on the left and right sides of a sampled
+ * centerline.
+ *
+ * @param centerline - Normalized centerline samples with local widths.
+ * @param closed - Whether the polyline is topologically closed.
+ * @returns Left and right boundary vertices.
+ */
+function createWidePolylineBoundaries(
+  centerline: WidePolylinePoint[],
+  closed: boolean
+) {
   const left: AcGePolyline2dVertex[] = []
   const right: AcGePolyline2dVertex[] = []
   for (let i = 0; i < centerline.length; i++) {
@@ -664,8 +687,7 @@ function createWidePolylineLoop(
     })
   }
 
-  if (left.length < 2 || right.length < 2) return []
-  return [...left, ...right.reverse()]
+  return { left, right }
 }
 
 /**
@@ -800,6 +822,18 @@ function calculateSignedArea(points: AcGePolyline2dVertex[]) {
     area += p1.x * p2.y - p2.x * p1.y
   }
   return area / 2
+}
+
+/**
+ * Checks whether a loop can represent a non-degenerate filled polygon.
+ *
+ * @param points - Loop vertices in order.
+ * @returns `true` when the loop encloses non-zero area.
+ */
+function isRenderableLoop(points: AcGePolyline2dVertex[]) {
+  return (
+    points.length >= 3 && Math.abs(calculateSignedArea(points)) > WIDTH_EPSILON
+  )
 }
 
 /**

--- a/packages/libdxfrw-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libdxfrw-converter/src/AcDbEntitiyConverter.ts
@@ -29,7 +29,8 @@ import {
   AcGeSpline3d,
   AcGeVector2d,
   AcGeVector3d,
-  transformOcsPointToWcs} from '@mlightcad/data-model'
+  transformOcsPointToWcs
+} from '@mlightcad/data-model'
 import {
   DRW_Arc,
   DRW_Circle,

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -60,7 +60,8 @@ import {
   AcGeVector3d,
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection,
-  transformOcsPointToWcs} from '@mlightcad/data-model'
+  transformOcsPointToWcs
+} from '@mlightcad/data-model'
 import type {
   Dwg3dFaceEntity,
   DwgAlignedDimensionEntity,


### PR DESCRIPTION
## Summary

This PR fixes rendering for closed wide `LWPOLYLINE` entities, where shapes such as rectangles could lose one edge after the wide-polyline fill logic introduced in `7853db46d767bf54ae4ddfd7622d23e3071d4860`.

## Problem

The previous wide-polyline rendering path treated both open and closed polylines as a single stitched fill loop.

That works for open polylines, but for closed polylines it can produce a self-intersecting polygon instead of a proper ring-shaped area. In practice, this caused closed shapes such as a rectangle with 4 vertices to render incorrectly, with one side appearing missing.

## What Changed

- Updated `AcDbPolyline.subWorldDraw` to build a renderable `AcGeArea2d` for wide polylines instead of always creating a single fill loop.
- Kept the existing single-loop fill behavior for open wide polylines.
- Added closed-wide-polyline handling that builds:
  - one outer loop
  - one inner loop
- Used those two loops to represent the stroke area of a closed polyline as a proper ring.
- Added stronger tests for closed constant-width polylines to verify:
  - `renderer.area(...)` is used
  - two loops are generated
  - the expected outer/inner bounds are produced
  - the filled area matches the expected rectangle ring area

## Why

A closed `LWPOLYLINE` does not need a duplicated final vertex. For example, a closed rectangle is correctly represented by 4 vertices, with closure implied by the `closed` flag.

Because of that, the wide rendering path must explicitly handle the closing segment and construct a valid filled ring for closed geometry.

## Testing

- `pnpm jest packages/data-model/__tests__/AcDbPolyline.spec.ts --runInBand`
- `pnpm jest packages/data-model/__tests__/AcDbEntityConverter.spec.ts --runInBand`
- `pnpm eslint packages/data-model/src/entity/AcDbPolyline.ts packages/data-model/__tests__/AcDbPolyline.spec.ts`
