### PR TITLE
feat: add MLEADERSTYLE support and style-driven MLeader rendering

### DIFF
--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -1,0 +1,120 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices } from '../src/base'
+import {
+  AcDbBlockTableRecord,
+  AcDbDatabase
+} from '../src/database'
+import { AcDbMLeader } from '../src/entity'
+import { AcDbRenderingCache } from '../src/misc'
+import { AcDbMLeaderStyle } from '../src/object'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+const createRenderer = () => {
+  const renderer = {
+    subEntityTraits: {
+      color: undefined,
+      rgbColor: 0,
+      lineType: {
+        type: 'UserSpecified',
+        name: 'CONTINUOUS',
+        standardFlag: 0,
+        description: '',
+        totalPatternLength: 0
+      },
+      lineTypeScale: 1,
+      lineWeight: undefined,
+      fillType: undefined,
+      transparency: undefined,
+      thickness: 0,
+      layer: '0',
+      drawOrder: 0
+    },
+    lines: jest.fn((points: unknown[]) => {
+      return { kind: 'lines', points }
+    }),
+    group: jest.fn((entities: unknown[]) => ({ kind: 'group', entities })),
+    point: jest.fn(),
+    circularArc: jest.fn(),
+    ellipticalArc: jest.fn(),
+    lineSegments: jest.fn(),
+    area: jest.fn(),
+    mtext: jest.fn(),
+    image: jest.fn(),
+    setFontMapping: jest.fn()
+  }
+  return renderer
+}
+
+const createSimpleLeader = (db: AcDbDatabase) => {
+  const mleader = new AcDbMLeader()
+  const leaderIndex = mleader.addLeader()
+  mleader.addLeaderLine(leaderIndex, [
+    new AcGePoint3d(0, 0, 0),
+    new AcGePoint3d(5, 0, 0)
+  ])
+  db.tables.blockTable.modelSpace.appendEntity(mleader)
+  return mleader
+}
+
+describe('AcDbMLeader arrowhead rendering', () => {
+  it('renders closed-filled arrows when style arrowhead id is default 0', () => {
+    const db = createWorkingDb()
+    const mleader = createSimpleLeader(db)
+
+    const style = new AcDbMLeaderStyle()
+    style.arrowheadId = '0'
+    db.objects.mleaderStyle.setAt(style.objectId, style)
+    mleader.mleaderStyleId = style.objectId
+
+    const renderer = createRenderer()
+    mleader.worldDraw(renderer as never)
+
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.area).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders arrowhead from referenced block record handle', () => {
+    const db = createWorkingDb()
+    const mleader = createSimpleLeader(db)
+
+    const arrowBlock = new AcDbBlockTableRecord()
+    arrowBlock.name = 'ARROW_BLOCK'
+    db.tables.blockTable.add(arrowBlock)
+    mleader.arrowheadId = arrowBlock.objectId
+
+    const renderer = createRenderer()
+    const cacheResult = { kind: 'arrow-block' }
+    const drawSpy = jest
+      .spyOn(AcDbRenderingCache.instance, 'draw')
+      .mockReturnValue(cacheResult as never)
+
+    mleader.worldDraw(renderer as never)
+
+    expect(drawSpy).toHaveBeenCalledTimes(1)
+    expect(drawSpy.mock.calls[0][1]).toBe(arrowBlock)
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.area).not.toHaveBeenCalled()
+
+    drawSpy.mockRestore()
+  })
+
+  it('does not render arrows when arrowhead type resolves to _NONE', () => {
+    const db = createWorkingDb()
+    const mleader = createSimpleLeader(db)
+    mleader.arrowheadId = '_NONE'
+
+    const renderer = createRenderer()
+    mleader.worldDraw(renderer as never)
+
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+    expect(renderer.area).not.toHaveBeenCalled()
+  })
+
+})

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mlightcad/common": "workspace:*",
-    "@mlightcad/dxf-json": "^1.1.6",
+    "@mlightcad/dxf-json": "^1.1.7",
     "@mlightcad/geometry-engine": "workspace:*",
     "@mlightcad/graphic-interface": "workspace:*",
     "iconv-lite": "^0.7.0",

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -1,11 +1,17 @@
 import { AcCmColor } from '@mlightcad/common'
 import {
   BlockRecordTableEntry,
+  CommonDxfEntity,
+  CommonDxfTableEntry,
   DimStylesTableEntry,
+  DxfBlock,
   DxfTable,
+  ImageDefDXFObject,
   InsertEntity,
   LayerTableEntry,
+  LayoutDXFObject,
   LTypeTableEntry,
+  MLeaderStyleDXFObject,
   MTextEntity,
   MultiLeaderEntity,
   ParsedDxf,
@@ -13,11 +19,6 @@ import {
   TextEntity,
   VPortTableEntry
 } from '@mlightcad/dxf-json'
-import { DxfBlock } from '@mlightcad/dxf-json'
-import { CommonDxfEntity } from '@mlightcad/dxf-json'
-import { ImageDefDXFObject } from '@mlightcad/dxf-json'
-import { LayoutDXFObject } from '@mlightcad/dxf-json'
-import { CommonDxfTableEntry } from '@mlightcad/dxf-json'
 import {
   AcGiDefaultLightingType,
   AcGiOrthographicType,
@@ -543,6 +544,15 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
           imageDef as ImageDefDXFObject
         )
         imageDefDict.setAt(dbImageDef.objectId, dbImageDef)
+      })
+    }
+    if ('MLEADERSTYLE' in objects) {
+      const mleaderStyleDict = db.objects.mleaderStyle
+      objects['MLEADERSTYLE'].forEach(style => {
+        const dbStyle = objectConverter.convertMLeaderStyle(
+          style as MLeaderStyleDXFObject
+        )
+        mleaderStyleDict.setAt(dbStyle.objectId, dbStyle)
       })
     }
   }

--- a/packages/data-model/src/converter/AcDbObjectConverter.ts
+++ b/packages/data-model/src/converter/AcDbObjectConverter.ts
@@ -1,14 +1,16 @@
-import { ParsedDxf } from '@mlightcad/dxf-json'
 import {
   CommonDXFObject,
   ImageDefDXFObject,
-  LayoutDXFObject
+  LayoutDXFObject,
+  MLeaderStyleDXFObject,
+  ParsedDxf
 } from '@mlightcad/dxf-json'
 
 import { AcDbObject } from '../base'
 import { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
 import {
   AcDbLayout,
+  AcDbMLeaderStyle,
   AcDbPlotPaperUnits,
   AcDbPlotRotation,
   AcDbPlotShadePlotResLevel,
@@ -197,6 +199,113 @@ export class AcDbObjectConverter {
     const dbObject = new AcDbRasterImageDef()
     dbObject.sourceFileName = image.fileName
     this.processCommonAttrs(image, dbObject)
+    return dbObject
+  }
+
+  /**
+   * Converts a DXF mleader style object to an AcDbMLeaderStyle.
+   */
+  convertMLeaderStyle(style: MLeaderStyleDXFObject) {
+    const dbObject = new AcDbMLeaderStyle()
+    dbObject.unknown1 = style.unknown1
+    if (style.contentType != null) dbObject.contentType = style.contentType
+    if (style.drawMLeaderOrderType != null) {
+      dbObject.drawMLeaderOrderType = style.drawMLeaderOrderType
+    }
+    if (style.drawLeaderOrderType != null) {
+      dbObject.drawLeaderOrderType = style.drawLeaderOrderType
+    }
+    if (style.maxLeaderSegmentPoints != null) {
+      dbObject.maxLeaderSegmentPoints = style.maxLeaderSegmentPoints
+    }
+    if (style.firstSegmentAngleConstraint != null) {
+      dbObject.firstSegmentAngleConstraint = style.firstSegmentAngleConstraint
+    }
+    if (style.secondSegmentAngleConstraint != null) {
+      dbObject.secondSegmentAngleConstraint = style.secondSegmentAngleConstraint
+    }
+    if (style.leaderLineType != null) {
+      dbObject.leaderLineType = style.leaderLineType
+    }
+    if (style.leaderLineColor != null) {
+      dbObject.leaderLineColor = style.leaderLineColor
+    }
+    dbObject.leaderLineTypeId = style.leaderLineTypeId
+    if (style.leaderLineWeight != null) {
+      dbObject.leaderLineWeight = style.leaderLineWeight
+    }
+    if (style.landingEnabled != null) {
+      dbObject.landingEnabled = style.landingEnabled
+    }
+    if (style.landingGap != null) dbObject.landingGap = style.landingGap
+    if (style.doglegEnabled != null) dbObject.doglegEnabled = style.doglegEnabled
+    if (style.doglegLength != null) dbObject.doglegLength = style.doglegLength
+    if (style.description != null) dbObject.description = style.description
+    dbObject.arrowheadId = style.arrowheadId
+    if (style.arrowheadSize != null) dbObject.arrowheadSize = style.arrowheadSize
+    if (style.defaultMTextContents != null) {
+      dbObject.defaultMTextContents = style.defaultMTextContents
+    }
+    dbObject.textStyleId = style.textStyleId
+    if (style.textLeftAttachmentType != null) {
+      dbObject.textLeftAttachmentType = style.textLeftAttachmentType
+    }
+    if (style.textAngleType != null) dbObject.textAngleType = style.textAngleType
+    if (style.textAlignmentType != null) {
+      dbObject.textAlignmentType = style.textAlignmentType
+    }
+    if (style.textRightAttachmentType != null) {
+      dbObject.textRightAttachmentType = style.textRightAttachmentType
+    }
+    if (style.textColor != null) dbObject.textColor = style.textColor
+    if (style.textHeight != null) dbObject.textHeight = style.textHeight
+    if (style.textFrameEnabled != null) {
+      dbObject.textFrameEnabled = style.textFrameEnabled
+    }
+    if (style.textAlignAlwaysLeft != null) {
+      dbObject.textAlignAlwaysLeft = style.textAlignAlwaysLeft
+    }
+    if (style.alignSpace != null) dbObject.alignSpace = style.alignSpace
+    dbObject.blockContentId = style.blockContentId
+    if (style.blockContentColor != null) {
+      dbObject.blockContentColor = style.blockContentColor
+    }
+    if (style.blockContentScale) {
+      dbObject.blockContentScale = {
+        x: style.blockContentScale.x,
+        y: style.blockContentScale.y,
+        z: style.blockContentScale.z ?? 1
+      }
+    }
+    if (style.blockContentScaleEnabled != null) {
+      dbObject.blockContentScaleEnabled = style.blockContentScaleEnabled
+    }
+    if (style.blockContentRotation != null) {
+      dbObject.blockContentRotation = style.blockContentRotation
+    }
+    if (style.blockContentRotationEnabled != null) {
+      dbObject.blockContentRotationEnabled = style.blockContentRotationEnabled
+    }
+    if (style.blockContentConnectionType != null) {
+      dbObject.blockContentConnectionType = style.blockContentConnectionType
+    }
+    if (style.scale != null) dbObject.scale = style.scale
+    if (style.overwritePropertyValue != null) {
+      dbObject.overwritePropertyValue = style.overwritePropertyValue
+    }
+    if (style.annotative != null) dbObject.annotative = style.annotative
+    if (style.breakGapSize != null) dbObject.breakGapSize = style.breakGapSize
+    if (style.textAttachmentDirection != null) {
+      dbObject.textAttachmentDirection = style.textAttachmentDirection
+    }
+    if (style.bottomTextAttachmentDirection != null) {
+      dbObject.bottomTextAttachmentDirection = style.bottomTextAttachmentDirection
+    }
+    if (style.topTextAttachmentDirection != null) {
+      dbObject.topTextAttachmentDirection = style.topTextAttachmentDirection
+    }
+    dbObject.unknown2 = style.unknown2
+    this.processCommonAttrs(style, dbObject)
     return dbObject
   }
 

--- a/packages/data-model/src/converter/AcDbRegenerator.ts
+++ b/packages/data-model/src/converter/AcDbRegenerator.ts
@@ -155,6 +155,15 @@ export class AcDbRegenerator extends AcDbDatabaseConverter<AcDbDatabase> {
         key: imageDef.objectId
       })
     }
