### PR TITLE
feat: add gradient hatch support

### DIFF
--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -10,7 +10,12 @@ import {
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbHatch, AcDbHatchPatternType, AcDbHatchStyle } from '../src/entity'
+import {
+  AcDbHatch,
+  AcDbHatchObjectType,
+  AcDbHatchPatternType,
+  AcDbHatchStyle
+} from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const createWorkingDb = () => {
@@ -190,6 +195,38 @@ describe('AcDbHatch', () => {
     expect(multiRenderer.group).toHaveBeenCalledTimes(1)
     expect(multiDraw.kind).toBe('group')
     expect(multiDraw.entities).toHaveLength(2)
+  })
+
+  it('passes gradient hatch settings to graphics traits', () => {
+    const hatch = new AcDbHatch()
+    hatch.hatchObjectType = AcDbHatchObjectType.GradientObject
+    hatch.gradientName = 'SPHERICAL'
+    hatch.gradientAngle = Math.PI / 3
+    hatch.gradientShift = 0.2
+    hatch.gradientOneColorMode = true
+    hatch.shadeTintValue = 0.6
+    hatch.gradientStartColor = 0x112233
+    hatch.gradientEndColor = 0x445566
+    hatch.add(createRectLoop(0, 0, 3, 2))
+
+    const renderer = {
+      subEntityTraits: {} as Record<string, unknown>,
+      area: jest.fn((area: unknown) => ({ kind: 'area', area })),
+      group: jest.fn()
+    }
+    hatch.subWorldDraw(renderer as never)
+
+    expect(renderer.subEntityTraits.fillType).toMatchObject({
+      gradient: {
+        name: 'SPHERICAL',
+        angle: Math.PI / 3,
+        shift: 0.2,
+        oneColorMode: true,
+        shadeTintValue: 0.6,
+        startColor: 0x112233,
+        endColor: 0x445566
+      }
+    })
   })
 
   it('transformBy updates loops, elevation, pattern angle/scale and handles zero-length x-axis', () => {

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mlightcad/common": "workspace:*",
-    "@mlightcad/dxf-json": "1.1.3",
+    "@mlightcad/dxf-json": "../../../dxf-json",
     "@mlightcad/geometry-engine": "workspace:*",
     "@mlightcad/graphic-interface": "workspace:*",
     "iconv-lite": "^0.7.0",

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mlightcad/common": "workspace:*",
-    "@mlightcad/dxf-json": "../../../dxf-json",
+    "@mlightcad/dxf-json": "^1.1.4",
     "@mlightcad/geometry-engine": "workspace:*",
     "@mlightcad/graphic-interface": "workspace:*",
     "iconv-lite": "^0.7.0",

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -661,10 +661,20 @@ export class AcDbEntityConverter {
     if (hatch.gradientFlag) {
       const gradientHatch = hatch as GradientHatchEntity
       dbEntity.hatchObjectType = AcDbHatchObjectType.GradientObject
+      dbEntity.gradientName = gradientHatch.gradientName
       dbEntity.gradientAngle = gradientHatch.gradientRotation ?? 0
       dbEntity.gradientShift = gradientHatch.gradientDefinition ?? 0
       dbEntity.gradientOneColorMode = gradientHatch.gradientColorFlag == 1
       dbEntity.shadeTintValue = gradientHatch.colorTint ?? 0
+      if (gradientHatch.gradientColors) {
+        const length = gradientHatch.gradientColors.length
+        if (length > 1) {
+          dbEntity.gradientStartColor = gradientHatch.gradientColors[0].rgb
+          dbEntity.gradientEndColor = gradientHatch.gradientColors[1].rgb
+        } else if (length > 0) {
+          dbEntity.gradientStartColor = gradientHatch.gradientColors[0].rgb
+        }
+      }
     }
     return dbEntity
   }

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -4,6 +4,7 @@ import {
   AttdefEntity,
   AttributeEntity,
   FaceEntity,
+  GradientHatchEntity,
   HatchSolidFill,
   SmoothType,
   VertexFlag
@@ -85,6 +86,7 @@ import {
   AcDbEntity,
   AcDbFace,
   AcDbHatch,
+  AcDbHatchObjectType,
   AcDbHatchPatternType,
   AcDbHatchStyle,
   AcDbLeader,
@@ -651,6 +653,19 @@ export class AcDbEntityConverter {
         }
       }
     })
+
+    // Handle gradient fill properties
+    // The meaning of gradientFlag is as follows.
+    // - 0: Solid hatch
+    // - 1: Gradient
+    if (hatch.gradientFlag) {
+      const gradientHatch = hatch as GradientHatchEntity
+      dbEntity.hatchObjectType = AcDbHatchObjectType.GradientObject
+      dbEntity.gradientAngle = gradientHatch.gradientRotation ?? 0
+      dbEntity.gradientShift = gradientHatch.gradientDefinition ?? 0
+      dbEntity.gradientOneColorMode = gradientHatch.gradientColorFlag == 1
+      dbEntity.shadeTintValue = gradientHatch.colorTint ?? 0
+    }
     return dbEntity
   }
 

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -184,6 +184,10 @@ export class AcDbHatch extends AcDbEntity {
   private _gradientShift: number
   /**The one-color tint shade (luminance) value. */
   private _shadeTintValue: number
+  /** Optional start color for gradient fill, stored as packed 0xRRGGBB. */
+  private _gradientStartColor?: number
+  /** Optional end color for gradient fill, stored as packed 0xRRGGBB. */
+  private _gradientEndColor?: number
   /** The type of the gradient pattern. */
   private _gradientType: AcDbGradientPatternType
   /** The name of the current gradient. */
@@ -224,6 +228,8 @@ export class AcDbHatch extends AcDbEntity {
     this._gradientAngle = 0
     this._gradientShift = 0
     this._shadeTintValue = 0
+    this._gradientStartColor = undefined
+    this._gradientEndColor = undefined
     this._gradientType = AcDbGradientPatternType.PreDefinedGradient
     this._gradientName = ''
     this._gradientOneColorMode = false
@@ -434,6 +440,36 @@ export class AcDbHatch extends AcDbEntity {
   }
 
   /**
+   * Gets the optional first gradient color as a packed RGB value.
+   */
+  get gradientStartColor() {
+    return this._gradientStartColor
+  }
+
+  /**
+   * Sets the optional first gradient color as a packed RGB value.
+   */
+  set gradientStartColor(value: number | undefined) {
+    this._gradientStartColor =
+      value == null || !Number.isFinite(value) ? undefined : value & 0xffffff
+  }
+
+  /**
+   * Gets the optional second gradient color as a packed RGB value.
+   */
+  get gradientEndColor() {
+    return this._gradientEndColor
+  }
+
+  /**
+   * Sets the optional second gradient color as a packed RGB value.
+   */
+  set gradientEndColor(value: number | undefined) {
+    this._gradientEndColor =
+      value == null || !Number.isFinite(value) ? undefined : value & 0xffffff
+  }
+
+  /**
    * Append one loop to loops of this area. If it is the first loop added, it is the outter loop.
    * Otherwise, it is an inner loop.
    * @param loop Input the loop to append
@@ -601,7 +637,18 @@ export class AcDbHatch extends AcDbEntity {
     traits.fillType = {
       solidFill: this.isSolidFill,
       patternAngle: this.patternAngle,
-      definitionLines: this.definitionLines
+      definitionLines: this.definitionLines,
+      gradient: this.isGradient
+        ? {
+            name: this.gradientName,
+            angle: this.gradientAngle,
+            shift: this.gradientShift,
+            oneColorMode: this.gradientOneColorMode,
+            shadeTintValue: this.shadeTintValue,
+            startColor: this.gradientStartColor,
+            endColor: this.gradientEndColor
+          }
+        : undefined
     }
     traits.drawOrder = -1
     const areas = this.buildAreasFromLoops()
@@ -640,7 +687,9 @@ export class AcDbHatch extends AcDbEntity {
     const origin = new AcGePoint3d().applyMatrix4(matrix)
     const xVector = new AcGePoint3d(xAxis).sub(origin)
     if (xVector.length() > 0) {
-      this._patternAngle += Math.atan2(xVector.y, xVector.x)
+      const rotation = Math.atan2(xVector.y, xVector.x)
+      this._patternAngle += rotation
+      this._gradientAngle += rotation
       this._patternScale *= xVector.length()
     }
     return this

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -80,6 +80,42 @@ export enum AcDbHatchStyle {
   Ignore = 2
 }
 
+export enum AcDbHatchObjectType {
+  /**
+   * Indicates that the object is currently a classic hatch
+   */
+  HatchObject = 0,
+  /**
+   * Indicates that the object is currently a color gradient
+   */
+  GradientObject = 1
+}
+
+export type AcDbGradientName =
+  | 'LINEAR'
+  | 'CYLINDER'
+  | 'INVCYLINDER'
+  | 'SPHERICAL'
+  | 'INVSPHERICAL'
+  | 'HEMISPHERICAL'
+  | 'INVHEMISPHERICAL'
+  | 'CURVED'
+  | 'INVCURVED'
+
+/**
+ * Defines the gradient pattern type for hatch.
+ */
+export enum AcDbGradientPatternType {
+  /**
+   * Indicates that the gradient name refers to one of the predefined gradient patterns
+   */
+  PreDefinedGradient = 0,
+  /**
+   * Indicates that the gradient name refers to one of the user-defined gradient patterns.
+   */
+  UserDefinedGradient = 1
+}
+
 /**
  * Represents a hatch entity in AutoCAD.
  *
@@ -135,6 +171,29 @@ export class AcDbHatch extends AcDbEntity {
   private _patternScale: number
   /** The hatch style for determining which areas to hatch */
   private _hatchStyle: AcDbHatchStyle
+  /**
+   * The current state of the gradient object.
+   */
+  private _hatchObjectType: AcDbHatchObjectType
+  /** The angle, in radians, at which the current gradient definition is applied. */
+  private _gradientAngle: number = 0
+  /**
+   * The current interpolation value between the gradient definition's default and shifted
+   * values. The default is 0.0f.
+   */
+  private _gradientShift: number
+  /**The one-color tint shade (luminance) value. */
+  private _shadeTintValue: number
+  /** The type of the gradient pattern. */
+  private _gradientType: AcDbGradientPatternType
+  /** The name of the current gradient. */
+  private _gradientName: string
+  /**
+   * Indicates whether the gradient hatch is transitioning from a start to a stop color (two-color)
+   * or from a color to an adjusted luminance version of the same color (one-color). In the latter
+   * case, the full luminance version is the "tint" and the zero luminance version is the "shade."
+   */
+  private _gradientOneColorMode: boolean
 
   /**
    * Creates a new hatch entity.
@@ -161,6 +220,27 @@ export class AcDbHatch extends AcDbEntity {
     this._patternAngle = 0
     this._patternScale = 1
     this._hatchStyle = AcDbHatchStyle.Normal
+    this._hatchObjectType = AcDbHatchObjectType.HatchObject
+    this._gradientAngle = 0
+    this._gradientShift = 0
+    this._shadeTintValue = 0
+    this._gradientType = AcDbGradientPatternType.PreDefinedGradient
+    this._gradientName = ''
+    this._gradientOneColorMode = false
+  }
+
+  /**
+   * Gets whether the hatch object is currently a gradient object.
+   */
+  get isGradient() {
+    return this._hatchObjectType === AcDbHatchObjectType.GradientObject
+  }
+
+  /**
+   * Gets whether the hatch object is currently using a hatched pattern.
+   */
+  get isHatch() {
+    return this._hatchObjectType === AcDbHatchObjectType.HatchObject
   }
 
   /**
@@ -249,6 +329,108 @@ export class AcDbHatch extends AcDbEntity {
   }
   set elevation(value: number) {
     this._elevation = value
+  }
+
+  /**
+   * Gets the current state of the gradient object.
+   */
+  get hatchObjectType(): AcDbHatchObjectType {
+    return this._hatchObjectType
+  }
+  /**
+   * Sets the current state of the gradient object.
+   */
+  set hatchObjectType(value: AcDbHatchObjectType) {
+    this._hatchObjectType = value
+  }
+
+  /**
+   * Gets the angle, in radians, at which the current gradient definition is applied.
+   */
+  get gradientAngle() {
+    return this._gradientAngle
+  }
+
+  /**
+   * Sets the angle, in radians, at which the current gradient definition is applied.
+   */
+  set gradientAngle(value: number) {
+    this._gradientAngle = value
+  }
+
+  /**
+   * Gets the current interpolation value between the gradient definition's default and shifted
+   * values. The default is 0.0f.
+   */
+  get gradientShift() {
+    return this._gradientShift
+  }
+
+  /**
+   * Sets the current interpolation value between the gradient definition's default and shifted
+   * values. The default is 0.0f.
+   */
+  set gradientShift(value: number) {
+    this._gradientShift = value
+  }
+
+  /**
+   * Gets the type of the gradient pattern.
+   */
+  get gradientType() {
+    return this._gradientType
+  }
+
+  /**
+   * Sets the type of the gradient pattern.
+   */
+  set gradientType(value: AcDbGradientPatternType) {
+    this._gradientType = value
+  }
+
+  /**
+   * Gets the name of the current gradient.
+   */
+  get gradientName() {
+    return this._gradientName
+  }
+
+  /**
+   * Sets the name of the current gradient.
+   */
+  set gradientName(value: string) {
+    this._gradientName = value
+  }
+
+  /**
+   * Gets whether the gradient hatch is transitioning from a start to a stop color (two-color).
+   */
+  get gradientOneColorMode() {
+    return this._gradientOneColorMode
+  }
+
+  /**
+   * Sets whether the gradient hatch is transitioning from a start to a stop color (two-color)
+   * or from a color to an adjusted luminance version of the same color (one-color). In the latter
+   * case, the full luminance version is the "tint" and the zero luminance version is the "shade."
+   */
+  set gradientOneColorMode(value: boolean) {
+    this._gradientOneColorMode = value
+  }
+
+  /**
+   * Gets the one-color tint shade (luminance) value.
+   */
+  get shadeTintValue() {
+    return this._shadeTintValue
+  }
+
+  /**
+   * Sets the one-color tint shade (luminance) value. If the gradient is using one-color mode,
+   * this function sets the luminance value applied to the first color.
+   */
+  set shadeTintValue(value: number) {
+    this._shadeTintValue = value
   }
 
   /**
@@ -588,6 +770,15 @@ export class AcDbHatch extends AcDbEntity {
       filer.writeInt16(79, line.dashLengths.length)
       line.dashLengths.forEach(length => filer.writeDouble(49, length))
     })
+    // Gradient fill parameters
+    if (this.isGradient) {
+      filer.writeInt16(450, this._hatchObjectType)
+      filer.writeInt16(451, 0)
+      filer.writeInt16(452, this._gradientOneColorMode ? 1 : 0)
+      filer.writeAngle(460, this._gradientAngle)
+      filer.writeDouble(461, this._gradientShift)
+      filer.writeString(470, this._gradientName)
+    }
     // TODO: Write the number of seed points
     filer.writeInt16(98, 0)
     return this

--- a/packages/graphic-interface/src/AcGiHatchStyle.ts
+++ b/packages/graphic-interface/src/AcGiHatchStyle.ts
@@ -7,6 +7,16 @@ export interface AcGiHatchPatternLine {
   dashLengths: number[]
 }
 
+export interface AcGiHatchGradientStyle {
+  name: string
+  angle: number
+  shift: number
+  oneColorMode: boolean
+  shadeTintValue: number
+  startColor?: number
+  endColor?: number
+}
+
 /**
  * Hatch style
  */
@@ -14,4 +24,5 @@ export interface AcGiHatchStyle {
   solidFill: boolean
   patternAngle: number
   definitionLines: AcGiHatchPatternLine[]
+  gradient?: AcGiHatchGradientStyle
 }

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "0.7.0"
+    "@mlightcad/libredwg-web": "^0.7.1"
   },
   "devDependencies": {
     "vite": "^5.2.10"

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -17,6 +17,7 @@ import {
   AcDbEntity,
   AcDbFace,
   AcDbHatch,
+  AcDbHatchObjectType,
   AcDbHatchPatternType,
   AcDbHatchStyle,
   AcDbLeader,
@@ -77,6 +78,7 @@ import type {
   DwgEllipseEdge,
   DwgEllipseEntity,
   DwgEntity,
+  DwgGradientHatchEntity,
   DwgHatchEntity,
   DwgImageEntity,
   DwgInsertEntity,
@@ -560,6 +562,28 @@ export class AcDbEntityConverter {
         }
       }
     })
+    // Handle gradient fill properties
+    // The meaning of gradientFlag is as follows.
+    // - 0: Solid hatch
+    // - 1: Gradient
+    if (hatch.gradientFlag) {
+      const gradientHatch = hatch as DwgGradientHatchEntity
+      dbEntity.hatchObjectType = AcDbHatchObjectType.GradientObject
+      dbEntity.gradientName = gradientHatch.gradientName
+      dbEntity.gradientAngle = gradientHatch.gradientRotation ?? 0
+      dbEntity.gradientShift = gradientHatch.gradientDefinition ?? 0
+      dbEntity.gradientOneColorMode = gradientHatch.gradientColorFlag == 1
+      dbEntity.shadeTintValue = gradientHatch.colorTint ?? 0
+      if (gradientHatch.gradientColors) {
+        const length = gradientHatch.gradientColors.length
+        if (length > 1) {
+          dbEntity.gradientStartColor = gradientHatch.gradientColors[0].rgb
+          dbEntity.gradientEndColor = gradientHatch.gradientColors[1].rgb
+        } else if (length > 0) {
+          dbEntity.gradientStartColor = gradientHatch.gradientColors[0].rgb
+        }
+      }
+    }
     return dbEntity
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: workspace:*
         version: link:../data-model
       '@mlightcad/libredwg-web':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: ^0.7.1
+        version: 0.7.1
     devDependencies:
       vite:
         specifier: ^5.2.10
@@ -1383,8 +1383,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.0':
-    resolution: {integrity: sha512-x58HIOaRGskAk143hhJwuT8Gw2Gker7qLfrHFJZsNrSSpD7wLwuuZIdfGD0VZMlzq2/PmQoTJFKqIM4Qp+ptJw==}
+  '@mlightcad/libredwg-web@0.7.1':
+    resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6274,7 +6274,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.0': {}
+  '@mlightcad/libredwg-web@0.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@mlightcad/dxf-json':
-        specifier: 1.1.3
-        version: 1.1.3
+        specifier: ../../../dxf-json
+        version: link:../../../dxf-json
       '@mlightcad/geometry-engine':
         specifier: workspace:*
         version: link:../geometry-engine
@@ -1230,9 +1230,6 @@ packages:
     resolution: {integrity: sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fxts/core@1.26.0':
-    resolution: {integrity: sha512-ONaza1CGr8dLKmJ0HQgi0h4XuyDJMr0P70M7o/My/YeeRxuYoSANHjE2nSY7xO4WHgxUD5ojd5dpxlFOzAEJsA==}
-
   '@gerrit0/mini-shiki@1.24.2':
     resolution: {integrity: sha512-kw11jMCKwS5+GMMDy/o7W6C1KwsxgHnPO/RXzNBUw000BzRvUhUSi5zE8D2Qq7/A7bfJysFenEVBHUR7aMSxUQ==}
 
@@ -1377,9 +1374,6 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.1.3':
-    resolution: {integrity: sha512-XslMIrowLI9VOs84/x4SmcsKSdNxSSGyEVrhJTFiSsB3CghtU2tzOmvDoCHCPa4jYCmYkQ1GK/rgQ+89wXXPgw==}
-
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
@@ -1453,24 +1447,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1516,36 +1514,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.0':
     resolution: {integrity: sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.0':
     resolution: {integrity: sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==}
@@ -1601,46 +1605,55 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -1698,24 +1711,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.13':
     resolution: {integrity: sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.13':
     resolution: {integrity: sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.13':
     resolution: {integrity: sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.13':
     resolution: {integrity: sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==}
@@ -5989,10 +6006,6 @@ snapshots:
     dependencies:
       levn: 0.4.1
 
-  '@fxts/core@1.26.0':
-    dependencies:
-      tslib: 2.6.3
-
   '@gerrit0/mini-shiki@1.24.2':
     dependencies:
       '@shikijs/engine-oniguruma': 1.24.1
@@ -6267,10 +6280,6 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-
-  '@mlightcad/dxf-json@1.1.3':
-    dependencies:
-      '@fxts/core': 1.26.0
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@mlightcad/dxf-json':
-        specifier: ../../../dxf-json
-        version: link:../../../dxf-json
+        specifier: ^1.1.4
+        version: 1.1.4
       '@mlightcad/geometry-engine':
         specifier: workspace:*
         version: link:../geometry-engine
@@ -1230,6 +1230,9 @@ packages:
     resolution: {integrity: sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fxts/core@1.26.0':
+    resolution: {integrity: sha512-ONaza1CGr8dLKmJ0HQgi0h4XuyDJMr0P70M7o/My/YeeRxuYoSANHjE2nSY7xO4WHgxUD5ojd5dpxlFOzAEJsA==}
+
   '@gerrit0/mini-shiki@1.24.2':
     resolution: {integrity: sha512-kw11jMCKwS5+GMMDy/o7W6C1KwsxgHnPO/RXzNBUw000BzRvUhUSi5zE8D2Qq7/A7bfJysFenEVBHUR7aMSxUQ==}
 
@@ -1374,6 +1377,9 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mlightcad/dxf-json@1.1.4':
+    resolution: {integrity: sha512-1Vo0g5La4JEHEyA3ayZx/5fHMIGYbcc6FM/4plNP9nF7803IdcvAzXrNHN/ddnv41mRqPy8awF0TvJBqRTe1xg==}
+
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
@@ -1447,28 +1453,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1514,42 +1516,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.0':
     resolution: {integrity: sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.0':
     resolution: {integrity: sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==}
@@ -1605,55 +1601,46 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -1711,28 +1698,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.13':
     resolution: {integrity: sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.13':
     resolution: {integrity: sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.13':
     resolution: {integrity: sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.13':
     resolution: {integrity: sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==}
@@ -6006,6 +5989,10 @@ snapshots:
     dependencies:
       levn: 0.4.1
 
+  '@fxts/core@1.26.0':
+    dependencies:
+      tslib: 2.6.3
+
   '@gerrit0/mini-shiki@1.24.2':
     dependencies:
       '@shikijs/engine-oniguruma': 1.24.1
@@ -6280,6 +6267,10 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mlightcad/dxf-json@1.1.4':
+    dependencies:
+      '@fxts/core': 1.26.0
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 


### PR DESCRIPTION
## Summary

- Add gradient hatch metadata to `AcDbHatch`, including gradient object type, name, angle, shift, tint, one-color mode, and start/end colors.
- Pass gradient hatch settings through graphics traits so renderers can consume gradient fill data.
- Convert gradient hatch properties from DXF/DWG input into `AcDbHatch`.
- Update DXF/DWG parser dependencies to versions that expose gradient hatch data.
- Add test coverage for forwarding gradient hatch settings to graphics traits.