### PR TITLE
feat: introduce explicit draw order for solid hatches

### DIFF
--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -618,6 +618,7 @@ export abstract class AcDbEntity extends AcDbObject {
     traits.lineWeight = this.lineWeight
     traits.transparency = this.transparency
     traits.layer = this.layer
+    traits.drawOrder = 0
     if ('thickness' in this) {
       traits.thickness = this.thickness as number
     }

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -421,6 +421,7 @@ export class AcDbHatch extends AcDbEntity {
       patternAngle: this.patternAngle,
       definitionLines: this.definitionLines
     }
+    traits.drawOrder = -1
     const areas = this.buildAreasFromLoops()
     if (areas.length === 0) {
       return renderer.area(this._geo)

--- a/packages/graphic-interface/src/AcGiSubEntityTraits.ts
+++ b/packages/graphic-interface/src/AcGiSubEntityTraits.ts
@@ -65,4 +65,15 @@ export interface AcGiSubEntityTraits {
    * Corresponds to AutoCAD layer name (i.e. current layer in drawing).
    */
   layer: string
+
+  /**
+   * Explicit render-order tier used when different primitive types
+   * share the same Z plane.
+   *
+   * Lower values render earlier. The default `0` matches normal
+   * linework / text. Solid hatches use `-1` so they stay below
+   * outlines and text, while wide polylines keep `0` because they
+   * are visually linework even though they are rasterized as meshes.
+   */
+  drawOrder: number
 }


### PR DESCRIPTION
## Summary

This PR adds an explicit `drawOrder` trait to sub-entity rendering and uses it to keep solid hatches behind regular linework when entities share the same Z plane.

## Changes

- add `drawOrder` to `AcGiSubEntityTraits`
- set the default draw order to `0` in `AcDbEntity.worldDraw`
- assign solid hatch rendering a lower draw order (`-1`) in `AcDbHatch.subWorldDraw`

## Why

Previously, solid hatches and regular geometry on the same plane relied on implicit rendering behavior. That could cause filled areas to visually compete with outlines or text.

By introducing an explicit render-order hint:
- normal linework and text keep the default priority
- solid hatches render underneath them
- wide polylines can still remain treated as normal linework even if they are rasterized as meshes

## Impact

This change improves visual layering consistency for drawings that contain solid hatches and overlapping geometry on the same Z level.