+
+    const mleaderStyles = this._database.objects.mleaderStyle.newIterator()
+    for (const mleaderStyle of mleaderStyles) {
+      this._database.events.dictObjetSet.dispatch({
+        database: this._database,
+        object: mleaderStyle,
+        key: mleaderStyle.objectId
+      })
+    }
   }
 
   /**

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -22,6 +22,7 @@ import {
   MLIGHTCAD_APPID
 } from '../misc'
 import { AcDbDictionary } from '../object/AcDbDictionary'
+import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
 import { AcDbRasterImageDef } from '../object/AcDbRasterImageDef'
 import { AcDbXrecord } from '../object/AcDbXrecord'
 import { AcDbBlockTable } from './AcDbBlockTable'
@@ -331,6 +332,7 @@ export class AcDbDatabase extends AcDbObject {
     readonly dictionary: AcDbDictionary<AcDbDictionary>
     readonly imageDefinition: AcDbDictionary<AcDbRasterImageDef>
     readonly layout: AcDbLayoutDictionary
+    readonly mleaderStyle: AcDbDictionary<AcDbMLeaderStyle>
     readonly xrecord: AcDbDictionary<AcDbXrecord>
   }
   /** Current space (model space or paper space) */
@@ -403,6 +405,7 @@ export class AcDbDatabase extends AcDbObject {
       dictionary: new AcDbDictionary(this),
       imageDefinition: new AcDbDictionary(this),
       layout: new AcDbLayoutDictionary(this),
+      mleaderStyle: new AcDbDictionary(this),
       xrecord: new AcDbDictionary(this)
     }
   }
@@ -1526,6 +1529,11 @@ export class AcDbDatabase extends AcDbObject {
     }
 
     ensureRootEntry('ACAD_LAYOUT', this.objects.layout)
