### PR TITLE
fix: fix issue # 243 in cad-viewer

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
@@ -2,6 +2,8 @@ import { AcDbDxfParser } from '../src/converter/AcDbDxfParser'
 import { AcDbDxfConverter } from '../src/converter/AcDbDxfConverter'
 import { AcDbDxfFiler } from '../src/base/AcDbDxfFiler'
 import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbBlockReference } from '../src/entity/AcDbBlockReference'
+import { AcDbBlockTableRecord } from '../src/database/AcDbBlockTableRecord'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
 
@@ -20,6 +22,18 @@ class TestDxfConverter extends AcDbDxfConverter {
 
   processCommonTableEntryAttrsPublic(entry: any, dbEntry: any) {
     return (this as any).processCommonTableEntryAttrs(entry, dbEntry)
+  }
+
+  processEntitiesInBlockPublic(
+    entities: any[],
+    blockTableRecord: AcDbBlockTableRecord,
+    checkOwner?: boolean
+  ) {
+    return (this as any).processEntitiesInBlock(
+      entities,
+      blockTableRecord,
+      checkOwner
+    )
   }
 }
 
@@ -105,5 +119,53 @@ describe('AcDbDxfConverter', () => {
     expect(record.ownerId).toBe(layerTable.objectId)
     expect(() => layerTable.dxfOut(filer)).not.toThrow()
     expect(() => record.dxfOut(filer)).not.toThrow()
+  })
+
+  it('attaches ATTRIB entities to INSERTs converted in the same block record', async () => {
+    const database = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = database
+
+    const blockTableRecord = new AcDbBlockTableRecord()
+    blockTableRecord.objectId = 'BTR1'
+    blockTableRecord.name = '*Paper_Space'
+    database.tables.blockTable.add(blockTableRecord)
+
+    const converter = new TestDxfConverter({ useWorker: false })
+
+    await converter.processEntitiesInBlockPublic(
+      [
+        {
+          type: 'INSERT',
+          handle: 'I1',
+          ownerBlockRecordSoftId: 'BTR1',
+          layer: 'Viewport',
+          name: 'TITLE_BLOCK',
+          insertionPoint: { x: 10, y: 20, z: 0 }
+        },
+        {
+          type: 'ATTRIB',
+          handle: 'A1',
+          ownerBlockRecordSoftId: 'I1',
+          layer: 'CARTOUCHE',
+          text: 'OPTICAL MODULE SUPPORT',
+          textHeight: 2.5,
+          startPoint: { x: 12, y: 22, z: 0 },
+          rotation: 0,
+          tag: 'TITLE',
+          textStyle: 'STANDARD',
+          horizontalJustification: 0,
+          verticalJustification: 0,
+          scale: 1
+        }
+      ],
+      blockTableRecord
+    )
+
+    const insert = blockTableRecord.getIdAt('I1') as AcDbBlockReference
+    const attributes = [...insert.attributeIterator()]
+
+    expect(attributes).toHaveLength(1)
+    expect(attributes[0].ownerId).toBe('I1')
+    expect(attributes[0].textString).toBe('OPTICAL MODULE SUPPORT')
   })
 })

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -6,8 +6,9 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
-import { AcDbDatabase } from '../src/database'
-import { AcDbTable } from '../src/entity'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import { AcDbMText, AcDbTable } from '../src/entity'
+import { AcDbRenderingCache } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const createGiEntity = () => {
@@ -54,6 +55,10 @@ const setWorkingDb = () => {
 }
 
 describe('AcDbTable', () => {
+  beforeEach(() => {
+    AcDbRenderingCache.instance.clear()
+  })
+
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbTable('TEST', 1, 1))
   })
