### PR TITLE
feat: expose editable runtime properties for dimension entities

### DIFF
--- a/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../../base'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbDimension } from './AcDbDimension'
 
 /**
@@ -123,6 +124,34 @@ export class AcDb3PointAngularDimension extends AcDbDimension {
   }
   set xLine2Point(value: AcGePoint3d) {
     this._xLine2Point.copy(value)
+  }
+
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties(
+              'centerPoint',
+              () => this.centerPoint
+            ),
+            ...this.createPoint3dProperties(
+              'xLine1Point',
+              () => this.xLine1Point
+            ),
+            ...this.createPoint3dProperties(
+              'xLine2Point',
+              () => this.xLine2Point
+            ),
+            ...this.createPoint3dProperties('arcPoint', () => this.arcPoint)
+          ]
+        }
+      ]
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
@@ -12,6 +12,7 @@ import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../../base'
 import { AcDbBlockTableRecord } from '../../database'
 import { AcDbBlockReference } from '../AcDbBlockReference'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbLine } from '../AcDbLine'
 import { AcDbMText } from '../AcDbMText'
 import { AcDbDimension } from './AcDbDimension'
@@ -266,6 +267,49 @@ export class AcDbAlignedDimension extends AcDbDimension {
     this._oblique = value
   }
 
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties(
+              'xLine1Point',
+              () => this.xLine1Point
+            ),
+            ...this.createPoint3dProperties(
+              'xLine2Point',
+              () => this.xLine2Point
+            ),
+            ...this.createPoint3dProperties(
+              'dimLinePoint',
+              () => this.dimLinePoint
+            ),
+            this.createProperty(
+              'rotation',
+              'float',
+              () => this.rotation,
+              (value: number) => {
+                this.rotation = value
+              }
+            ),
+            this.createProperty(
+              'oblique',
+              'float',
+              () => this.oblique,
+              (value: number) => {
+                this.oblique = value
+              }
+            )
+          ]
+        }
+      ]
+    }
+  }
+
   /**
    * @inheritdoc
    */