+    if (this.objects.mleaderStyle.numEntries > 0) {
+      ensureRootEntry('ACAD_MLEADERSTYLE', this.objects.mleaderStyle)
+    } else {
+      dropRootEntry('ACAD_MLEADERSTYLE')
+    }
     if (this.objects.imageDefinition.numEntries > 0) {
       ensureRootEntry('ISM_RASTER_IMAGE_DICT', this.objects.imageDefinition)
     } else {
@@ -1539,6 +1547,10 @@ export class AcDbDatabase extends AcDbObject {
 
     writeDictionary(rootDict)
     writeDictionary(this.objects.layout)
+
+    if (this.objects.mleaderStyle.numEntries > 0) {
+      writeDictionary(this.objects.mleaderStyle)
+    }
 
     if (this.objects.imageDefinition.numEntries > 0) {
       writeDictionary(this.objects.imageDefinition)
@@ -1556,6 +1568,11 @@ export class AcDbDatabase extends AcDbObject {
     for (const [_, imageDef] of this.objects.imageDefinition.entries()) {
       filer.writeStart('IMAGEDEF')
       imageDef.dxfOut(filer)
+    }
+
+    for (const [_, mleaderStyle] of this.objects.mleaderStyle.entries()) {
+      filer.writeStart('MLEADERSTYLE')
+      mleaderStyle.dxfOut(filer)
     }
 
     for (const [_, xrecord] of this.objects.xrecord.entries()) {
@@ -1638,6 +1655,9 @@ export class AcDbDatabase extends AcDbObject {
     this._tables.layerTable.removeAll()
     this._tables.viewportTable.removeAll()
     this._objects.layout.removeAll()
+    this._objects.imageDefinition.removeAll()
+    this._objects.mleaderStyle.removeAll()
+    this._objects.xrecord.removeAll()
     this._currentSpace = undefined
     this._extents.makeEmpty()
   }

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -1,8 +1,10 @@
 import {
+  AcGeArea2d,
   AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
+  AcGePolyline2d,
   AcGeVector3d,
   AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
@@ -16,7 +18,8 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
-import { DEFAULT_TEXT_STYLE } from '../misc'
+import { AcDbRenderingCache, DEFAULT_TEXT_STYLE } from '../misc'
+import { AcDbMLeaderStyle } from '../object'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 
@@ -72,18 +75,27 @@ export enum AcDbMLeaderDirectionType {
   Bottom = 4
 }
 
+/**
+ * Represents a leader break segment input using point-like values.
+ */
 export interface AcDbMLeaderBreakLike {
   index?: number
   start: AcGePoint3dLike
   end: AcGePoint3dLike
 }
 
+/**
+ * Represents a normalized leader break segment stored with concrete points.
+ */
 export interface AcDbMLeaderBreak {
   index?: number
   start: AcGePoint3d
   end: AcGePoint3d
 }
 
+/**
+ * Represents a leader-line input payload before normalization.
+ */
 export interface AcDbMLeaderLineLike {
   vertices?: AcGePoint3dLike[]
   breakPointIndexes?: number[]
@@ -91,6 +103,9 @@ export interface AcDbMLeaderLineLike {
   breaks?: AcDbMLeaderBreakLike[]
 }
 
+/**
+ * Represents one normalized leader line.
+ */
 export interface AcDbMLeaderLine {
   vertices: AcGePoint3d[]
   breakPointIndexes: number[]
@@ -98,6 +113,9 @@ export interface AcDbMLeaderLine {
   breaks: AcDbMLeaderBreak[]
 }
 
+/**
+ * Represents a leader-branch input payload.
+ */
 export interface AcDbMLeaderLeaderLike {
   lastLeaderLinePoint?: AcGePoint3dLike
   lastLeaderLinePointSet?: boolean
@@ -111,6 +129,9 @@ export interface AcDbMLeaderLeaderLike {
   leaderLines?: AcDbMLeaderLineLike[]
 }
 
+/**
+ * Represents one normalized leader branch stored by the entity.
+ */
 export interface AcDbMLeaderLeader {
   lastLeaderLinePoint?: AcGePoint3d
   lastLeaderLinePointSet?: boolean
@@ -124,16 +145,25 @@ export interface AcDbMLeaderLeader {
   leaderLines: AcDbMLeaderLine[]
 }
 
+/**
+ * Represents MText content input data for a multileader.
+ */
 export interface AcDbMLeaderMTextContentLike {
   text: string
   anchorPoint: AcGePoint3dLike
 }
 
+/**
+ * Represents normalized MText content stored by a multileader.
+ */
 export interface AcDbMLeaderMTextContent {
   text: string
   anchorPoint: AcGePoint3d
 }
 
+/**
+ * Represents block content input data for a multileader.
+ */
 export interface AcDbMLeaderBlockContentLike {
   blockContentId?: string
   blockHandle?: string
@@ -145,6 +175,9 @@ export interface AcDbMLeaderBlockContentLike {
   transformationMatrix?: number[]
 }
 
+/**
+ * Represents normalized block content stored by a multileader.
+ */
 export interface AcDbMLeaderBlockContent {
   blockContentId?: string
   blockHandle?: string
@@ -156,11 +189,17 @@ export interface AcDbMLeaderBlockContent {
   transformationMatrix: number[]
 }
 
+/**
+ * Represents a handle tied to a specific index in multileader data.
+ */
 export interface AcDbMLeaderIndexedHandle {
   index: number
   handle?: string
 }
 
+/**
+ * Represents one block attribute override entry.
+ */
 export interface AcDbMLeaderBlockAttribute {
   id?: string
   index?: number
@@ -178,6 +217,9 @@ export class AcDbMLeader extends AcDbEntity {
   /** The entity type name. */
   static override typeName: string = 'MLeader'
 
+  /**
+   * Gets the DXF type name used when exporting this entity.
+   */
   override get dxfTypeName() {
     return 'MULTILEADER'
   }
@@ -202,61 +244,62 @@ export class AcDbMLeader extends AcDbEntity {
   private _textLineSpacingFactor: number
   private _textAttachmentDirection: AcDbMLeaderTextAttachmentDirection
   private _blockContent?: AcDbMLeaderBlockContent
-
-  version?: number
-  leaderStyleId?: string
-  propertyOverrideFlag?: number
-  leaderLineColor?: number
-  leaderLineTypeId?: string
-  leaderLineWeight?: number
-  landingEnabled?: boolean
-  arrowheadId?: string
-  arrowheadSize?: number
-  textStyleId?: string
-  textLeftAttachmentType?: number
-  textRightAttachmentType?: number
-  textAngleType?: number
-  textAlignmentType?: number
-  textColor?: number
-  textFrameEnabled?: boolean
-  landingGap?: number
-  textAttachment?: number
-  textFlowDirection?: number
-  blockContentId?: string
-  blockContentColor?: number
-  blockContentScale?: AcGeVector3d
-  blockContentRotation?: number
-  blockContentConnectionType?: number
-  annotativeScaleEnabled?: boolean
-  arrowheadOverrides: AcDbMLeaderIndexedHandle[]
-  blockAttributes: AcDbMLeaderBlockAttribute[]
-  textDirectionNegative?: boolean
-  textAlignInIPE?: number
-  bottomTextAttachmentDirection?: number
-  topTextAttachmentDirection?: number
-  contentScale?: number
-  contentBasePosition?: AcGePoint3d
-  textAnchor?: AcGePoint3d
-  textLineSpacingStyle?: number
-  textBackgroundColor?: number
-  textBackgroundScaleFactor?: number
-  textBackgroundTransparency?: number
-  textBackgroundColorOn?: boolean
-  textFillOn?: boolean
-  textColumnType?: number
-  textUseAutoHeight?: boolean
-  textColumnWidth?: number
-  textColumnGutterWidth?: number
-  textColumnFlowReversed?: boolean
-  textColumnHeight?: number
-  textUseWordBreak?: boolean
-  hasMText?: boolean
-  hasBlock?: boolean
-  planeOrigin?: AcGePoint3d
-  planeXAxisDirection?: AcGeVector3d
-  planeYAxisDirection?: AcGeVector3d
-  planeNormalReversed?: boolean
-
+  private _version?: number
+  private _leaderStyleId?: string
+  private _propertyOverrideFlag?: number
+  private _leaderLineColor?: number
+  private _leaderLineTypeId?: string
+  private _leaderLineWeight?: number
+  private _landingEnabled?: boolean
+  private _arrowheadId?: string
+  private _arrowheadSize?: number
+  private _textStyleId?: string
+  private _textLeftAttachmentType?: number
+  private _textRightAttachmentType?: number
+  private _textAngleType?: number
+  private _textAlignmentType?: number
+  private _textColor?: number
+  private _textFrameEnabled?: boolean
+  private _landingGap?: number
+  private _textAttachment?: number
+  private _textFlowDirection?: number
+  private _blockContentId?: string
+  private _blockContentColor?: number
+  private _blockContentScale?: AcGeVector3d
+  private _blockContentRotation?: number
+  private _blockContentConnectionType?: number
+  private _annotativeScaleEnabled?: boolean
+  private _arrowheadOverrides: AcDbMLeaderIndexedHandle[]
+  private _blockAttributes: AcDbMLeaderBlockAttribute[]
+  private _textDirectionNegative?: boolean
+  private _textAlignInIPE?: number
+  private _bottomTextAttachmentDirection?: number
+  private _topTextAttachmentDirection?: number
+  private _contentScale?: number
+  private _contentBasePosition?: AcGePoint3d
+  private _textAnchor?: AcGePoint3d
+  private _textLineSpacingStyle?: number
+  private _textBackgroundColor?: number
+  private _textBackgroundScaleFactor?: number
+  private _textBackgroundTransparency?: number
+  private _textBackgroundColorOn?: boolean
+  private _textFillOn?: boolean
+  private _textColumnType?: number
+  private _textUseAutoHeight?: boolean
+  private _textColumnWidth?: number
+  private _textColumnGutterWidth?: number
+  private _textColumnFlowReversed?: boolean
+  private _textColumnHeight?: number
+  private _textUseWordBreak?: boolean
+  private _hasMText?: boolean
+  private _hasBlock?: boolean
+  private _planeOrigin?: AcGePoint3d
+  private _planeXAxisDirection?: AcGeVector3d
+  private _planeYAxisDirection?: AcGeVector3d
+  private _planeNormalReversed?: boolean
+  /**
+   * Creates an empty multileader entity with default style-related state.
+   */
   constructor() {
     super()
     this._leaders = []
@@ -277,17 +320,29 @@ export class AcDbMLeader extends AcDbEntity {
     this._textLineSpacingFactor = 1
     this._textAttachmentDirection =
       AcDbMLeaderTextAttachmentDirection.Horizontal
-    this.arrowheadOverrides = []
-    this.blockAttributes = []
+    this._arrowheadOverrides = []
+    this._blockAttributes = []
   }
+
+  /**
+   * Gets a deep-cloned collection of all leader branches.
+   */
 
   get leaders() {
     return this._leaders.map(leader => this.cloneLeader(leader))
   }
 
+  /**
+   * Gets the current number of leader branches.
+   */
+
   get numberOfLeaders() {
     return this._leaders.length
   }
+
+  /**
+   * Gets the leader line type.
+   */
 
   get leaderLineType() {
     return this._leaderLineType
@@ -296,12 +351,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._leaderLineType = value
   }
 
+  /**
+   * Gets the content type.
+   */
+
   get contentType() {
     return this._contentType
   }
   set contentType(value: AcDbMLeaderContentType) {
     this._contentType = value
   }
+
+  /**
+   * Gets the dogleg enabled.
+   */
 
   get doglegEnabled() {
     return this._doglegEnabled
@@ -310,12 +373,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._doglegEnabled = value
   }
 
+  /**
+   * Gets the dogleg length.
+   */
+
   get doglegLength() {
     return this._doglegLength
   }
   set doglegLength(value: number) {
     this._doglegLength = value
   }
+
+  /**
+   * Gets the dogleg vector.
+   */
 
   get doglegVector() {
     return this._doglegVector
@@ -324,12 +395,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._doglegVector.copy(value)
   }
 
+  /**
+   * Gets the landing point.
+   */
+
   get landingPoint() {
     return this._landingPoint
   }
   set landingPoint(value: AcGePoint3dLike | undefined) {
     this._landingPoint = value ? this.createPoint(value) : undefined
   }
+
+  /**
+   * Gets the normal.
+   */
 
   get normal() {
     return this._normal
@@ -338,6 +417,10 @@ export class AcDbMLeader extends AcDbEntity {
     this._normal.copy(value)
   }
 
+  /**
+   * Gets the mleader style id.
+   */
+
   get mleaderStyleId() {
     return this._mleaderStyleId
   }
@@ -345,13 +428,566 @@ export class AcDbMLeader extends AcDbEntity {
     this._mleaderStyleId = value
   }
 
+  /**
+   * Gets or sets the serialized MLeader version code.
+   *
+   * This value mirrors DXF/internal version metadata and is used to keep
+   * compatibility with files saved from different AutoCAD generations.
+   */
+  get version() {
+    return this._version
+  }
+  set version(value: number | undefined) {
+    this._version = value
+  }
+
+  /**
+   * Gets or sets the MLeader style handle override stored on the entity.
+   *
+   * When provided, this value is typically used as a fallback in addition to
+   * `mleaderStyleId` during style resolution.
+   */
+  get leaderStyleId() {
+    return this._leaderStyleId
+  }
+  set leaderStyleId(value: string | undefined) {
+    this._leaderStyleId = value
+  }
+
+  /**
+   * Gets or sets the property-override bit flag.
+   *
+   * The flag indicates which visual/behavioral properties are overridden at the
+   * entity level instead of inherited from the referenced MLeader style.
+   */
+  get propertyOverrideFlag() {
+    return this._propertyOverrideFlag
+  }
+  set propertyOverrideFlag(value: number | undefined) {
+    this._propertyOverrideFlag = value
+  }
+
+  /**
+   * Gets or sets the explicit leader line color override.
+   */
+  get leaderLineColor() {
+    return this._leaderLineColor
+  }
+  set leaderLineColor(value: number | undefined) {
+    this._leaderLineColor = value
+  }
+
+  /**
+   * Gets or sets the leader line type handle override.
+   */
+  get leaderLineTypeId() {
+    return this._leaderLineTypeId
+  }
+  set leaderLineTypeId(value: string | undefined) {
+    this._leaderLineTypeId = value
+  }
+
+  /**
+   * Gets or sets the lineweight override for leader segments.
+   */
+  get leaderLineWeight() {
+    return this._leaderLineWeight
+  }
+  set leaderLineWeight(value: number | undefined) {
+    this._leaderLineWeight = value
+  }
+
+  /**
+   * Gets or sets whether leader landings are enabled.
+   */
+  get landingEnabled() {
+    return this._landingEnabled
+  }
+  set landingEnabled(value: boolean | undefined) {
+    this._landingEnabled = value
+  }
+
+  /**
+   * Gets or sets the arrowhead block handle/name override.
+   */
+  get arrowheadId() {
+    return this._arrowheadId
+  }
+  set arrowheadId(value: string | undefined) {
+    this._arrowheadId = value
+  }
+
+  /**
+   * Gets or sets the arrowhead size override in drawing units.
+   */
+  get arrowheadSize() {
+    return this._arrowheadSize
+  }
+  set arrowheadSize(value: number | undefined) {
+    this._arrowheadSize = value
+  }
+
+  /**
+   * Gets or sets the text style handle override for MText content.
+   */
+  get textStyleId() {
+    return this._textStyleId
+  }
+  set textStyleId(value: string | undefined) {
+    this._textStyleId = value
+  }
+
+  /**
+   * Gets or sets left-side text attachment behavior code.
+   */
+  get textLeftAttachmentType() {
+    return this._textLeftAttachmentType
+  }
+  set textLeftAttachmentType(value: number | undefined) {
+    this._textLeftAttachmentType = value
+  }
+
+  /**
+   * Gets or sets right-side text attachment behavior code.
+   */
+  get textRightAttachmentType() {
+    return this._textRightAttachmentType
+  }
+  set textRightAttachmentType(value: number | undefined) {
+    this._textRightAttachmentType = value
+  }
+
+  /**
+   * Gets or sets the text angle type code controlling rotation strategy.
+   */
+  get textAngleType() {
+    return this._textAngleType
+  }
+  set textAngleType(value: number | undefined) {
+    this._textAngleType = value
+  }
+
+  /**
+   * Gets or sets the text alignment type code.
+   */
+  get textAlignmentType() {
+    return this._textAlignmentType
+  }
+  set textAlignmentType(value: number | undefined) {
+    this._textAlignmentType = value
+  }
+
+  /**
+   * Gets or sets the MText color override.
+   */
+  get textColor() {
+    return this._textColor
+  }
+  set textColor(value: number | undefined) {
+    this._textColor = value
+  }
+
+  /**
+   * Gets or sets whether a text frame (border) is enabled.
+   */
+  get textFrameEnabled() {
+    return this._textFrameEnabled
+  }
+  set textFrameEnabled(value: boolean | undefined) {
+    this._textFrameEnabled = value
+  }
+
+  /**
+   * Gets or sets the gap distance between landing and annotation content.
+   */
+  get landingGap() {
+    return this._landingGap
+  }
+  set landingGap(value: number | undefined) {
+    this._landingGap = value
+  }
+
+  /**
+   * Gets or sets the legacy text attachment value used in some DXF variants.
+   */
+  get textAttachment() {
+    return this._textAttachment
+  }
+  set textAttachment(value: number | undefined) {
+    this._textAttachment = value
+  }
+
+  /**
+   * Gets or sets the text flow direction override code.
+   */
+  get textFlowDirection() {
+    return this._textFlowDirection
+  }
+  set textFlowDirection(value: number | undefined) {
+    this._textFlowDirection = value
+  }
+
+  /**
+   * Gets or sets the referenced block content id/handle for block-based content.
+   */
+  get blockContentId() {
+    return this._blockContentId
+  }
+  set blockContentId(value: string | undefined) {
+    this._blockContentId = value
+  }
+
+  /**
+   * Gets or sets the block content color override.
+   */
+  get blockContentColor() {
+    return this._blockContentColor
+  }
+  set blockContentColor(value: number | undefined) {
+    this._blockContentColor = value
+  }
+
+  /**
+   * Gets or sets the block content scale vector override.
+   */
+  get blockContentScale() {
+    return this._blockContentScale
+  }
+  set blockContentScale(value: AcGeVector3d | undefined) {
+    this._blockContentScale = value
+  }
+
+  /**
+   * Gets or sets the block content rotation override in radians.
+   */
+  get blockContentRotation() {
+    return this._blockContentRotation
+  }
+  set blockContentRotation(value: number | undefined) {
+    this._blockContentRotation = value
+  }
+
+  /**
+   * Gets or sets the block content connection type code.
+   */
+  get blockContentConnectionType() {
+    return this._blockContentConnectionType
+  }
+  set blockContentConnectionType(value: number | undefined) {
+    this._blockContentConnectionType = value
+  }
+
+  /**
+   * Gets or sets whether annotative scaling is enabled for this entity.
+   */
+  get annotativeScaleEnabled() {
+    return this._annotativeScaleEnabled
+  }
+  set annotativeScaleEnabled(value: boolean | undefined) {
+    this._annotativeScaleEnabled = value
+  }
+
+  /**
+   * Gets or sets per-index arrowhead overrides.
+   *
+   * Each entry maps a branch/line index to a specific arrowhead handle.
+   */
+  get arrowheadOverrides() {
+    return this._arrowheadOverrides
+  }
+  set arrowheadOverrides(value: AcDbMLeaderIndexedHandle[]) {
+    this._arrowheadOverrides = value
+  }
+
+  /**
+   * Gets or sets block attribute override values used by block content.
+   */
+  get blockAttributes() {
+    return this._blockAttributes
+  }
+  set blockAttributes(value: AcDbMLeaderBlockAttribute[]) {
+    this._blockAttributes = value
+  }
+
+  /**
+   * Gets or sets whether text direction is treated as negative.
+   */
+  get textDirectionNegative() {
+    return this._textDirectionNegative
+  }
+  set textDirectionNegative(value: boolean | undefined) {
+    this._textDirectionNegative = value
+  }
+
+  /**
+   * Gets or sets the in-place editor text alignment code.
+   */
+  get textAlignInIPE() {
+    return this._textAlignInIPE
+  }
+  set textAlignInIPE(value: number | undefined) {
+    this._textAlignInIPE = value
+  }
+
+  /**
+   * Gets or sets bottom attachment direction code for vertical text behavior.
+   */
+  get bottomTextAttachmentDirection() {
+    return this._bottomTextAttachmentDirection
+  }
+  set bottomTextAttachmentDirection(value: number | undefined) {
+    this._bottomTextAttachmentDirection = value
+  }
+
+  /**
+   * Gets or sets top attachment direction code for vertical text behavior.
+   */
+  get topTextAttachmentDirection() {
+    return this._topTextAttachmentDirection
+  }
+  set topTextAttachmentDirection(value: number | undefined) {
+    this._topTextAttachmentDirection = value
+  }
+
+  /**
+   * Gets or sets the overall content scale override.
+   */
+  get contentScale() {
+    return this._contentScale
+  }
+  set contentScale(value: number | undefined) {
+    this._contentScale = value
+  }
+
+  /**
+   * Gets or sets the base insertion position of annotation content.
+   */
+  get contentBasePosition() {
+    return this._contentBasePosition
+  }
+  set contentBasePosition(value: AcGePoint3d | undefined) {
+    this._contentBasePosition = value
+  }
+
+  /**
+   * Gets or sets the explicit text anchor position.
+   */
+  get textAnchor() {
+    return this._textAnchor
+  }
+  set textAnchor(value: AcGePoint3d | undefined) {
+    this._textAnchor = value
+  }
+
+  /**
+   * Gets or sets the text line spacing style code for column/text layout.
+   */
+  get textLineSpacingStyle() {
+    return this._textLineSpacingStyle
+  }
+  set textLineSpacingStyle(value: number | undefined) {
+    this._textLineSpacingStyle = value
+  }
+
+  /**
+   * Gets or sets text background color override.
+   */
+  get textBackgroundColor() {
+    return this._textBackgroundColor
+  }
+  set textBackgroundColor(value: number | undefined) {
+    this._textBackgroundColor = value
+  }
+
+  /**
+   * Gets or sets background-mask scale factor around text.
+   */
+  get textBackgroundScaleFactor() {
+    return this._textBackgroundScaleFactor
+  }
+  set textBackgroundScaleFactor(value: number | undefined) {
+    this._textBackgroundScaleFactor = value
+  }
+
+  /**
+   * Gets or sets text background transparency value.
+   */
+  get textBackgroundTransparency() {
+    return this._textBackgroundTransparency
+  }
+  set textBackgroundTransparency(value: number | undefined) {
+    this._textBackgroundTransparency = value
+  }
+
+  /**
+   * Gets or sets whether explicit background color masking is enabled.
+   */
+  get textBackgroundColorOn() {
+    return this._textBackgroundColorOn
+  }
+  set textBackgroundColorOn(value: boolean | undefined) {
+    this._textBackgroundColorOn = value
+  }
+
+  /**
+   * Gets or sets whether text fill/mask is enabled.
+   */
+  get textFillOn() {
+    return this._textFillOn
+  }
+  set textFillOn(value: boolean | undefined) {
+    this._textFillOn = value
+  }
+
+  /**
+   * Gets or sets the text column layout type code.
+   */
+  get textColumnType() {
+    return this._textColumnType
+  }
+  set textColumnType(value: number | undefined) {
+    this._textColumnType = value
+  }
+
+  /**
+   * Gets or sets whether text column height is auto-managed.
+   */
+  get textUseAutoHeight() {
+    return this._textUseAutoHeight
+  }
+  set textUseAutoHeight(value: boolean | undefined) {
+    this._textUseAutoHeight = value
+  }
+
+  /**
+   * Gets or sets the fixed width for text columns.
+   */
+  get textColumnWidth() {
+    return this._textColumnWidth
+  }
+  set textColumnWidth(value: number | undefined) {
+    this._textColumnWidth = value
+  }
+
+  /**
+   * Gets or sets the gutter width between text columns.
+   */
+  get textColumnGutterWidth() {
+    return this._textColumnGutterWidth
+  }
+  set textColumnGutterWidth(value: number | undefined) {
+    this._textColumnGutterWidth = value
+  }
+
+  /**
+   * Gets or sets whether text columns flow in reverse order.
+   */
+  get textColumnFlowReversed() {
+    return this._textColumnFlowReversed
+  }
+  set textColumnFlowReversed(value: boolean | undefined) {
+    this._textColumnFlowReversed = value
+  }
+
+  /**
+   * Gets or sets the explicit text column height.
+   */
+  get textColumnHeight() {
+    return this._textColumnHeight
+  }
+  set textColumnHeight(value: number | undefined) {
+    this._textColumnHeight = value
+  }
+
+  /**
+   * Gets or sets whether word breaking is enabled in column layout.
+   */
+  get textUseWordBreak() {
+    return this._textUseWordBreak
+  }
+  set textUseWordBreak(value: boolean | undefined) {
+    this._textUseWordBreak = value
+  }
+
+  /**
+   * Gets or sets whether MText content exists in the serialized payload.
+   */
+  get hasMText() {
+    return this._hasMText
+  }
+  set hasMText(value: boolean | undefined) {
+    this._hasMText = value
+  }
+
+  /**
+   * Gets or sets whether block content exists in the serialized payload.
+   */
+  get hasBlock() {
+    return this._hasBlock
+  }
+  set hasBlock(value: boolean | undefined) {
+    this._hasBlock = value
+  }
+
+  /**
+   * Gets or sets the origin of the MLeader plane definition.
+   */
+  get planeOrigin() {
+    return this._planeOrigin
+  }
+  set planeOrigin(value: AcGePoint3d | undefined) {
+    this._planeOrigin = value
+  }
+
+  /**
+   * Gets or sets the X-axis direction vector of the MLeader plane.
+   */
+  get planeXAxisDirection() {
+    return this._planeXAxisDirection
+  }
+  set planeXAxisDirection(value: AcGeVector3d | undefined) {
+    this._planeXAxisDirection = value
+  }
+
+  /**
+   * Gets or sets the Y-axis direction vector of the MLeader plane.
+   */
+  get planeYAxisDirection() {
+    return this._planeYAxisDirection
+  }
+  set planeYAxisDirection(value: AcGeVector3d | undefined) {
+    this._planeYAxisDirection = value
+  }
+
+  /**
+   * Gets or sets whether the MLeader plane normal is reversed.
+   */
+  get planeNormalReversed() {
+    return this._planeNormalReversed
+  }
+  set planeNormalReversed(value: boolean | undefined) {
+    this._planeNormalReversed = value
+  }
+
+  /**
+   * Gets the alias of `leaders`.
+   */
+
   get leaderSections() {
     return this.leaders
   }
 
+  /**
+   * Gets the alias of `blockContent`.
+   */
+
   get blockContentData() {
     return this.blockContent
   }
+
+  /**
+   * Gets the MText content payload if present.
+   */
 
   get mtextContent() {
     return this._mtextContent
@@ -376,6 +1012,10 @@ export class AcDbMLeader extends AcDbEntity {
     this._contentType = AcDbMLeaderContentType.MTextContent
   }
 
+  /**
+   * Gets the displayed MText string content.
+   */
+
   get contents() {
     return this._mtextContent?.text ?? ''
   }
@@ -390,6 +1030,10 @@ export class AcDbMLeader extends AcDbEntity {
     }
     this._contentType = AcDbMLeaderContentType.MTextContent
   }
+
+  /**
+   * Gets the MText anchor point.
+   */
 
   get textLocation() {
     return this._mtextContent?.anchorPoint
@@ -410,12 +1054,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._contentType = AcDbMLeaderContentType.MTextContent
   }
 
+  /**
+   * Gets the text height.
+   */
+
   get textHeight() {
     return this._textHeight
   }
   set textHeight(value: number) {
     this._textHeight = value
   }
+
+  /**
+   * Gets the text width.
+   */
 
   get textWidth() {
     return this._textWidth
@@ -424,12 +1076,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._textWidth = value
   }
 
+  /**
+   * Gets the text rotation.
+   */
+
   get textRotation() {
     return this._textRotation
   }
   set textRotation(value: number) {
     this._textRotation = value
   }
+
+  /**
+   * Gets the text direction.
+   */
 
   get textDirection() {
     return this._textDirection
@@ -438,12 +1098,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._textDirection.copy(value)
   }
 
+  /**
+   * Gets the text style name.
+   */
+
   get textStyleName() {
     return this._textStyleName
   }
   set textStyleName(value: string) {
     this._textStyleName = value
   }
+
+  /**
+   * Gets the text attachment point.
+   */
 
   get textAttachmentPoint() {
     return this._textAttachmentPoint
@@ -452,12 +1120,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._textAttachmentPoint = value
   }
 
+  /**
+   * Gets the text drawing direction.
+   */
+
   get textDrawingDirection() {
     return this._textDrawingDirection
   }
   set textDrawingDirection(value: AcGiMTextFlowDirection) {
     this._textDrawingDirection = value
   }
+
+  /**
+   * Gets the text line spacing factor.
+   */
 
   get textLineSpacingFactor() {
     return this._textLineSpacingFactor
@@ -466,12 +1142,20 @@ export class AcDbMLeader extends AcDbEntity {
     this._textLineSpacingFactor = value
   }
 
+  /**
+   * Gets the text attachment direction.
+   */
+
   get textAttachmentDirection() {
     return this._textAttachmentDirection
   }
   set textAttachmentDirection(value: AcDbMLeaderTextAttachmentDirection) {
     this._textAttachmentDirection = value
   }
+
+  /**
+   * Gets the block content.
+   */
 
   get blockContent() {
     return this._blockContent
@@ -592,12 +1276,28 @@ export class AcDbMLeader extends AcDbEntity {
     return this
   }
 
+  /**
+   * Gets cloned vertices from the specified leader line.
+   *
+   * @param leaderIndex Index of the leader branch.
+   * @param leaderLineIndex Index of the leader line in the branch.
+   * @returns A cloned vertex list so callers cannot mutate internal state.
+   */
   getLeaderLineVertices(leaderIndex: number, leaderLineIndex: number) {
     return this.getMutableLeaderLine(leaderIndex, leaderLineIndex).vertices.map(
       point => point.clone()
     )
   }
 
+  /**
+   * Adds a break segment to a specific leader line.
+   *
+   * @param leaderIndex Index of the leader branch.
+   * @param leaderLineIndex Index of the leader line.
+   * @param start Break start point.
+   * @param end Break end point.
+   * @returns The current entity instance for chaining.
+   */
   addBreak(
     leaderIndex: number,
     leaderLineIndex: number,
@@ -611,6 +1311,13 @@ export class AcDbMLeader extends AcDbEntity {
     return this
   }
 
+  /**
+   * Sets the landing point for one leader branch.
+   *
+   * @param leaderIndex Index of the leader branch.
+   * @param point New landing point, or `undefined` to clear it.
+   * @returns The current entity instance for chaining.
+   */
   setLandingPoint(leaderIndex: number, point: AcGePoint3dLike | undefined) {
     this.checkLeaderIndex(leaderIndex)
     this._leaders[leaderIndex].landingPoint = point
@@ -619,17 +1326,35 @@ export class AcDbMLeader extends AcDbEntity {
     return this
   }
 
+  /**
+   * Sets the dogleg direction for one leader branch.
+   *
+   * @param leaderIndex Index of the leader branch.
+   * @param vector New dogleg direction vector.
+   * @returns The current entity instance for chaining.
+   */
   setDoglegDirection(leaderIndex: number, vector: AcGeVector3dLike) {
     this.checkLeaderIndex(leaderIndex)
     this._leaders[leaderIndex].doglegVector = new AcGeVector3d(vector)
     return this
   }
 
+  /**
+   * Sets the dogleg length for one leader branch.
+   *
+   * @param leaderIndex Index of the leader branch.
+   * @param length New dogleg length, or `undefined` to clear the override.
+   * @returns The current entity instance for chaining.
+   */
   setDoglegLength(leaderIndex: number, length: number | undefined) {
     this.checkLeaderIndex(leaderIndex)
     this._leaders[leaderIndex].doglegLength = length
     return this
   }
+
+  /**
+   * Gets the axis-aligned extents computed from all geometry points.
+   */
 
   get geometricExtents() {
     const points = this.collectGeometryPoints()
@@ -638,10 +1363,21 @@ export class AcDbMLeader extends AcDbEntity {
       : new AcGeBox3d()
   }
 
+  /**
+   * Gets grip points used for interactive editing.
+   *
+   * @returns Cloned grip points derived from renderable geometry.
+   */
   subGetGripPoints() {
     return this.collectGeometryPoints().map(point => point.clone())
   }
 
+  /**
+   * Applies a transformation matrix to this entity.
+   *
+   * @param matrix Transformation matrix applied to all geometry and vectors.
+   * @returns The current entity instance for chaining.
+   */
   transformBy(matrix: AcGeMatrix3d) {
     this._leaders.forEach(leader => {
       leader.lastLeaderLinePoint?.applyMatrix4(matrix)
@@ -839,7 +1575,12 @@ export class AcDbMLeader extends AcDbEntity {
       ]
     }
   }
-
+  /**
+   * Builds renderable primitives for this multileader entity.
+   *
+   * @param renderer Graphics renderer used to create draw entities.
+   * @returns A single entity, an entity group, or undefined when nothing is drawable.
+   */
   subWorldDraw(
     renderer: AcGiRenderer
   ): AcGiEntity | undefined {
@@ -849,11 +1590,8 @@ export class AcDbMLeader extends AcDbEntity {
         leader.leaderLines.forEach(line => {
           const points = this.getLeaderLineDrawPoints(leader, line)
           if (points.length > 0) {
-            entities.push(renderer.lines(points))
-            const arrowPoints = this.getArrowheadPoints(points)
-            if (arrowPoints) {
-              entities.push(renderer.lines(arrowPoints))
-            }
+            const leaderEntity = this.drawLeaderLine(renderer, points)
+            if (leaderEntity) entities.push(leaderEntity)
           }
         })
         const doglegPoints = this.getDoglegPoints(leader)
@@ -863,15 +1601,14 @@ export class AcDbMLeader extends AcDbEntity {
       })
     }
 
-    if (
-      this.contentType === AcDbMLeaderContentType.MTextContent &&
-      this._mtextContent
-    ) {
+    const mtextContent = this.getRenderableMTextContent()
+    if (this.contentType === AcDbMLeaderContentType.MTextContent && mtextContent) {
+      const textHeight = this.getResolvedTextHeight()
       const mtextData: AcGiMTextData = {
-        text: this._mtextContent.text,
-        height: this.textHeight,
-        width: this.getMTextRenderWidth(),
-        position: this._mtextContent.anchorPoint,
+        text: mtextContent.text,
+        height: textHeight,
+        width: this.getMTextRenderWidth(mtextContent.text, textHeight),
+        position: mtextContent.anchorPoint,
         rotation: this.textRotation,
         directionVector: this.textDirection,
         attachmentPoint: this.textAttachmentPoint,
@@ -888,10 +1625,10 @@ export class AcDbMLeader extends AcDbEntity {
   }
 
   /**
-   * Writes a compact MULTILEADER representation for DXF export.
+   * Writes this multileader entity to DXF group codes.
    *
-   * The data model keeps the full leader graph for consumers even though DXF's
-   * native MULTILEADER encoding is much more verbose than most entities.
+   * @param filer DXF filer that receives serialized values.
+   * @returns The current entity instance for chaining.
    */
   override dxfOutFields(filer: AcDbDxfFiler) {
     super.dxfOutFields(filer)
@@ -935,10 +1672,22 @@ export class AcDbMLeader extends AcDbEntity {
     return this
   }
 
+  /**
+   * Creates a concrete point from point-like input.
+   *
+   * @param point Source point-like value.
+   * @returns A newly created point instance.
+   */
   private createPoint(point: AcGePoint3dLike) {
     return new AcGePoint3d().copy(point)
   }
 
+  /**
+   * Normalizes one leader-line payload into internal storage format.
+   *
+   * @param line Source leader-line payload.
+   * @returns A normalized leader line.
+   */
   private createLeaderLine(line: AcDbMLeaderLineLike): AcDbMLeaderLine {
     return {
       vertices: line.vertices?.map(point => this.createPoint(point)) ?? [],
@@ -955,6 +1704,12 @@ export class AcDbMLeader extends AcDbEntity {
     }
   }
 
+  /**
+   * Creates a deep clone of a leader branch.
+   *
+   * @param leader Leader branch to clone.
+   * @returns A deep-cloned leader branch.
+   */
   private cloneLeader(leader: AcDbMLeaderLeader): AcDbMLeaderLeader {
     return {
       lastLeaderLinePoint: leader.lastLeaderLinePoint?.clone(),
@@ -983,12 +1738,24 @@ export class AcDbMLeader extends AcDbEntity {
     }
   }
 
+  /**
+   * Validates that a leader index is in range.
+   *
+   * @param leaderIndex Leader branch index to validate.
+   */
   private checkLeaderIndex(leaderIndex: number) {
     if (leaderIndex < 0 || leaderIndex >= this._leaders.length) {
       throw new Error('The leader index is out of range!')
     }
   }
 
+  /**
+   * Gets a mutable leader line by branch and line index.
+   *
+   * @param leaderIndex Leader branch index.
+   * @param leaderLineIndex Leader-line index in the branch.
+   * @returns The mutable leader line reference.
+   */
   private getMutableLeaderLine(
     leaderIndex: number,
     leaderLineIndex: number
@@ -1001,6 +1768,11 @@ export class AcDbMLeader extends AcDbEntity {
     return line
   }
 
+  /**
+   * Collects all geometry points contributing to draw/extents calculations.
+   *
+   * @returns Geometry point collection.
+   */
   private collectGeometryPoints() {
     const points: AcGePoint3d[] = []
     this._leaders.forEach(leader => {
@@ -1029,6 +1801,13 @@ export class AcDbMLeader extends AcDbEntity {
     return points
   }
 
+  /**
+   * Resolves the final draw points for a leader line.
+   *
+   * @param leader Owning leader branch.
+   * @param line Leader line to resolve.
+   * @returns The resolved draw-point sequence.
+   */
   private getLeaderLineDrawPoints(
     leader: AcDbMLeaderLeader,
     line: AcDbMLeaderLine
@@ -1045,6 +1824,12 @@ export class AcDbMLeader extends AcDbEntity {
     return [line.vertices[0], end]
   }
 
+  /**
+   * Computes the dogleg segment points for a leader branch.
+   *
+   * @param leader Leader branch to evaluate.
+   * @returns Dogleg segment points, or `undefined` if not applicable.
+   */
   private getDoglegPoints(leader: AcDbMLeaderLeader) {
     if (!this.doglegEnabled) return undefined
     const start =
@@ -1062,6 +1847,12 @@ export class AcDbMLeader extends AcDbEntity {
     return [start, end]
   }
 
+  /**
+   * Gets the last available vertex from all lines in one leader branch.
+   *
+   * @param leader Leader branch to inspect.
+   * @returns The last vertex, or `undefined` when no vertices exist.
+   */
   private getLastLeaderLineVertex(leader: AcDbMLeaderLeader) {
     for (let i = leader.leaderLines.length - 1; i >= 0; i--) {
       const line = leader.leaderLines[i]
@@ -1072,18 +1863,20 @@ export class AcDbMLeader extends AcDbEntity {
     return undefined
   }
 
+  /**
+   * Builds arrowhead polyline points from leader-line points.
+   *
+   * @param points Leader-line points where the first point is treated as tip.
+   * @returns Arrowhead points, or `undefined` when no arrowhead is drawable.
+   */
   private getArrowheadPoints(points: AcGePoint3d[]) {
     if (!this.isArrowheadVisible() || points.length < 2) return undefined
 
-    const tip = points[0]
-    const next = points.find(point => !point.equals(tip))
-    if (!next) return undefined
+    const frame = this.getArrowheadFrame(points)
+    if (!frame) return undefined
 
-    const direction = new AcGeVector3d().subVectors(next, tip)
-    if (direction.lengthSq() === 0) return undefined
-
-    const size = this.getArrowheadSize()
-    const unit = direction.normalize()
+    const size = this.getResolvedArrowheadSize()
+    const { tip, unit } = frame
     const baseCenter = tip.clone().add(unit.clone().multiplyScalar(size))
     const halfWidth = size / 6
     const perpendicular = new AcGeVector3d(-unit.y, unit.x, 0)
@@ -1097,20 +1890,187 @@ export class AcDbMLeader extends AcDbEntity {
     return [tip, left, right, tip]
   }
 
+  /**
+   * Checks whether an arrowhead should be rendered.
+   *
+   * @returns `true` if arrowhead configuration is visible.
+   */
   private isArrowheadVisible() {
-    if (this.arrowheadId === '_NONE') return false
-    return this.getArrowheadSize() > 0
+    const arrowId = this.getResolvedArrowheadId()
+    if (arrowId?.toUpperCase() === '_NONE') return false
+    return this.getResolvedArrowheadSize() > 0
   }
 
-  private getArrowheadSize() {
-    return this.arrowheadSize ?? this.contentScale ?? this.textHeight
+  /**
+   * Draws one leader line and applies arrow style from MLEADER/MLEADERSTYLE.
+   */
+  private drawLeaderLine(renderer: AcGiRenderer, points: AcGePoint3d[]) {
+    const entities: AcGiEntity[] = [renderer.lines(points)]
+    const arrow = this.drawArrowhead(renderer, points)
+    if (arrow) entities.push(arrow)
+    return entities.length === 1 ? entities[0] : renderer.group(entities)
   }
 
-  private getMTextRenderWidth() {
+  /**
+   * Draws one arrowhead primitive from leader-line points.
+   */
+  private drawArrowhead(renderer: AcGiRenderer, points: AcGePoint3d[]) {
+    if (!this.isArrowheadVisible()) return undefined
+
+    const blockArrow = this.drawArrowheadBlock(renderer, points)
+    if (blockArrow) return blockArrow
+
+    const arrowPoints = this.getArrowheadPoints(points)
+    if (!arrowPoints) return undefined
+
+    const area = new AcGeArea2d()
+    area.add(new AcGePolyline2d(arrowPoints, true))
+    const traits = renderer.subEntityTraits
+    const originalFillType = traits.fillType
+    traits.fillType = {
+      solidFill: true,
+      patternAngle: 0,
+      definitionLines: []
+    }
+    const entity = renderer.area(area)
+    traits.fillType = originalFillType
+    return entity
+  }
+
+  /**
+   * Draws arrowhead by rendering entities from referenced arrow block record.
+   */
+  private drawArrowheadBlock(renderer: AcGiRenderer, points: AcGePoint3d[]) {
+    const blockTableRecord = this.getResolvedArrowheadBlockTableRecord()
+    if (!blockTableRecord) return undefined
+
+    const frame = this.getArrowheadFrame(points)
+    if (!frame) return undefined
+
+    const { tip, unit } = frame
+    const size = this.getResolvedArrowheadSize()
+    const angle = Math.atan2(unit.y, unit.x)
+    const basePoint = blockTableRecord.origin ?? AcGePoint3d.ORIGIN
+
+    const mBase = new AcGeMatrix3d().makeTranslation(
+      -basePoint.x,
+      -basePoint.y,
+      -basePoint.z
+    )
+    const mScale = new AcGeMatrix3d().makeScale(size, size, size)
+    const mRot = new AcGeMatrix3d().makeRotationZ(angle)
+    const mInsert = new AcGeMatrix3d().makeTranslation(tip.x, tip.y, tip.z)
+    const transform = new AcGeMatrix3d()
+      .multiplyMatrices(mInsert, mRot)
+      .multiply(mScale)
+      .multiply(mBase)
+
+    return AcDbRenderingCache.instance.draw(
+      renderer,
+      blockTableRecord,
+      this.rgbColor,
+      [],
+      true,
+      transform,
+      new AcGeVector3d(this.normal)
+    )
+  }
+
+  /**
+   * Resolves tip point and direction for arrowhead placement.
+   */
+  private getArrowheadFrame(points: AcGePoint3d[]) {
+    if (points.length < 2) return undefined
+
+    const tip = points[0]
+    const next = points.find(point => !point.equals(tip))
+    if (!next) return undefined
+
+    const direction = new AcGeVector3d().subVectors(next, tip)
+    if (direction.lengthSq() === 0) return undefined
+
+    return {
+      tip,
+      unit: direction.normalize()
+    }
+  }
+
+  /**
+   * Resolves the effective arrowhead id.
+   *
+   * @returns Arrowhead id used for rendering.
+   */
+  private getResolvedArrowheadId() {
+    const styleArrowId = this.getMLeaderStyle()?.arrowSymbolId
+    return this.arrowheadId ?? styleArrowId
+  }
+
+  /**
+   * Resolves arrowhead block record by Arrowhead ID handle.
+   */
+  private getResolvedArrowheadBlockTableRecord() {
+    const arrowId = this.getResolvedArrowheadId()
+    if (!arrowId) return undefined
+    return this.database.tables.blockTable.getIdAt(arrowId)
+  }
+
+  /**
+   * Resolves the effective arrowhead size.
+   *
+   * @returns Arrowhead size used for rendering.
+   */
+  private getResolvedArrowheadSize() {
+    const style = this.getMLeaderStyle()
+    const styleArrowSize = style?.arrowSize ?? style?.scale
+    return (
+      this.arrowheadSize ??
+      this.contentScale ??
+      styleArrowSize ??
+      this.getResolvedTextHeight()
+    )
+  }
+
+  /**
+   * Resolves effective text height by style and override-flag rules.
+   */
+  private getResolvedTextHeight() {
+    const styleTextHeight = this.getMLeaderStyle()?.textHeight
+    if (this.textHeight > 0) return this.textHeight
+    if (styleTextHeight != null && styleTextHeight > 0) return styleTextHeight
+    return 2.5
+  }
+
+  /**
+   * Resolves renderable MText content using entity content first, with style fallback.
+   */
+  private getRenderableMTextContent() {
+    if (this._mtextContent) {
+      return {
+        text: this._mtextContent.text,
+        anchorPoint: this._mtextContent.anchorPoint
+      }
+    }
+
+    const defaultText = this.getMLeaderStyle()?.defaultMTextContents
+    const anchorPoint =
+      this.textAnchor ?? this.contentBasePosition ?? this._landingPoint
+    if (!defaultText || !anchorPoint) return undefined
+    return {
+      text: defaultText,
+      anchorPoint
+    }
+  }
+
+  /**
+   * Computes render width for current MText content.
+   *
+   * @returns Explicit width or an estimated width based on plain text length.
+   */
+  private getMTextRenderWidth(text: string, textHeight: number) {
     if (this._textWidth > 0) return this._textWidth
-    if (!this._mtextContent) return this._textWidth
+    if (!text) return this._textWidth
 
-    const plainText = this._mtextContent.text
+    const plainText = text
       .replace(/\\[PpNn]/g, '\n')
       .replace(/\\[A-Za-z][^;]*;/g, '')
       .replace(/[{}]/g, '')
@@ -1118,9 +2078,15 @@ export class AcDbMLeader extends AcDbEntity {
       ...plainText.split(/\r\n|\r|\n/g).map(line => line.length),
       1
     )
-    return Math.max(this._textHeight, longestLineLength * this._textHeight)
+    return Math.max(textHeight, longestLineLength * textHeight)
   }
 
+  /**
+   * Transforms a direction vector with an affine matrix.
+   *
+   * @param vector Vector to mutate.
+   * @param matrix Transformation matrix.
+   */
   private transformVector(vector: AcGeVector3d, matrix: AcGeMatrix3d) {
     const origin = new AcGePoint3d()
     const endpoint = new AcGePoint3d(vector.x, vector.y, vector.z)
@@ -1133,10 +2099,49 @@ export class AcDbMLeader extends AcDbEntity {
     )
   }
 
+  /**
+   * Resolves the referenced MLeader style object.
+   */
+  private getMLeaderStyle(): AcDbMLeaderStyle | undefined {
+    const dictionary = this.database.objects.mleaderStyle
+    const styleId = this.mleaderStyleId || this.leaderStyleId
+    if (styleId) {
+      const style = dictionary.getIdAt(styleId)
+      if (style) return style
+    }
+    return dictionary.newIterator().toArray()[0]
+  }
+
+  /**
+   * Resolves text style name considering entity values, ids and style fallback.
+   */
+  private getResolvedTextStyleName() {
+    const textStyleTable = this.database.tables.textStyleTable
+    const styleIdFromStyle = this.getMLeaderStyle()?.textStyleId
+    const styleNameFromStyleId = styleIdFromStyle
+      ? textStyleTable.getIdAt(styleIdFromStyle)?.name
+      : undefined
+
+    if (this.textStyleName) return this.textStyleName
+
+    const directStyle = this.textStyleId
+      ? textStyleTable.getIdAt(this.textStyleId)
+      : undefined
+    if (directStyle?.name) return directStyle.name
+
+    return styleNameFromStyleId
+  }
+
+  /**
+   * Resolves the text style used by renderer-side MText drawing.
+   *
+   * @returns A valid text style object.
+   */
   private getTextStyle(): AcGiTextStyle {
     const textStyleTable = this.database.tables.textStyleTable
+    const textStyleName = this.getResolvedTextStyleName()
     const style =
-      textStyleTable.getAt(this.textStyleName) ??
+      (textStyleName ? textStyleTable.getAt(textStyleName) : undefined) ??
       textStyleTable.getAt(this.database.textstyle) ??
       textStyleTable.getAt(DEFAULT_TEXT_STYLE)
 
@@ -1146,3 +2151,5 @@ export class AcDbMLeader extends AcDbEntity {
     return style.textStyle
   }
 }
+
+

--- a/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
@@ -4,15 +4,9 @@ import {
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
-import {
-  AcGiEntity,
-  AcGiLineArrowStyle,
-  AcGiRenderer
-} from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../../base'
 import { AcDbEntityProperties } from '../AcDbEntityProperties'
-import { AcDbLine } from '../AcDbLine'
 import { AcDbDimension } from './AcDbDimension'
 
 /**
@@ -229,93 +223,6 @@ export class AcDbDiametricDimension extends AcDbDimension {
   get geometricExtents() {
     // TODO: Finish it
     return new AcGeBox3d()
-  }
-
-  /**
-   * Draws the dimension lines with appropriate arrow styles.
-   *
-   * This method handles the rendering of dimension lines based on the number of
-   * line segments. It applies different arrow styles to the first and last lines
-   * when appropriate, and sorts the lines for proper visual representation.
-   *
-   * @param renderer - The graphics renderer used to draw the dimension lines
-   * @param lines - Array of line entities that make up the dimension
-   * @returns Array of rendered graphics entities
-   * @protected
-   */
-  protected drawLines(renderer: AcGiRenderer, lines: AcDbLine[]) {
-    const results: AcGiEntity[] = []
-    const count = lines.length
-    if (count == 1) {
-      results.push(
-        this.drawLine(renderer, lines[0], {
-          firstArrow: this.firstArrowStyle
-        })
-      )
-    } else if (count == 3) {
-      this.sortLines(lines)
-      results.push(
-        this.drawLine(renderer, lines[0], {
-          firstArrow: this.firstArrowStyle
-        })
-      )
-      results.push(this.drawLine(renderer, lines[1]))
-      results.push(
-        this.drawLine(renderer, lines[2], {
-          firstArrow: this.firstArrowStyle
-        })
-      )
-    } else {
-      lines.forEach(line => {
-        results.push(this.drawLine(renderer, line))
-      })
-    }
-    return results
-  }
-
-  /**
-   * Draws a single line with optional arrow styling.
-   *
-   * @param renderer - The graphics renderer used to draw the line
-   * @param line - The line entity to draw
-   * @param lineArrowStyle - Optional arrow style configuration for the line
-   * @returns The rendered graphics entity
-   */
-  private drawLine(
-    renderer: AcGiRenderer,
-    line: AcDbLine,
-    lineArrowStyle?: AcGiLineArrowStyle
-  ) {
-    if (lineArrowStyle) {
-      const points = [line.startPoint, line.endPoint]
-      return renderer.lines(points)
-    } else {
-      return line.worldDraw(renderer)!
-    }
-  }
-
-  /**
-   * Sorts the dimension lines for proper visual representation.
-   *
-   * This method sorts the line segments based on their start and end points to ensure
-   * they are drawn in the correct order for proper dimension visualization.
-   *
-   * @param lines - Array of line entities to sort
-   */
-  private sortLines(lines: AcDbLine[]) {
-    // Function to compare positions of points
-    const comparePoints = (a: AcGePoint3d, b: AcGePoint3d): number => {
-      if (a.x !== b.x) return a.x - b.x
-      if (a.y !== b.y) return a.y - b.y
-      return a.z - b.z
-    }
-
-    // Sort segments based on the start points first, then end points
-    lines.sort((segA, segB) => {
-      const startCompare = comparePoints(segA.startPoint, segB.startPoint)
-      if (startCompare !== 0) return startCompare
-      return comparePoints(segA.endPoint, segB.endPoint)
-    })
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -11,7 +11,6 @@ import {
 import {
   AcGiArrowStyle,
   AcGiArrowType,
-  AcGiLineArrowStyle,
   AcGiRenderer
 } from '@mlightcad/graphic-interface'
 
@@ -28,7 +27,6 @@ import {
   AcDbEntityPropertyType,
   AcDbEntityRuntimeProperty
 } from '../AcDbEntityProperties'
-import { AcDbLine } from '../AcDbLine'
 
 /**
  * Defines the line spacing style for dimension text.
@@ -716,17 +714,6 @@ export abstract class AcDbDimension extends AcDbEntity {
    */
   protected get arrowLineCount() {
     return 1
-  }
-
-  /**
-   * Get line arrow style of the specified line according to its type (extension line or dimension
-   * line). Return undefined if no line arrow style applied.
-   * @param line Input line to get its line style
-   * @returns Return the line style of the specified line. Return undefined if no line arrow style applied.
-   */
-  // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
-  protected getLineArrowStyle(line: AcDbLine): AcGiLineArrowStyle | undefined {
-    return undefined
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
@@ -4,11 +4,9 @@ import {
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
-import { AcGiLineArrowStyle } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../../base'
 import { AcDbEntityProperties } from '../AcDbEntityProperties'
-import { AcDbLine } from '../AcDbLine'
 import { AcDbDimension } from './AcDbDimension'
 
 /**
@@ -327,15 +325,6 @@ export class AcDbRadialDimension extends AcDbDimension {
   get geometricExtents() {
     // TODO: Finish it
     return new AcGeBox3d()
-  }
-
-  /**
-   * @inheritdoc
-   */
-  protected getLineArrowStyle(_line: AcDbLine): AcGiLineArrowStyle | undefined {
-    return {
-      secondArrow: this.secondArrowStyle
-    }
   }
 
   /**

--- a/packages/data-model/src/object/AcDbMLeaderStyle.ts
+++ b/packages/data-model/src/object/AcDbMLeaderStyle.ts
@@ -1,0 +1,905 @@
+import {
+  AcGeVector3d,
+  AcGeVector3dLike
+} from '@mlightcad/geometry-engine'
+
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbObject } from '../base/AcDbObject'
+
+/**
+ * Represents the nongraphical MLEADERSTYLE object.
+ *
+ * This class mirrors the core ObjectARX `AcDbMLeaderStyle` get/set API by
+ * exposing equivalent TypeScript properties.
+ */
+export class AcDbMLeaderStyle extends AcDbObject {
+  private _unknown1?: number
+  private _contentType: number
+  private _drawMLeaderOrderType: number
+  private _drawLeaderOrderType: number
+  private _bitFlags: number
+  private _maxLeaderSegmentsPoints: number
+  private _firstSegmentAngleConstraint: number
+  private _secondSegmentAngleConstraint: number
+  private _leaderLineType: number
+  private _leaderLineColor: number
+  private _leaderLineTypeId?: string
+  private _leaderLineWeight: number
+  private _enableLanding: boolean
+  private _landingGap: number
+  private _enableDogleg: boolean
+  private _doglegLength: number
+  private _description: string
+  private _arrowSymbolId?: string
+  private _arrowSize: number
+  private _defaultMTextContents: string
+  private _textStyleId?: string
+  private _textLeftAttachmentType: number
+  private _textAngleType: number
+  private _textAlignmentType: number
+  private _textRightAttachmentType: number
+  private _textColor: number
+  private _textHeight: number
+  private _enableFrameText: boolean
+  private _textAlignAlwaysLeft: boolean
+  private _alignSpace: number
+  private _blockId?: string
+  private _blockColor: number
+  private _blockScale: AcGeVector3d
+  private _enableBlockScale: boolean
+  private _blockRotation: number
+  private _enableBlockRotation: boolean
+  private _blockConnectionType: number
+  private _scale: number
+  private _overwritePropChanged: boolean
+  private _annotative: boolean
+  private _breakSize: number
+  private _textAttachmentDirection: number
+  private _bottomTextAttachmentType: number
+  private _topTextAttachmentType: number
+  private _unknown2?: boolean
+  private _extendLeaderToText: boolean
+  /**
+   * Creates an MLeader style with ObjectARX-compatible default values.
+   */
+  constructor() {
+    super()
+    this._contentType = 2
+    this._drawMLeaderOrderType = 1
+    this._drawLeaderOrderType = 0
+    this._bitFlags = 0
+    this._maxLeaderSegmentsPoints = -1
+    this._firstSegmentAngleConstraint = 0
+    this._secondSegmentAngleConstraint = 0
+    this._leaderLineType = 1
+    this._leaderLineColor = 256
+    this._leaderLineWeight = -2
+    this._enableLanding = true
+    this._landingGap = 2
+    this._enableDogleg = true
+    this._doglegLength = 8
+    this._description = ''
+    this._arrowSize = 4
+    this._defaultMTextContents = ''
+    this._textLeftAttachmentType = 1
+    this._textAngleType = 1
+    this._textAlignmentType = 0
+    this._textRightAttachmentType = 1
+    this._textColor = 256
+    this._textHeight = 4
+    this._enableFrameText = false
+    this._textAlignAlwaysLeft = false
+    this._alignSpace = 0
+    this._blockColor = 0
+    this._blockScale = new AcGeVector3d(1, 1, 1)
+    this._enableBlockScale = true
+    this._blockRotation = 0
+    this._enableBlockRotation = false
+    this._blockConnectionType = 0
+    this._scale = 1
+    this._overwritePropChanged = false
+    this._annotative = false
+    this._breakSize = 0
+    this._textAttachmentDirection = 0
+    this._bottomTextAttachmentType = 9
+    this._topTextAttachmentType = 9
+    this._extendLeaderToText = false
+  }
+
+  /**
+   * Gets the first undocumented raw style value.
+   */
+
+  get unknown1() {
+    return this._unknown1
+  }
+  set unknown1(value: number | undefined) {
+    this._unknown1 = value
+  }
+
+  /**
+   * Gets the content type.
+   */
+
+  get contentType() {
+    return this._contentType
+  }
+  set contentType(value: number) {
+    this._contentType = value
+  }
+
+  /**
+   * Gets the draw mleader order type.
+   */
+
+  get drawMLeaderOrderType() {
+    return this._drawMLeaderOrderType
+  }
+  set drawMLeaderOrderType(value: number) {
+    this._drawMLeaderOrderType = value
+  }
+
+  /**
+   * Gets the draw leader order type.
+   */
+
+  get drawLeaderOrderType() {
+    return this._drawLeaderOrderType
+  }
+  set drawLeaderOrderType(value: number) {
+    this._drawLeaderOrderType = value
+  }
+
+  /**
+   * Gets the bit flags.
+   */
+
+  get bitFlags() {
+    return this._bitFlags
+  }
+  set bitFlags(value: number) {
+    this._bitFlags = value
+  }
+
+  /**
+   * Gets the max leader segments points.
+   */
+
+  get maxLeaderSegmentsPoints() {
+    return this._maxLeaderSegmentsPoints
+  }
+  set maxLeaderSegmentsPoints(value: number) {
+    this._maxLeaderSegmentsPoints = value
+  }
+
+  /**
+   * Gets the legacy alias of `maxLeaderSegmentsPoints`.
+   */
+
+  get maxLeaderSegmentPoints() {
+    return this.maxLeaderSegmentsPoints
+  }
+  set maxLeaderSegmentPoints(value: number) {
+    this.maxLeaderSegmentsPoints = value
+  }
+
+  /**
+   * Gets the first segment angle constraint.
+   */
+
+  get firstSegmentAngleConstraint() {
+    return this._firstSegmentAngleConstraint
+  }
+  set firstSegmentAngleConstraint(value: number) {
+    this._firstSegmentAngleConstraint = value
+  }
+
+  /**
+   * Gets the second segment angle constraint.
+   */
+
+  get secondSegmentAngleConstraint() {
+    return this._secondSegmentAngleConstraint
+  }
+  set secondSegmentAngleConstraint(value: number) {
+    this._secondSegmentAngleConstraint = value
+  }
+
+  /**
+   * Gets the leader line type.
+   */
+
+  get leaderLineType() {
+    return this._leaderLineType
+  }
+  set leaderLineType(value: number) {
+    this._leaderLineType = value
+  }
+
+  /**
+   * Gets the leader line color.
+   */
+
+  get leaderLineColor() {
+    return this._leaderLineColor
+  }
+  set leaderLineColor(value: number) {
+    this._leaderLineColor = value
+  }
+
+  /**
+   * Gets the leader line type id.
+   */
+
+  get leaderLineTypeId() {
+    return this._leaderLineTypeId
+  }
+  set leaderLineTypeId(value: string | undefined) {
+    this._leaderLineTypeId = value
+  }
+
+  /**
+   * Gets the leader line weight.
+   */
+
+  get leaderLineWeight() {
+    return this._leaderLineWeight
+  }
+  set leaderLineWeight(value: number) {
+    this._leaderLineWeight = value
+  }
+
+  /**
+   * Gets the enable landing.
+   */
+
+  get enableLanding() {
+    return this._enableLanding
+  }
+  set enableLanding(value: boolean) {
+    this._enableLanding = value
+  }
+
+  /**
+   * Gets the alias of `enableLanding`.
+   */
+
+  get landingEnabled() {
+    return this.enableLanding
+  }
+  set landingEnabled(value: boolean) {
+    this.enableLanding = value
+  }
+
+  /**
+   * Gets the landing gap.
+   */
+
+  get landingGap() {
+    return this._landingGap
+  }
+  set landingGap(value: number) {
+    this._landingGap = value
+  }
+
+  /**
+   * Gets the enable dogleg.
+   */
+
+  get enableDogleg() {
+    return this._enableDogleg
+  }
+  set enableDogleg(value: boolean) {
+    this._enableDogleg = value
+  }
+
+  /**
+   * Gets the alias of `enableDogleg`.
+   */
+
+  get doglegEnabled() {
+    return this.enableDogleg
+  }
+  set doglegEnabled(value: boolean) {
+    this.enableDogleg = value
+  }
+
+  /**
+   * Gets the dogleg length.
+   */
+
+  get doglegLength() {
+    return this._doglegLength
+  }
+  set doglegLength(value: number) {
+    this._doglegLength = value
+  }
+
+  /**
+   * Gets the description.
+   */
+
+  get description() {
+    return this._description
+  }
+  set description(value: string) {
+    this._description = value
+  }
+
+  /**
+   * Gets the arrow symbol id.
+   */
+
+  get arrowSymbolId() {
+    return this._arrowSymbolId
+  }
+  set arrowSymbolId(value: string | undefined) {
+    this._arrowSymbolId = value
+  }
+
+  /**
+   * Gets the alias of `arrowSymbolId`.
+   */
+
+  get arrowheadId() {
+    return this.arrowSymbolId
+  }
+  set arrowheadId(value: string | undefined) {
+    this.arrowSymbolId = value
+  }
+
+  /**
+   * Gets the arrow size.
+   */
+
+  get arrowSize() {
+    return this._arrowSize
+  }
+  set arrowSize(value: number) {
+    this._arrowSize = value
+  }
+
+  /**
+   * Gets the alias of `arrowSize`.
+   */
+
+  get arrowheadSize() {
+    return this.arrowSize
+  }
+  set arrowheadSize(value: number) {
+    this.arrowSize = value
+  }
+
+  /**
+   * Gets the default mtext contents.
+   */
+
+  get defaultMTextContents() {
+    return this._defaultMTextContents
+  }
+  set defaultMTextContents(value: string) {
+    this._defaultMTextContents = value
+  }
+
+  /**
+   * Gets the alias of `defaultMTextContents`.
+   */
+
+  get defaultMText() {
+    return this.defaultMTextContents
+  }
+  set defaultMText(value: string) {
+    this.defaultMTextContents = value
+  }
+
+  /**
+   * Gets the alias of `defaultMTextContents`.
+   */
+
+  get textString() {
+    return this.defaultMTextContents
+  }
+  set textString(value: string) {
+    this.defaultMTextContents = value
+  }
+
+  /**
+   * Gets the text style id.
+   */
+
+  get textStyleId() {
+    return this._textStyleId
+  }
+  set textStyleId(value: string | undefined) {
+    this._textStyleId = value
+  }
+
+  /**
+   * Gets the alias of `textStyleId`.
+   */
+
+  get textStyle() {
+    return this.textStyleId
+  }
+  set textStyle(value: string | undefined) {
+    this.textStyleId = value
+  }
+
+  /**
+   * Gets the text left attachment type.
+   */
+
+  get textLeftAttachmentType() {
+    return this._textLeftAttachmentType
+  }
+  set textLeftAttachmentType(value: number) {
+    this._textLeftAttachmentType = value
+  }
+
+  /**
+   * Gets the text angle type.
+   */
+
+  get textAngleType() {
+    return this._textAngleType
+  }
+  set textAngleType(value: number) {
+    this._textAngleType = value
+  }
+
+  /**
+   * Gets the text alignment type.
+   */
+
+  get textAlignmentType() {
+    return this._textAlignmentType
+  }
+  set textAlignmentType(value: number) {
+    this._textAlignmentType = value
+  }
+
+  /**
+   * Gets the text right attachment type.
+   */
+
+  get textRightAttachmentType() {
+    return this._textRightAttachmentType
+  }
+  set textRightAttachmentType(value: number) {
+    this._textRightAttachmentType = value
+  }
+
+  /**
+   * Gets the text color.
+   */
+
+  get textColor() {
+    return this._textColor
+  }
+  set textColor(value: number) {
+    this._textColor = value
+  }
+
+  /**
+   * Gets the text height.
+   */
+
+  get textHeight() {
+    return this._textHeight
+  }
+  set textHeight(value: number) {
+    this._textHeight = value
+  }
+
+  /**
+   * Gets the enable frame text.
+   */
+
+  get enableFrameText() {
+    return this._enableFrameText
+  }
+  set enableFrameText(value: boolean) {
+    this._enableFrameText = value
+  }
+
+  /**
+   * Gets the alias of `enableFrameText`.
+   */
+
+  get textFrameEnabled() {
+    return this.enableFrameText
+  }
+  set textFrameEnabled(value: boolean) {
+    this.enableFrameText = value
+  }
+
+  /**
+   * Gets the text align always left.
+   */
+
+  get textAlignAlwaysLeft() {
+    return this._textAlignAlwaysLeft
+  }
+  set textAlignAlwaysLeft(value: boolean) {
+    this._textAlignAlwaysLeft = value
+  }
+
+  /**
+   * Gets the align space.
+   */
+
+  get alignSpace() {
+    return this._alignSpace
+  }
+  set alignSpace(value: number) {
+    this._alignSpace = value
+  }
+
+  /**
+   * Gets the block id.
+   */
+
+  get blockId() {
+    return this._blockId
+  }
+  set blockId(value: string | undefined) {
+    this._blockId = value
+  }
+
+  /**
+   * Gets the alias of `blockId`.
+   */
+
+  get blockContentId() {
+    return this.blockId
+  }
+  set blockContentId(value: string | undefined) {
+    this.blockId = value
+  }
+
+  /**
+   * Gets the block color.
+   */
+
+  get blockColor() {
+    return this._blockColor
+  }
+  set blockColor(value: number) {
+    this._blockColor = value
+  }
+
+  /**
+   * Gets the alias of `blockColor`.
+   */
+
+  get blockContentColor() {
+    return this.blockColor
+  }
+  set blockContentColor(value: number) {
+    this.blockColor = value
+  }
+
+  /**
+   * Gets the block scale.
+   */
+
+  get blockScale() {
+    return this._blockScale.clone()
+  }
+  set blockScale(value: AcGeVector3dLike) {
+    this._blockScale.copy(value)
+  }
+
+  /**
+   * Gets the alias of `blockScale`.
+   */
+
+  get blockContentScale() {
+    return this.blockScale
+  }
+  set blockContentScale(value: AcGeVector3dLike) {
+    this.blockScale = value
+  }
+
+  /**
+   * Gets the enable block scale.
+   */
+
+  get enableBlockScale() {
+    return this._enableBlockScale
+  }
+  set enableBlockScale(value: boolean) {
+    this._enableBlockScale = value
+  }
+
+  /**
+   * Gets the alias of `enableBlockScale`.
+   */
+
+  get blockContentScaleEnabled() {
+    return this.enableBlockScale
+  }
+  set blockContentScaleEnabled(value: boolean) {
+    this.enableBlockScale = value
+  }
+
+  /**
+   * Gets the block rotation.
+   */
+
+  get blockRotation() {
+    return this._blockRotation
+  }
+  set blockRotation(value: number) {
+    this._blockRotation = value
+  }
+
+  /**
+   * Gets the alias of `blockRotation`.
+   */
+
+  get blockContentRotation() {
+    return this.blockRotation
+  }
+  set blockContentRotation(value: number) {
+    this.blockRotation = value
+  }
+
+  /**
+   * Gets the enable block rotation.
+   */
+
+  get enableBlockRotation() {
+    return this._enableBlockRotation
+  }
+  set enableBlockRotation(value: boolean) {
+    this._enableBlockRotation = value
+  }
+
+  /**
+   * Gets the alias of `enableBlockRotation`.
+   */
+
+  get blockContentRotationEnabled() {
+    return this.enableBlockRotation
+  }
+  set blockContentRotationEnabled(value: boolean) {
+    this.enableBlockRotation = value
+  }
+
+  /**
+   * Gets the block connection type.
+   */
+
+  get blockConnectionType() {
+    return this._blockConnectionType
+  }
+  set blockConnectionType(value: number) {
+    this._blockConnectionType = value
+  }
+
+  /**
+   * Gets the alias of `blockConnectionType`.
+   */
+
+  get blockContentConnectionType() {
+    return this.blockConnectionType
+  }
+  set blockContentConnectionType(value: number) {
+    this.blockConnectionType = value
+  }
+
+  /**
+   * Gets the scale.
+   */
+
+  get scale() {
+    return this._scale
+  }
+  set scale(value: number) {
+    this._scale = value
+  }
+
+  /**
+   * Gets the alias of `scale`.
+   */
+
+  get scaleFactor() {
+    return this.scale
+  }
+  set scaleFactor(value: number) {
+    this.scale = value
+  }
+
+  /**
+   * Gets the overwrite prop changed.
+   */
+
+  get overwritePropChanged() {
+    return this._overwritePropChanged
+  }
+  set overwritePropChanged(value: boolean) {
+    this._overwritePropChanged = value
+  }
+
+  /**
+   * Gets the alias of `overwritePropChanged`.
+   */
+
+  get overwritePropertyValue() {
+    return this.overwritePropChanged
+  }
+  set overwritePropertyValue(value: boolean) {
+    this.overwritePropChanged = value
+  }
+
+  /**
+   * Gets the annotative.
+   */
+
+  get annotative() {
+    return this._annotative
+  }
+  set annotative(value: boolean) {
+    this._annotative = value
+  }
+
+  /**
+   * Gets the break size.
+   */
+
+  get breakSize() {
+    return this._breakSize
+  }
+  set breakSize(value: number) {
+    this._breakSize = value
+  }
+
+  /**
+   * Gets the alias of `breakSize`.
+   */
+
+  get breakGapSize() {
+    return this.breakSize
+  }
+  set breakGapSize(value: number) {
+    this.breakSize = value
+  }
+
+  /**
+   * Gets the text attachment direction.
+   */
+
+  get textAttachmentDirection() {
+    return this._textAttachmentDirection
+  }
+  set textAttachmentDirection(value: number) {
+    this._textAttachmentDirection = value
+  }
+
+  /**
+   * Gets the bottom text attachment type.
+   */
+
+  get bottomTextAttachmentType() {
+    return this._bottomTextAttachmentType
+  }
+  set bottomTextAttachmentType(value: number) {
+    this._bottomTextAttachmentType = value
+  }
+
+  /**
+   * Gets the alias of `bottomTextAttachmentType`.
+   */
+
+  get bottomTextAttachmentDirection() {
+    return this.bottomTextAttachmentType
+  }
+  set bottomTextAttachmentDirection(value: number) {
+    this.bottomTextAttachmentType = value
+  }
+
+  /**
+   * Gets the top text attachment type.
+   */
+
+  get topTextAttachmentType() {
+    return this._topTextAttachmentType
+  }
+  set topTextAttachmentType(value: number) {
+    this._topTextAttachmentType = value
+  }
+
+  /**
+   * Gets the alias of `topTextAttachmentType`.
+   */
+
+  get topTextAttachmentDirection() {
+    return this.topTextAttachmentType
+  }
+  set topTextAttachmentDirection(value: number) {
+    this.topTextAttachmentType = value
+  }
+
+  /**
+   * Gets the extend leader to text.
+   */
+
+  get extendLeaderToText() {
+    return this._extendLeaderToText
+  }
+  set extendLeaderToText(value: boolean) {
+    this._extendLeaderToText = value
+  }
+
+  /**
+   * Gets the second undocumented raw style value.
+   */
+
+  get unknown2() {
+    return this._unknown2
+  }
+  set unknown2(value: boolean | undefined) {
+    this._unknown2 = value
+  }
+
+  /**
+   * Writes this MLeaderStyle object to DXF fields.
+   *
+   * @param filer DXF filer that receives serialized group codes.
+   * @returns The current style instance for chaining.
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbMLeaderStyle')
+    filer.writeInt16(179, this.unknown1)
+    filer.writeInt16(170, this.contentType)
+    filer.writeInt16(171, this.drawMLeaderOrderType)
+    filer.writeInt16(172, this.drawLeaderOrderType)
+    filer.writeInt32(90, this.maxLeaderSegmentsPoints)
+    filer.writeDouble(40, this.firstSegmentAngleConstraint)
+    filer.writeDouble(41, this.secondSegmentAngleConstraint)
+    filer.writeInt16(173, this.leaderLineType)
+    filer.writeInt32(91, this.leaderLineColor)
+    filer.writeHandle(340, this.leaderLineTypeId)
+    filer.writeInt32(92, this.leaderLineWeight)
+    filer.writeBoolean(290, this.enableLanding)
+    filer.writeDouble(42, this.landingGap)
+    filer.writeBoolean(291, this.enableDogleg)
+    filer.writeDouble(43, this.doglegLength)
+    filer.writeString(3, this.description)
+    filer.writeHandle(341, this.arrowSymbolId)
+    filer.writeDouble(44, this.arrowSize)
+    filer.writeString(300, this.defaultMTextContents)
+    filer.writeHandle(342, this.textStyleId)
+    filer.writeInt16(174, this.textLeftAttachmentType)
+    filer.writeInt16(175, this.textAngleType)
+    filer.writeInt16(176, this.textAlignmentType)
+    filer.writeInt16(178, this.textRightAttachmentType)
+    filer.writeInt32(93, this.textColor)
+    filer.writeDouble(45, this.textHeight)
+    filer.writeBoolean(292, this.enableFrameText)
+    filer.writeBoolean(297, this.textAlignAlwaysLeft)
+    filer.writeDouble(46, this.alignSpace)
+    filer.writeHandle(343, this.blockId)
+    filer.writeInt32(94, this.blockColor)
+    filer.writeDouble(47, this._blockScale.x)
+    filer.writeDouble(49, this._blockScale.y)
+    filer.writeDouble(140, this._blockScale.z)
+    filer.writeBoolean(293, this.enableBlockScale)
+    filer.writeDouble(141, this.blockRotation)
+    filer.writeBoolean(294, this.enableBlockRotation)
+    filer.writeInt16(177, this.blockConnectionType)
+    filer.writeDouble(142, this.scale)
+    filer.writeBoolean(295, this.overwritePropChanged)
+    filer.writeBoolean(296, this.annotative)
+    filer.writeDouble(143, this.breakSize)
+    filer.writeInt16(271, this.textAttachmentDirection)
+    filer.writeInt16(272, this.bottomTextAttachmentType)
+    filer.writeInt16(273, this.topTextAttachmentType)
+    filer.writeBoolean(298, this.unknown2)
+    return this
+  }
+}
+
+

--- a/packages/data-model/src/object/index.ts
+++ b/packages/data-model/src/object/index.ts
@@ -1,4 +1,5 @@
 export * from './layout'
 export * from './AcDbDictionary'
+export * from './AcDbMLeaderStyle'
 export * from './AcDbRasterImageDef'
 export * from './AcDbXrecord'

--- a/packages/graphic-interface/src/AcGiLineStyle.ts
+++ b/packages/graphic-interface/src/AcGiLineStyle.ts
@@ -49,20 +49,6 @@ export interface AcGiArrowStyle {
 }
 
 /**
- * Interface to define arrow style of arrows at the start point and end point of one line
- */
-export interface AcGiLineArrowStyle {
-  /**
-   * Arrow style at the first point of the line. If it is undefined, no arrow style applied for this point.
-   */
-  firstArrow?: AcGiArrowStyle
-  /**
-   * Arrow style at the second point of the line. If it is undefined, no arrow style applied for this point.
-   */
-  secondArrow?: AcGiArrowStyle
-}
-
-/**
  * Line type
  */
 export interface AcGiBaseLineStyle {
@@ -103,9 +89,4 @@ export interface AcGiLineStyle extends AcGiBaseLineStyle {
    * - `UserSpecified`: The style is explicitly defined on the entity itself.
    */
   type: AcGiStyleType
-  /**
-   * Arrow style of arrows at the start point and end point of one line.
-   * If it is undefined, no arrow style applied at the start and end points.
-   */
-  arrows?: AcGiLineArrowStyle
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@mlightcad/dxf-json':
-        specifier: ^1.1.6
-        version: 1.1.6
+        specifier: ^1.1.7
+        version: 1.1.7
       '@mlightcad/geometry-engine':
         specifier: workspace:*
         version: link:../geometry-engine
@@ -1377,8 +1377,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.1.6':
-    resolution: {integrity: sha512-Z8nSRupkrELAEIYn46qoIsPUagLM7BUfiH8wg+fqIhaeRN2rbljCvEDx+SawXTMsE2ofg39Qcw6TJKyIci/2pg==}
+  '@mlightcad/dxf-json@1.1.7':
+    resolution: {integrity: sha512-iexpeEZVAUgdm25zRK6zuwvLmt3eeCUjKxDvS5thWjDl/bvccOZFE33Biiwrcw0dnM06EdkRWVFHJJNjF233uA==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -1453,24 +1453,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1516,36 +1520,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.0':
     resolution: {integrity: sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.0':
     resolution: {integrity: sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==}
@@ -1601,46 +1611,55 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -1698,24 +1717,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.13':
     resolution: {integrity: sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.13':
     resolution: {integrity: sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.13':
     resolution: {integrity: sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.13':
     resolution: {integrity: sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==}
@@ -6268,7 +6291,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.1.6':
+  '@mlightcad/dxf-json@1.1.7':
     dependencies:
       '@fxts/core': 1.26.0
 


### PR DESCRIPTION
## Summary
- Add first-class `AcDbMLeaderStyle` object support, including DXF serialization fields and compatibility aliases.
- Wire MLeader style dictionaries through database import/export/regeneration so `ACAD_MLEADERSTYLE` round-trips correctly.
- Update `AcDbMLeader` rendering to resolve arrow/text settings from entity overrides and style fallbacks.
- Add unit tests for MLeader arrowhead rendering behaviors (solid arrow, block-based arrow, `_NONE` suppression).

## Why
- MLeader rendering and DXF round-trip were missing key style-driven behavior from `MLEADERSTYLE`.
- Arrowhead and text output should honor style defaults when entity-level values are absent.
- Redundant arrow-style API paths in dimension/graphics interfaces were no longer aligned with current rendering flow.

## What Changed
- Added new object class: `AcDbMLeaderStyle` with ObjectARX-like properties and DXF writer support.
- Extended DXF/object converters to parse `MLEADERSTYLE` records into `AcDbMLeaderStyle`.
- Extended `AcDbDatabase` object dictionaries and export flow:
- Added `objects.mleaderStyle` dictionary.
- Emitted/removed `ACAD_MLEADERSTYLE` root entry based on dictionary content.
- Wrote `MLEADERSTYLE` objects during DXF export.
- Updated `AcDbRegenerator` to dispatch dictionary-set events for MLeader styles.
- Refactored `AcDbMLeader` drawing:
- Added style resolution helpers for arrow id/size, text height/style, and default MText content.
- Added block-based arrowhead rendering via `AcDbRenderingCache`.
- Added filled polygon arrow fallback rendering.
- Simplified line+arrow composition through dedicated drawing helpers.
- Removed unused line-arrow-style interfaces/hooks:
- Deleted `AcGiLineArrowStyle` and `AcGiLineStyle.arrows`.
- Removed legacy arrow-style overrides/helpers in radial/diametric dimension classes.
- Added `AcDbMLeader.spec.ts` coverage for style/default/block arrow cases.
- Switched `@mlightcad/dxf-json` in `packages/data-model` to a local path link; lockfile updated accordingly.

## Risks / Notes
- `@mlightcad/dxf-json` now points to a local relative path (`../../../dxf-json`), which may not be suitable for CI or external consumers unless that path exists in the target environment.
- Removing `AcGiLineArrowStyle` / `AcGiLineStyle.arrows` changes the public interface and may require downstream updates.
- `pnpm-lock.yaml` includes broad platform metadata churn beyond feature logic; reviewers may want to confirm this was produced by the intended package manager/toolchain.