@@ -212,6 +217,93 @@ describe('AcDbTable', () => {
     expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
     const grouped = renderer.group.mock.results[0]?.value
     expect(grouped.applyMatrix).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds populated table cells before falling back to an anonymous block', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const block = new AcDbBlockTableRecord()
+    block.name = '*T_TABLE_TEST'
+    db.tables.blockTable.add(block)
+
+    const mtext = new AcDbMText()
+    mtext.contents = 'BLOCK_TABLE_TEXT'
+    mtext.height = 4.5
+    block.appendEntity(mtext)
+
+    const table = new AcDbTable('*T_TABLE_TEST', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(9)
+    table.setUniformColumnWidth(20)
+    table.setCell(0, {
+      text: 'CELL_TEXT_WITHOUT_HEIGHT',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      cellType: 1,
+      textHeight: undefined as unknown as number
+    })
+
+    table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
+    expect((mtextCall[0] as { text: string }).text).toBe(
+      'CELL_TEXT_WITHOUT_HEIGHT'
+    )
+    expect((mtextCall[0] as { height: number }).height).toBe(4.5)
+    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders an anonymous table block when cell content is unavailable', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const block = new AcDbBlockTableRecord()
+    block.name = '*T_TABLE_TEST'
+    db.tables.blockTable.add(block)
+
+    const mtext = new AcDbMText()
+    mtext.contents = 'BLOCK_TABLE_TEXT'
+    mtext.height = 4.5
+    block.appendEntity(mtext)
+
+    const table = new AcDbTable('*T_TABLE_TEST', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(9)
+    table.setUniformColumnWidth(20)
+
+    table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
+    expect((mtextCall[0] as { text: string }).text).toBe('BLOCK_TABLE_TEXT')
+    const groupedChildren = renderer.group.mock.calls[0][0] as Array<{
+      objectId: string
+      layerName: string
+    }>
+    expect(groupedChildren[0].objectId).toBe(table.objectId)
+    expect(groupedChildren[0].layerName).toBe(table.layer)
+    expect(renderer.lineSegments).not.toHaveBeenCalled()
+  })
+
+  it('uses a visible fallback text height when rebuilding cells without one', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const table = new AcDbTable('TABLE_WITHOUT_BLOCK', 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(9)
+    table.setUniformColumnWidth(20)
+    table.setCell(0, {
+      text: 'VISIBLE_FALLBACK_TEXT',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      cellType: 1,
+      textHeight: undefined as unknown as number
+    })
+
+    table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
+    expect((mtextCall[0] as { height: number }).height).toBe(4.5)
+    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
   })
 
   it('uses text style fallback order and throws if no style can be resolved', () => {

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mlightcad/common": "workspace:*",
-    "@mlightcad/dxf-json": "^1.1.4",
+    "@mlightcad/dxf-json": "^1.1.5",
     "@mlightcad/geometry-engine": "workspace:*",
     "@mlightcad/graphic-interface": "workspace:*",
     "iconv-lite": "^0.7.0",

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -370,6 +370,9 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       }
     }
 
+    // Use batch append to improve performance
+    blockTableRecord.appendEntity(dbEntities)
+
     attributes.forEach(attribute => {
       const owner = blockTableRecord.getIdAt(
         attribute.ownerId
@@ -378,9 +381,6 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         owner.appendAttributes(attribute)
       }
     })
-
-    // Use batch append to improve performance
-    blockTableRecord.appendEntity(dbEntities)
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -1,3 +1,4 @@
+import { AcCmColor } from '@mlightcad/common'
 import {
   AcGeBox3d,
   AcGeMatrix3d,
@@ -13,6 +14,7 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
+import type { AcDbBlockTableRecord } from '../database'
 import { DEFAULT_TEXT_STYLE } from '../misc'
 import { AcDbBlockReference } from './AcDbBlockReference'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
@@ -503,6 +505,16 @@ export class AcDbTable extends AcDbBlockReference {
    * @returns The rendered graphics entity representing the table
    */
   subWorldDraw(renderer: AcGiRenderer): AcGiEntity {
+    const blockTableRecord = this.blockTableRecord
+    if (
+      !this.hasRenderableCellContent() &&
+      blockTableRecord &&
+      blockTableRecord.newIterator().count > 0
+    ) {
+      const block = this.drawAnonymousTableBlock(renderer, blockTableRecord)
+      if (block) return block
+    }
+
     let allRowHeights = 0,
       allColumnWidths = 0
     const indices = new Uint16Array(this.numColumns * this.numRows * 8)
@@ -587,7 +599,7 @@ export class AcDbTable extends AcDbBlockReference {
             )
             const mtextData: AcGiMTextData = {
               text: cell.text,
-              height: cell.textHeight,
+              height: this.getCellTextHeight(cell, height),
               width: width,
               position: tempVector
                 .set(allColumnWidths, -allRowHeights, 0)
@@ -609,6 +621,50 @@ export class AcDbTable extends AcDbBlockReference {
     quaternion.setFromAxisAngle(AcGeVector3d.Z_AXIS, this.rotation)
     _tmpMatrix.compose(this.position, quaternion, this.scaleFactors)
     group.applyMatrix(_tmpMatrix)
+    return group
+  }
+
+  private hasRenderableCellContent() {
+    return this._cells.some(cell => {
+      return !!cell && (!!cell.text || !!cell.blockTableRecordId)
+    })
+  }
+
+  private drawAnonymousTableBlock(
+    renderer: AcGiRenderer,
+    blockTableRecord: AcDbBlockTableRecord
+  ) {
+    const results: AcGiEntity[] = []
+    const entities = blockTableRecord.newIterator()
+    for (const entity of entities) {
+      let object: AcGiEntity | undefined
+      if (entity.color.isByBlock && this.rgbColor) {
+        _tmpColor.copy(entity.color)
+        entity.color.setRGBValue(this.rgbColor)
+        object = entity.worldDraw(renderer)
+        entity.color.copy(_tmpColor)
+      } else {
+        object = entity.worldDraw(renderer)
+      }
+
+      if (object) {
+        object.objectId = this.objectId
+        object.ownerId = this.ownerId
+        object.layerName = this.layer
+        object.visible = this.visibility && entity.visibility
+        results.push(object)
+      }
+    }
+
+    const group = renderer.group(results)
+    group.applyMatrix(this.blockTransform)
+
+    const normal = this.normal
+    if (normal && (normal.x !== 0 || normal.y !== 0 || normal.z !== 1)) {
+      _tmpMatrix.setFromExtrusionDirection(normal)
+      group.applyMatrix(_tmpMatrix)
+    }
+
     return group
   }
 
@@ -716,6 +772,20 @@ export class AcDbTable extends AcDbBlockReference {
         break
     }
     return offset
+  }
+
+  /**
+   * Resolves a usable text height for table cells.
+   *
+   * Some DXF tables omit per-cell text height because their anonymous table block
+   * carries the final MTEXT geometry. When that block is unavailable, fall back to
+   * a conservative half-row height so the table text still has visible geometry.
+   */
+  private getCellTextHeight(cell: AcDbTableCell, rowHeight: number) {
+    if (cell.textHeight && cell.textHeight > 0) {
+      return cell.textHeight
+    }
+    return Math.max(rowHeight / 2, 1)
   }
 
   /**
@@ -948,3 +1018,4 @@ export class AcDbTable extends AcDbBlockReference {
 }
 
 const _tmpMatrix = /*@__PURE__*/ new AcGeMatrix3d()
+const _tmpColor = /*@__PURE__*/ new AcCmColor()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@mlightcad/dxf-json':
-        specifier: ^1.1.4
-        version: 1.1.4
+        specifier: ^1.1.5
+        version: 1.1.5
       '@mlightcad/geometry-engine':
         specifier: workspace:*
         version: link:../geometry-engine
@@ -1377,8 +1377,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.1.4':
-    resolution: {integrity: sha512-1Vo0g5La4JEHEyA3ayZx/5fHMIGYbcc6FM/4plNP9nF7803IdcvAzXrNHN/ddnv41mRqPy8awF0TvJBqRTe1xg==}
+  '@mlightcad/dxf-json@1.1.5':
+    resolution: {integrity: sha512-v8UTFkodHuF0BtUqMvtZOXKvipiDq38z1YdMIro6K+UrvORzRAwfxvhu8y85JzJ5SqVguTx7MtC1ggyrV0WReA==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -6268,7 +6268,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.1.4':
+  '@mlightcad/dxf-json@1.1.5':
     dependencies:
       '@fxts/core': 1.26.0
 


### PR DESCRIPTION
## Summary

Fixes two DXF/data-model rendering issues: `ATTRIB` entities are now correctly attached to `INSERT` entities converted within the same block record, and table entities can fall back to rendering their anonymous table block when cell content is unavailable. Also upgrades `@mlightcad/dxf-json` to `^1.1.5`.

## Changes

- Adjust entity append order in `AcDbDxfConverter` so converted `INSERT` entities are available before attaching `ATTRIB` entities
- Add anonymous table block fallback rendering for `AcDbTable`
- Add a visible fallback text height for table cells without `textHeight`
- Add unit coverage for DXF attribute attachment and table rendering fallback behavior
- Upgrade `@mlightcad/dxf-json` to `^1.1.5`

### Testing

- `pnpm test -- packages/data-model/__tests__/AcDbDxfConverter.spec.ts packages/data-model/__tests__/AcDbTable.spec.ts --runInBand`
