### PR TITLE
fix: propagate layer/color/lineType to INSERT ATTRIBs (#183)

### DIFF
--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -1,11 +1,43 @@
 import {
   AcDbArc,
+  AcDbAttribute,
+  AcDbBlockReference,
   AcDbCircle,
   AcDbDatabase,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
 
 import { AcDbEntityConverter } from '../src/AcDbEntitiyConverter'
+
+const baseAttrib = (overrides: Record<string, unknown> = {}) => ({
+  type: 'ATTRIB',
+  handle: 'A1',
+  layer: 'TAGS',
+  ownerBlockRecordSoftId: 'INSERT_HANDLE',
+  color: 0xff0000,
+  lineType: 'CONTINUOUS',
+  lineweight: 25,
+  lineTypeScale: 1,
+  text: {
+    text: 'ROOM-101',
+    styleName: 'STANDARD',
+    textHeight: 2.5,
+    startPoint: { x: 10, y: 20, z: 0 },
+    rotation: 0,
+    obliqueAngle: 0,
+    thickness: 0,
+    halign: 0,
+    valign: 0,
+    xScale: 1
+  },
+  tag: 'COMODO',
+  fieldLength: 0,
+  flags: 0,
+  mtextFlag: 0,
+  lockPositionFlag: false,
+  isReallyLocked: false,
+  ...overrides
+})
 
 describe('libredwg AcDbEntityConverter', () => {
   it('converts ARC/CIRCLE OCS centers into WCS when extrusion points to -Z', () => {
@@ -38,5 +70,78 @@ describe('libredwg AcDbEntityConverter', () => {
     expect(dbArc.startPoint).toMatchObject({ x: -2, y: 2, z: 0 })
     expect(dbArc.endPoint).toMatchObject({ x: -1, y: 3, z: 0 })
     expect(dbCircle.center).toMatchObject({ x: -1, y: 2, z: 0 })
+  })
+
+  describe('ATTRIB common attribute propagation (issue #183 follow-up)', () => {
+    beforeEach(() => {
+      acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    })
+
+    it('routes a top-level ATTRIB through convert() so common attrs are set', () => {
+      const converter = new AcDbEntityConverter()
+      const dbAttrib = converter.convert(baseAttrib() as any)
+
+      expect(dbAttrib).toBeInstanceOf(AcDbAttribute)
+      const attr = dbAttrib as AcDbAttribute
+      // Common attrs from processCommonAttrs
+      expect(attr.layer).toBe('TAGS')
+      expect(attr.objectId).toBe('A1')
+      expect(attr.ownerId).toBe('INSERT_HANDLE')
+      expect(attr.lineType).toBe('CONTINUOUS')
+      expect(attr.lineWeight).toBe(25)
+      // ATTRIB-specific attrs from convertAttributeCommon
+      expect(attr.tag).toBe('COMODO')
+      expect(attr.textString).toBe('ROOM-101')
+      expect(attr.styleName).toBe('STANDARD')
+      expect(attr.height).toBe(2.5)
+    })
+
+    it('appends ATTRIBs of an INSERT through convert() preserving common attrs', () => {
+      const converter = new AcDbEntityConverter()
+      const dbInsert = converter.convert({
+        type: 'INSERT',
+        handle: 'INSERT_HANDLE',
+        layer: 'BLOCKS',
+        ownerBlockRecordSoftId: 'MS',
+        name: 'CARIMBO',
+        insertionPoint: { x: 0, y: 0, z: 0 },
+        xScale: 1,
+        yScale: 1,
+        zScale: 1,
+        rotation: 0,
+        extrusionDirection: { x: 0, y: 0, z: 1 },
+        attribs: [
+          baseAttrib({ handle: 'A1', tag: 'COMODO', layer: 'TAGS' }),
+          baseAttrib({
+            handle: 'A2',
+            tag: 'AREA',
+            layer: 'AREAS',
+            color: 0x00ff00,
+            text: {
+              ...(baseAttrib().text as any),
+              text: '23.45 m2'
+            }
+          })
+        ]
+      } as any) as AcDbBlockReference
+
+      expect(dbInsert).toBeInstanceOf(AcDbBlockReference)
+      const attrs = Array.from(dbInsert.attributeIterator())
+      expect(attrs.length).toBe(2)
+      // Each ATTRIB carries its OWN layer/color (not inherited from INSERT),
+      // so per-attrib layer toggles can take effect downstream.
+      const tag = attrs.find(a => a.tag === 'COMODO') as AcDbAttribute
+      const area = attrs.find(a => a.tag === 'AREA') as AcDbAttribute
+      expect(tag.layer).toBe('TAGS')
+      expect(area.layer).toBe('AREAS')
+      // Each ATTRIB has its own DWG handle (objectId), so they don't collide
+      // in `_attribs` Map keyed by objectId.
+      expect(tag.objectId).toBe('A1')
+      expect(area.objectId).toBe('A2')
+      // ATTRIB.ownerId points at the INSERT, not at the BTR — matches
+      // ObjectARX semantics.
+      expect(tag.ownerId).toBe('INSERT_HANDLE')
+      expect(area.ownerId).toBe('INSERT_HANDLE')
+    })
   })
 })

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -123,6 +123,8 @@ export class AcDbEntityConverter {
       return this.convertArc(entity as DwgArcEntity)
     } else if (entity.type == 'ATTDEF') {
       return this.convertAttributeDefinition(entity as DwgAttdefEntity)
+    } else if (entity.type == 'ATTRIB') {
+      return this.convertAttribute(entity as DwgAttribEntity)
     } else if (entity.type == 'CIRCLE') {
       return this.convertCirle(entity as DwgCircleEntity)
     } else if (entity.type == 'DIMENSION') {
@@ -842,10 +844,25 @@ export class AcDbEntityConverter {
     dbBlockReference.scaleFactors.z = blockReference.zScale
     dbBlockReference.rotation = blockReference.rotation
     dbBlockReference.normal.copy(blockReference.extrusionDirection)
+    // Pre-assign the BlockReference's objectId from the DWG handle so that
+    // `appendAttributes` below (which sets `attrib.ownerId = this.objectId`)
+    // produces a valid ownerId pointing at this INSERT, matching ObjectARX
+    // semantics. Without this, ownerId would be assigned undefined here and
+    // only later when `processCommonAttrs` runs on the returned BlockReference.
+    if (blockReference.handle != null) {
+      dbBlockReference.objectId = blockReference.handle
+    }
     if (blockReference.attribs) {
       blockReference.attribs.forEach(attrib => {
-        const dbAttrib = this.convertAttribute(attrib)
-        dbBlockReference.appendAttributes(dbAttrib)
+        // Route through `convert()` rather than `convertAttribute()` so
+        // `processCommonAttrs` runs and the AcDbAttribute receives its
+        // layer / color / objectId / lineType / lineWeight / linetypeScale
+        // from the DWG. Without this, ATTRIBs render with default styling
+        // and cannot be addressed individually by per-layer toggles.
+        const dbAttrib = this.convert(attrib)
+        if (dbAttrib instanceof AcDbAttribute) {
+          dbBlockReference.appendAttributes(dbAttrib)
+        }
       })
     }
     return dbBlockReference


### PR DESCRIPTION
## Summary                                                                                                                                                                
                                                                                                                                                                            
  Follow-up to #183. After the libredwg-web fixes (PRs #10/#11) made ATTRIBs reach the data-model, they were rendering with default styling because `AcDbEntityConverter.convertBlockReference` was calling the private `convertAttribute(...)` directly, which bypassed `processCommonAttrs`. As a result, every `AcDbAttribute` had:                                                                                                             
                                                                                                                                                                            
  - empty `objectId` (so multiple ATTRIBs of the same INSERT collided in the `_attribs` Map keyed by objectId),                                                                                                                                  
  - empty `layer` (defaulting to layer "0"),          
  - no `color`, `lineType`, `lineWeight`, or `linetypeScale` set.
                                                                   
  This made ATTRIBs visually inconsistent with AutoCAD: wrong color, wrong layer, wrong linetype, and `_attribs` losing entries by handle collision.                                                                                                                                                                
                                                                                                                                                                            
  ### Changes                                                                                                                                                               
                                                                                                                                                                            
  - `AcDbEntityConverter.createEntity`: dispatch `'ATTRIB'` to `convertAttribute` so a top-level ATTRIB also goes through `convert()` and receives `processCommonAttrs`.                                                                                                                                      
  - `AcDbEntityConverter.convertBlockReference`: route ATTRIBs through `convert(attrib)` (the public entry point) instead of `convertAttribute(attrib)` (private), so each ATTRIB receives its layer / color / lineType / lineWeight / linetypeScale / objectId from the DWG.                                                                                                                                                                
  - Pre-assign the BlockReference's `objectId` from the DWG handle before the attribs loop, so that `appendAttributes` (which sets `attrib.ownerId = this.objectId`) produces a valid ownerId pointing at the INSERT — matching ObjectARX semantics.                                                                                                                           
                                                                                                                                                                            
  Selectability of individual ATTRIBs and per-attrib **color** toggle of their layer are tracked separately as a follow-up (visibility toggle already works through the existing per-layer enumeration). Text alignment / typography of centered ATTRIBs (e.g. the "P5" / "M1" tags inside ellipses) is also tracked separately.                                                                                                                              
                                                                                                                                                                            
  ## Test plan                                                                                                                                                              
                                                                                                                                                                            
  - [x] New unit tests in `__tests__/AcDbEntitiyConverter.spec.ts`:                                                                                                         
    - top-level ATTRIB through `convert()` carries the common attrs
    - INSERT with multiple ATTRIBs preserves each ATTRIB's own layer and handle (no collision in `_attribs`)                                                                                                                                   
  - [x] Existing data-model & libredwg-converter test suites still pass (`pnpm jest --testPathPattern="data-model|libredwg-converter"`)                                                                                                         
  - [x] Visual validation with `arquivo-test-defpoints.dwg` (DWG BR AC1015/R_2000): ATTRIBs of `CARIMBO`, `Nomesc`, `Area`, `D5` now render with the correct font, color, and layer. 