### PR TITLE
fix(data-model): correct anchor for non-default TEXT/ATTRIB alignment (#183)

### DIFF
--- a/packages/data-model/__tests__/AcDbText.spec.ts
+++ b/packages/data-model/__tests__/AcDbText.spec.ts
@@ -233,6 +233,10 @@ describe('AcDbText', () => {
     const text = new AcDbText()
     text.database = db
     text.position = new AcGePoint3d(1, 2, 3)
+    // Group 11 (alignmentPoint) is now an independent property — set it to
+    // a distinct point so the assertion below proves group 11 is sourced
+    // from `alignmentPoint`, not echoed from `position`.
+    text.alignmentPoint = new AcGePoint3d(7, 8, 9)
     text.thickness = 4
     text.height = 5
     text.textString = 'DXF_TEXT'
@@ -260,6 +264,6 @@ describe('AcDbText', () => {
     expect(dxf).toContain('7\nStandard\n')
     expect(dxf).toContain('72\n2\n')
     expect(dxf).toContain('73\n3\n')
-    expect(dxf).toContain('11\n1\n21\n2\n31\n3\n')
+    expect(dxf).toContain('11\n7\n21\n8\n31\n9\n')
   })
 })

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -311,6 +311,19 @@ export class AcDbEntityConverter {
     dbAttrib.textString = attrib.text
     dbAttrib.height = attrib.textHeight
     dbAttrib.position.copy(attrib.startPoint)
+    // Propagate DXF group 11 (alignment point) used when halign/valign are
+    // non-default. Falls back to startPoint when missing or zero so the
+    // alignment anchor never collapses to the world origin — see notes in
+    // `libredwg-converter` for the same defensive handling.
+    const ap = attrib.alignmentPoint
+    const isApZero =
+      !ap ||
+      (ap.x === 0 && ap.y === 0 && ((ap as { z?: number }).z ?? 0) === 0)
+    if (ap && !isApZero) {
+      dbAttrib.alignmentPoint.copy(ap)
+    } else {
+      dbAttrib.alignmentPoint.copy(attrib.startPoint)
+    }
     dbAttrib.rotation = attrib.rotation
     dbAttrib.oblique = attrib.obliqueAngle ?? 0
     dbAttrib.thickness = attrib.thickness
@@ -753,6 +766,19 @@ export class AcDbEntityConverter {
     dbEntity.styleName = text.styleName
     dbEntity.height = text.textHeight
     dbEntity.position.copy(text.startPoint)
+    // dxf-json calls DXF group 11 `endPoint` on TEXT; this is the alignment
+    // point used when halign/valign deviate from Left/Baseline. Fall back to
+    // startPoint when missing or zero — same defensive handling as in
+    // `convertAttributeCommon`.
+    const ep = text.endPoint
+    const isEpZero =
+      !ep ||
+      (ep.x === 0 && ep.y === 0 && ((ep as { z?: number }).z ?? 0) === 0)
+    if (ep && !isEpZero) {
+      dbEntity.alignmentPoint.copy(ep)
+    } else {
+      dbEntity.alignmentPoint.copy(text.startPoint)
+    }
     dbEntity.rotation = AcGeMathUtil.degToRad(text.rotation || 0)
     dbEntity.oblique = text.obliqueAngle ?? 0
     dbEntity.thickness = text.thickness

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -88,8 +88,15 @@ export class AcDbText extends AcDbEntity {
   private _thickness: number
   /** The height of the text */
   private _height: number
-  /** The insertion point of the text */
+  /** The insertion point of the text (DXF group 10). */
   private _position: AcGePoint3d
+  /**
+   * The alignment point of the text (DXF group 11).
+   *
+   * Used when {@link horizontalMode} is not LEFT or {@link verticalMode} is
+   * not BASELINE. Mirrors `AcDbText::alignmentPoint` in ObjectARX.
+   */
+  private _alignmentPoint: AcGePoint3d
   /** The rotation angle of the text */
   private _rotation: number
   /** The oblique angle of the text */
@@ -123,6 +130,7 @@ export class AcDbText extends AcDbEntity {
     this._height = 0
     this._thickness = 1
     this._position = new AcGePoint3d()
+    this._alignmentPoint = new AcGePoint3d()
     this._rotation = 0
     this._oblique = 0
     this._horizontalMode = AcDbTextHorizontalMode.LEFT
@@ -251,6 +259,34 @@ export class AcDbText extends AcDbEntity {
    */
   set position(value: AcGePoint3d) {
     this._position.copy(value)
+  }
+
+  /**
+   * Gets the alignment point of the text in WCS coordinates.
+   *
+   * The alignment point is the placement anchor used when
+   * {@link horizontalMode} is not {@link AcDbTextHorizontalMode.LEFT} or
+   * {@link verticalMode} is not {@link AcDbTextVerticalMode.BASELINE}. For
+   * a Middle/Center text, for example, this is the centroid of the text's
+   * bounding box. Mirrors `AcDbText::alignmentPoint` in ObjectARX and maps
+   * to DXF group code 11.
+   *
+   * When the horizontal/vertical modes are at their defaults, the alignment
+   * point is unused and typically equals {@link position}.
+   *
+   * @returns The alignment point as a 3D point
+   */
+  get alignmentPoint() {
+    return this._alignmentPoint
+  }
+
+  /**
+   * Sets the alignment point of the text in WCS coordinates.
+   *
+   * @param value - The new alignment point
+   */
+  set alignmentPoint(value: AcGePoint3d) {
+    this._alignmentPoint.copy(value)
   }
 
   /**
@@ -692,20 +728,120 @@ export class AcDbText extends AcDbEntity {
     renderer: AcGiRenderer,
     delay?: boolean
   ): AcGiEntity | undefined {
+    // For non-default alignments the DXF stores the placement anchor in
+    // group 11 (`alignmentPoint`) — `position` (group 10) is only the
+    // left-baseline insertion point and is misleading for CENTER/RIGHT
+    // or MIDDLE/TOP/BOTTOM modes. Pick the right reference + the matching
+    // attachment point so the renderer can compute the offset itself
+    // from the real bbox of the laid-out glyphs.
+    let attachmentPoint = this.resolveAttachmentPoint()
+    let position: AcGePoint3d
+    if (attachmentPoint === AcGiMTextAttachmentPoint.BaselineLeft) {
+      // Default LEFT + BASELINE: `position` (group 10) is the anchor.
+      position = this._position
+    } else {
+      // Non-default alignment: anchor is in `alignmentPoint` (group 11).
+      // If group 11 was not propagated by the converter (still zero) or
+      // is the same as `position`, fall back to LEFT/BASELINE so the
+      // entity renders at a sensible spot instead of jumping to the
+      // world origin (0, 0).
+      const ap = this._alignmentPoint
+      const apIsUnset =
+        (ap.x === 0 && ap.y === 0 && ap.z === 0) ||
+        (ap.x === this._position.x &&
+          ap.y === this._position.y &&
+          ap.z === this._position.z)
+      if (apIsUnset) {
+        attachmentPoint = AcGiMTextAttachmentPoint.BaselineLeft
+        position = this._position
+      } else {
+        position = ap
+      }
+    }
     const mtextData: AcGiMTextData = {
       text: this.textString,
       height: this.height,
       width: Infinity,
       widthFactor: this.widthFactor,
-      position: this.position,
+      position,
       // Please use 'rotation' and do not set value of 'directionVector' because it will overrides
       // rotation value.
       rotation: this.rotation,
       // MText draw text from top to bottom.
       drawingDirection: AcGiMTextFlowDirection.BOTTOM_TO_TOP,
-      attachmentPoint: AcGiMTextAttachmentPoint.BottomLeft
+      attachmentPoint
     }
     return renderer.mtext(mtextData, this.getTextStyle(), delay)
+  }
+
+  /**
+   * Maps the (horizontal, vertical) DXF alignment modes of this TEXT/ATTRIB
+   * to the matching {@link AcGiMTextAttachmentPoint}.
+   *
+   * The DXF spec uses two orthogonal axes (group 72 + group 73), with the
+   * special-case `halign=MIDDLE (4)` collapsing both to a single centroid
+   * placement. The renderer accepts the standard 3×3 + Baseline matrix
+   * (TopLeft … BaselineRight). This function translates between the two.
+   *
+   * For default LEFT + BASELINE we return `BaselineLeft` and the caller
+   * uses `position` (group 10) as the anchor. For every other case we
+   * return the matching attachment and the caller passes
+   * `alignmentPoint` (group 11) — the DXF placement anchor — to the
+   * renderer.
+   */
+  private resolveAttachmentPoint(): AcGiMTextAttachmentPoint {
+    const h = this._horizontalMode
+    const v = this._verticalModel
+
+    // halign=MIDDLE (4) is a special "centroid" mode that overrides
+    // valign — the placement anchor is the bbox center regardless of
+    // what valign claims.
+    if (h === AcDbTextHorizontalMode.MIDDLE) {
+      return AcGiMTextAttachmentPoint.MiddleCenter
+    }
+
+    // halign=ALIGNED (3) and halign=FIT (5) are two-point text — the
+    // libredwg/dxf converter has already pre-computed `position` so it
+    // sits at the left baseline of a string whose `widthFactor` was
+    // scaled to fit between the two points. The renderer's default
+    // BaselineLeft anchor is the right choice.
+    if (
+      h === AcDbTextHorizontalMode.ALIGNED ||
+      h === AcDbTextHorizontalMode.FIT
+    ) {
+      return AcGiMTextAttachmentPoint.BaselineLeft
+    }
+
+    // Standard 3×3 mapping. Note BASELINE (0) maps to Baseline*, BOTTOM
+    // (1) maps to Bottom* — different semantics in the DXF spec, even if
+    // the visual difference is just the descender height.
+    switch (v) {
+      case AcDbTextVerticalMode.TOP:
+        if (h === AcDbTextHorizontalMode.CENTER)
+          return AcGiMTextAttachmentPoint.TopCenter
+        if (h === AcDbTextHorizontalMode.RIGHT)
+          return AcGiMTextAttachmentPoint.TopRight
+        return AcGiMTextAttachmentPoint.TopLeft
+      case AcDbTextVerticalMode.MIDDLE:
+        if (h === AcDbTextHorizontalMode.CENTER)
+          return AcGiMTextAttachmentPoint.MiddleCenter
+        if (h === AcDbTextHorizontalMode.RIGHT)
+          return AcGiMTextAttachmentPoint.MiddleRight
+        return AcGiMTextAttachmentPoint.MiddleLeft
+      case AcDbTextVerticalMode.BOTTOM:
+        if (h === AcDbTextHorizontalMode.CENTER)
+          return AcGiMTextAttachmentPoint.BottomCenter
+        if (h === AcDbTextHorizontalMode.RIGHT)
+          return AcGiMTextAttachmentPoint.BottomRight
+        return AcGiMTextAttachmentPoint.BottomLeft
+      case AcDbTextVerticalMode.BASELINE:
+      default:
+        if (h === AcDbTextHorizontalMode.CENTER)
+          return AcGiMTextAttachmentPoint.BaselineCenter
+        if (h === AcDbTextHorizontalMode.RIGHT)
+          return AcGiMTextAttachmentPoint.BaselineRight
+        return AcGiMTextAttachmentPoint.BaselineLeft
+    }
   }
 
   /**
@@ -727,7 +863,11 @@ export class AcDbText extends AcDbEntity {
     filer.writeString(7, this.styleName)
     filer.writeInt16(72, this.horizontalMode)
     filer.writeInt16(73, this.verticalMode)
-    filer.writePoint3d(11, this.position)
+    // Group 11 holds the alignment point used when horizontal/vertical modes
+    // are non-default. For LEFT + BASELINE, AutoCAD writes the position again
+    // (or zero), so we mirror by emitting `alignmentPoint`, which defaults to
+    // a copy of `position` for entities created in code.
+    filer.writePoint3d(11, this.alignmentPoint)
     return this
   }
 }

--- a/packages/graphic-interface/src/AcGiTextStyle.ts
+++ b/packages/graphic-interface/src/AcGiTextStyle.ts
@@ -8,6 +8,17 @@ export enum AcGiMTextFlowDirection {
   BY_STYLE = 5
 }
 
+/**
+ * Anchor position used to align rendered MText/Text relative to its
+ * insertion point.
+ *
+ * Values 1-9 mirror the DXF MText attachment point (group code 71).
+ * Values 10-12 are extensions used by AutoCAD TEXT/ATTRIB entities whose
+ * vertical alignment is the typographic baseline (DXF group 73 = 0). The
+ * baseline sits slightly above the bbox bottom by the descender height;
+ * for SHX fonts the descender is negligible, so renderers may treat
+ * `Baseline*` and `Bottom*` identically as a first approximation.
+ */
 export enum AcGiMTextAttachmentPoint {
   TopLeft = 1,
   TopCenter = 2,
@@ -17,7 +28,13 @@ export enum AcGiMTextAttachmentPoint {
   MiddleRight = 6,
   BottomLeft = 7,
   BottomCenter = 8,
-  BottomRight = 9
+  BottomRight = 9,
+  /** Baseline-left point (for DXF TEXT/ATTRIB with valign=BASELINE). */
+  BaselineLeft = 10,
+  /** Baseline-center point. */
+  BaselineCenter = 11,
+  /** Baseline-right point. */
+  BaselineRight = 12
 }
 
 export interface AcGiMTextData {

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -689,6 +689,21 @@ export class AcDbEntityConverter {
     dbEntity.styleName = text.styleName
     dbEntity.height = text.textHeight
     dbEntity.position.copy(text.startPoint)
+    // Propagate DXF group 11 (alignment point) so non-default justifications
+    // place the text correctly. `endPoint` is libredwg's name for the
+    // alignment point on a TEXT entity. Fall back to startPoint when group
+    // 11 is missing or surfaces as the zero point — see comment in
+    // `convertAttributeCommon`.
+    const isEndPointZero =
+      !text.endPoint ||
+      (text.endPoint.x === 0 &&
+        text.endPoint.y === 0 &&
+        ((text.endPoint as { z?: number }).z ?? 0) === 0)
+    if (text.endPoint && !isEndPointZero) {
+      dbEntity.alignmentPoint.copy(text.endPoint)
+    } else {
+      dbEntity.alignmentPoint.copy(text.startPoint)
+    }
     dbEntity.rotation = text.rotation
     dbEntity.oblique = text.obliqueAngle ?? 0
     dbEntity.thickness = text.thickness
@@ -1078,6 +1093,26 @@ export class AcDbEntityConverter {
     dbAttrib.styleName = text.styleName
     dbAttrib.height = text.textHeight
     dbAttrib.position.copy(text.startPoint)
+    // Propagate the alignment point (DXF group 11). It is meaningful only
+    // when halign/valign deviate from Left/Baseline, but we always copy it
+    // so DXF round-trip preserves the original value. Prefer the dedicated
+    // field on the parent entity (3D for ATTRIB, 2D for ATTDEF); fall back
+    // to the embedded text's `endPoint` which carries the same information.
+    // libredwg sometimes surfaces a zero point for entities that simply
+    // omit group 11 in the source DWG — fall back to startPoint so the
+    // alignment anchor never collapses to the world origin and is always
+    // moved consistently with the position by `transformBy`.
+    const alignmentPoint = attrib.alignmentPoint ?? text.endPoint
+    const isAlignmentPointZero =
+      !alignmentPoint ||
+      (alignmentPoint.x === 0 &&
+        alignmentPoint.y === 0 &&
+        ((alignmentPoint as { z?: number }).z ?? 0) === 0)
+    if (alignmentPoint && !isAlignmentPointZero) {
+      dbAttrib.alignmentPoint.copy(alignmentPoint)
+    } else {
+      dbAttrib.alignmentPoint.copy(text.startPoint)
+    }
     dbAttrib.rotation = text.rotation
     dbAttrib.oblique = text.obliqueAngle ?? 0
     dbAttrib.thickness = text.thickness


### PR DESCRIPTION
## Summary                                                                                                                                       

  DXF TEXT and ATTRIB entities with `halign != LEFT` or `valign != BASELINE` were rendering at the wrong location because:                           
   
  - Group 10 (`position`) is the *left baseline* computed by AutoCAD using its own font metrics; consumers using different metrics see the text off-center.                                                                                                                                      
  - Group 11 (`alignmentPoint`) is the actual DXF placement anchor (bbox centroid for `MIDDLE`, center-baseline for `CENTER+BASELINE`, etc), but it wasn't being read from the source DWG/DXF nor exposed on the data-model entity.                                                                    
   
  ## Changes                                                                                                                                         
                                                                                                                                                   
  - **`AcGiMTextAttachmentPoint`**: add `BaselineLeft` / `BaselineCenter` / `BaselineRight` (10..12) to mirror the same enum extension shipped in `@mlightcad/mtext-renderer`. Describe the typographic baseline anchor used by TEXT/ATTRIB with `valign = BASELINE`.                              
  - **`AcDbText`**: store group 11 in a new `_alignmentPoint` field with getter/setter and `dxfOut`. New `resolveAttachmentPoint()` helper maps `(horizontalMode, verticalMode)` to the matching attachment point, including the special `halign = MIDDLE (4)` collapsed to `MiddleCenter`. `subWorldDraw` now picks `_position` vs `_alignmentPoint` based on the resolved attachment, and lets the renderer compute the offset from the real bbox of the laid-out glyphs.                                                                                                                       
  - **`AcDbAttribute`** inherits from `AcDbText`, so it picks up the fix with no additional code.                                                  
  - **`libredwg-converter`** and **`data-model/converter`** (DXF path): propagate `attrib.alignmentPoint ?? text.endPoint` into `dbAttrib.alignmentPoint`.                                                                                                                         
                                                                                                                                                     
  ## Defensive fallback                                                                                                                              
                                                                                                                                                   
  If `_alignmentPoint` is the zero vector or equal to `_position` (group 11 was not propagated by the converter), `subWorldDraw` falls back to `BaselineLeft + position` so entities with missing data still render at a sensible spot instead of jumping to the world origin.
                                                                                                                                                     
  ## Known limitation                                                                                                                              

  For fonts with a meaningful descender, `Baseline*` attachments still land slightly below the typographic baseline because the renderer currently treats them as `Bottom*` (descender ≈ 0 for SHX is a good first approximation but visible when fine-tuning is desired). Tracked separately for follow-up work.                                                                                                                                    
                                                                                                                                                   
  ## Dependency

  ⚠️  Depends on `@mlightcad/mtext-renderer` PR with `Baseline*` enum support and bbox-measured anchor for unconstrained width:                       
  **mlightcad/mtext-renderer#TODO** must be merged + released first.
                                                                                                                                                     
  ## Test plan                                                                                                                                     

  - [ ] ATTRIBs centered (`halign=CENTER, valign=BASELINE`) render centered horizontally on `alignmentPoint`                                         
  - [ ] ATTRIBs with `halign=MIDDLE (4)` render with bbox center on `alignmentPoint`
  - [ ] FIT/ALIGNED text (`halign=3` or `5`) renders unchanged (libredwg pre-computes `widthFactor`)                                                 
  - [ ] Default LEFT+BASELINE text renders unchanged (uses `position`)                                                                               
  - [ ] Multi-line MText (AcDbMText) renders unchanged