@@ -442,6 +486,10 @@ export class AcDbAlignedDimension extends AcDbDimension {
    */
   protected get dxfSubclassMarker() {
     return 'AcDbAlignedDimension'
+  }
+
+  protected override getMeasurementPropertyValue() {
+    return this.measurement ?? this.xLine1Point.distanceTo(this.xLine2Point)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../../base'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbDimension } from './AcDbDimension'
 
 /**
@@ -125,6 +126,34 @@ export class AcDbArcDimension extends AcDbDimension {
   }
   set xLine2Point(value: AcGePoint3d) {
     this._xLine2Point.copy(value)
+  }
+
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties(
+              'centerPoint',
+              () => this.centerPoint
+            ),
+            ...this.createPoint3dProperties(
+              'xLine1Point',
+              () => this.xLine1Point
+            ),
+            ...this.createPoint3dProperties(
+              'xLine2Point',
+              () => this.xLine2Point
+            ),
+            ...this.createPoint3dProperties('arcPoint', () => this.arcPoint)
+          ]
+        }
+      ]
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
@@ -11,6 +11,7 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../../base'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbLine } from '../AcDbLine'
 import { AcDbDimension } from './AcDbDimension'
 
@@ -152,12 +153,67 @@ export class AcDbDiametricDimension extends AcDbDimension {
     return this._leaderLength
   }
 
+  set leaderLength(value: number) {
+    this._leaderLength = value
+  }
+
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties(
+              'chordPoint',
+              () => this.chordPoint
+            ),
+            ...this.createPoint3dProperties(
+              'farChordPoint',
+              () => this.farChordPoint
+            ),
+            this.createProperty(
+              'leaderLength',
+              'float',
+              () => this.leaderLength,
+              (value: number) => {
+                this.leaderLength = value
+              }
+            ),
+            this.createProperty(
+              'extArcStartAngle',
+              'float',
+              () => this.extArcStartAngle,
+              (value: number) => {
+                this.extArcStartAngle = value
+              }
+            ),
+            this.createProperty(
+              'extArcEndAngle',
+              'float',
+              () => this.extArcEndAngle,
+              (value: number) => {
+                this.extArcEndAngle = value
+              }
+            )
+          ]
+        }
+      ]
+    }
+  }
+
   /**
    * @inheritdoc
    */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._chordPoint.applyMatrix4(matrix)
     this._farChordPoint.applyMatrix4(matrix)
+  }
+
+  protected override getMeasurementPropertyValue() {
+    return this.measurement ?? this.chordPoint.distanceTo(this.farChordPoint)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -22,6 +22,12 @@ import { AcDbRenderingCache } from '../../misc'
 import { AcDbOsnapMode } from '../../misc'
 import { AcDbBlockReference } from '../AcDbBlockReference'
 import { AcDbEntity } from '../AcDbEntity'
+import {
+  AcDbEntityProperties,
+  AcDbEntityPropertyGroup,
+  AcDbEntityPropertyType,
+  AcDbEntityRuntimeProperty
+} from '../AcDbEntityProperties'
 import { AcDbLine } from '../AcDbLine'
 
 /**
@@ -215,6 +221,7 @@ export abstract class AcDbDimension extends AcDbEntity {
    */
   set dimensionStyleName(value: string | null) {
     this._dimensionStyleName = value
+    this._dimStyle = undefined
   }
 
   /**
@@ -340,6 +347,17 @@ export abstract class AcDbDimension extends AcDbEntity {
    */
   set normal(value: AcGeVector3dLike) {
     this._normal.copy(value).normalize()
+  }
+
+  override get properties(): AcDbEntityProperties {
+    return this.getBaseProperties()
+  }
+
+  protected getBaseProperties(): AcDbEntityProperties {
+    return {
+      type: this.type,
+      groups: [this.getGeneralProperties(), this.getDimensionProperties()]
+    }
   }
 
   /**
@@ -478,6 +496,133 @@ export abstract class AcDbDimension extends AcDbEntity {
     return this.dimBlockId
       ? this.database.tables.blockTable.getAt(this.dimBlockId)
       : undefined
+  }
+
+  protected getDimensionProperties(): AcDbEntityPropertyGroup {
+    return {
+      groupName: 'dimension',
+      properties: [
+        this.createProperty(
+          'dimensionStyleName',
+          'string',
+          () => this.dimensionStyleName ?? '',
+          (value: string) => {
+            this.dimensionStyleName = value.trim() === '' ? null : value
+          }
+        ),
+        this.createProperty(
+          'dimensionText',
+          'string',
+          () => this.dimensionText ?? '',
+          (value: string) => {
+            this.dimensionText = value
+          }
+        ),
+        this.createProperty('measurement', 'float', () =>
+          this.getMeasurementPropertyValue()
+        ),
+        this.createProperty(
+          'dimBlockId',
+          'string',
+          () => this.dimBlockId ?? ''
+        ),
+        ...this.createPoint3dProperties(
+          'dimBlockPosition',
+          () => this.dimBlockPosition
+        ),
+        ...this.createPoint3dProperties(
+          'textPosition',
+          () => this.textPosition
+        ),
+        this.createProperty(
+          'textRotation',
+          'float',
+          () => this.textRotation,
+          (value: number) => {
+            this.textRotation = value
+          }
+        ),
+        this.createProperty(
+          'textLineSpacingFactor',
+          'float',
+          () => this.textLineSpacingFactor,
+          (value: number) => {
+            this.textLineSpacingFactor = value
+          }
+        ),
+        this.createProperty(
+          'textLineSpacingStyle',
+          'enum',
+          () => this.textLineSpacingStyle,
+          (value: AcDbLineSpacingStyle) => {
+            this.textLineSpacingStyle = value
+          },
+          [
+            {
+              label: AcDbLineSpacingStyle[AcDbLineSpacingStyle.AtLeast],
+              value: AcDbLineSpacingStyle.AtLeast
+            },
+            {
+              label: AcDbLineSpacingStyle[AcDbLineSpacingStyle.Exactly],
+              value: AcDbLineSpacingStyle.Exactly
+            }
+          ]
+        ),
+        ...this.createPoint3dProperties('normal', () => this.normal)
+      ]
+    }
+  }
+
+  protected createProperty<T>(
+    name: string,
+    type: AcDbEntityPropertyType,
+    get: () => T,
+    set?: (value: T) => void,
+    options?: { label: string; value: unknown }[]
+  ): AcDbEntityRuntimeProperty<T> {
+    return {
+      name,
+      type,
+      editable: set != null,
+      options,
+      accessor: set ? { get, set } : { get }
+    }
+  }
+
+  protected createPoint3dProperties(
+    prefix: string,
+    getPoint: () => AcGePoint3d
+  ): AcDbEntityRuntimeProperty<number>[] {
+    return [
+      this.createProperty(
+        `${prefix}X`,
+        'float',
+        () => getPoint().x,
+        (value: number) => {
+          getPoint().x = value
+        }
+      ),
+      this.createProperty(
+        `${prefix}Y`,
+        'float',
+        () => getPoint().y,
+        (value: number) => {
+          getPoint().y = value
+        }
+      ),
+      this.createProperty(
+        `${prefix}Z`,
+        'float',
+        () => getPoint().z,
+        (value: number) => {
+          getPoint().z = value
+        }
+      )
+    ]
+  }
+
+  protected getMeasurementPropertyValue(): number | undefined {
+    return this.measurement
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
@@ -6,6 +6,7 @@ import {
 } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../../base'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbDimension } from './AcDbDimension'
 
 /**
@@ -86,6 +87,29 @@ export class AcDbOrdinateDimension extends AcDbDimension {
   }
   set leaderEndPoint(value: AcGePoint3d) {
     this._leaderEndPoint.copy(value)
+  }
+
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties(
+              'definingPoint',
+              () => this.definingPoint
+            ),
+            ...this.createPoint3dProperties(
+              'leaderEndPoint',
+              () => this.leaderEndPoint
+            )
+          ]
+        }
+      ]
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
@@ -7,6 +7,7 @@ import {
 import { AcGiLineArrowStyle } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../../base'
+import { AcDbEntityProperties } from '../AcDbEntityProperties'
 import { AcDbLine } from '../AcDbLine'
 import { AcDbDimension } from './AcDbDimension'
 
@@ -246,6 +247,10 @@ export class AcDbRadialDimension extends AcDbDimension {
     return this._leaderLength
   }
 
+  set leaderLength(value: number) {
+    this._leaderLength = value
+  }
+
   /**
    * Sets the leader length.
    *
@@ -260,12 +265,60 @@ export class AcDbRadialDimension extends AcDbDimension {
     this._leaderLength = value
   }
 
+  override get properties(): AcDbEntityProperties {
+    const baseProperties = this.getBaseProperties()
+    return {
+      type: this.type,
+      groups: [
+        ...baseProperties.groups,
+        {
+          groupName: 'geometry',
+          properties: [
+            ...this.createPoint3dProperties('center', () => this.center),
+            ...this.createPoint3dProperties(
+              'chordPoint',
+              () => this.chordPoint
+            ),
+            this.createProperty(
+              'leaderLength',
+              'float',
+              () => this.leaderLength,
+              (value: number) => {
+                this.leaderLength = value
+              }
+            ),
+            this.createProperty(
+              'extArcStartAngle',
+              'float',
+              () => this.extArcStartAngle,
+              (value: number) => {
+                this.extArcStartAngle = value
+              }
+            ),
+            this.createProperty(
+              'extArcEndAngle',
+              'float',
+              () => this.extArcEndAngle,
+              (value: number) => {
+                this.extArcEndAngle = value
+              }
+            )
+          ]
+        }
+      ]
+    }
+  }
+
   /**
    * @inheritdoc
    */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._center.applyMatrix4(matrix)
     this._chordPoint.applyMatrix4(matrix)
+  }
+
+  protected override getMeasurementPropertyValue() {
+    return this.measurement ?? this.center.distanceTo(this.chordPoint)
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR adds runtime property metadata for dimension entities in the data model so their common and geometry-specific fields can be inspected and edited consistently.

### What changed

- add shared property helpers to `AcDbDimension`
- expose common dimension properties through the base `properties` getter
- add geometry property groups for:
  - `AcDbAlignedDimension`
  - `AcDbRadialDimension`
  - `AcDbDiametricDimension`
  - `AcDbOrdinateDimension`
  - `AcDbArcDimension`
  - `AcDb3PointAngularDimension`
- provide computed measurement fallback values for aligned, radial, and diametric dimensions when no explicit measurement is set
- reset cached dimension style data when `dimensionStyleName` changes
- make `leaderLength` editable for radial and diametric dimensions

## Why

These changes make dimension entities behave more consistently in runtime property panels or editor tooling, while also exposing subtype-specific geometry fields in a structured way.

## Notes

- common dimension fields are now centralized in the base class
- subtype classes only append their own geometry-specific property groups
- measurement exposure is more reliable for dimensions whose value can be derived directly from geometry