### PR TITLE
feat: add SVG rendering support for hatch gradient previews

### DIFF
--- a/packages/data-model/__tests__/AcDbPat.spec.ts
+++ b/packages/data-model/__tests__/AcDbPat.spec.ts
@@ -1,3 +1,4 @@
+import type { AcDbGradientName } from '../src/entity/AcDbHatch'
 import { HATCH_PATTERN_SOLID } from '../src/misc'
 import {
   AcDbPatSvgRenderer,
@@ -20,6 +21,18 @@ describe('AcDbPat predefined patterns', () => {
 })
 
 describe('AcDbPatSvgRenderer', () => {
+  const gradientNames: AcDbGradientName[] = [
+    'LINEAR',
+    'CYLINDER',
+    'INVCYLINDER',
+    'SPHERICAL',
+    'INVSPHERICAL',
+    'HEMISPHERICAL',
+    'INVHEMISPHERICAL',
+    'CURVED',
+    'INVCURVED'
+  ]
+
   it('renders SOLID as an area fill', () => {
     const solid = AcDbPredefinedAcadPat.patterns.find(
       pattern => pattern.name === HATCH_PATTERN_SOLID
@@ -55,5 +68,35 @@ describe('AcDbPatSvgRenderer', () => {
     expect(svg).toContain('fill="#abcdef"')
     expect(svg).not.toContain('fill="#123456"')
     expect(svg).not.toContain('<path')
+  })
+
+  it.each(gradientNames)('renders %s gradient previews', name => {
+    const svg = new AcDbPatSvgRenderer().renderGradient(name, {
+      width: 24,
+      height: 16,
+      startColor: 0x112233,
+      endColor: 0x445566,
+      angle: Math.PI / 4,
+      shift: 0.2,
+      background: '#abcdef'
+    })
+
+    expect(svg).toContain('<defs>')
+    expect(svg).toContain('fill="#abcdef"')
+    expect(svg).toContain('fill="url(#acdb-pat-gradient-')
+    expect(svg).toContain('#112233')
+    expect(svg).toContain('#445566')
+    expect(svg).not.toContain('undefined')
+  })
+
+  it('supports one-color gradient shade and tint previews', () => {
+    const svg = new AcDbPatSvgRenderer().renderGradient('LINEAR', {
+      startColor: 0x336699,
+      oneColorMode: true,
+      shadeTintValue: 1
+    })
+
+    expect(svg).toContain('#336699')
+    expect(svg).toContain('#ffffff')
   })
 })

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -24,7 +24,11 @@ import { AcDbDxfFiler } from '../base'
 import type { AcDbDatabase } from '../database/AcDbDatabase'
 import { AcDbSystemVariables } from '../database/AcDbSystemVariables'
 import { AcDbSysVarManager } from '../database/AcDbSysVarManager'
-import { HATCH_PATTERN_SOLID, HATCH_PATTERN_USER } from '../misc/AcDbConstants'
+import {
+  DEFAULT_GRADIENT_HATCH_NAME,
+  HATCH_PATTERN_SOLID,
+  HATCH_PATTERN_USER
+} from '../misc/AcDbConstants'
 import { AcDbPredefinedAcadIsoPat } from '../misc/pat/AcDbPatPredefined'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
@@ -531,6 +535,9 @@ export class AcDbHatch extends AcDbEntity {
    * Gets the name of the current gradient.
    */
   get gradientName() {
+    if (this.isGradient && this._gradientName.trim() === '') {
+      return DEFAULT_GRADIENT_HATCH_NAME
+    }
     return this._gradientName
   }
 
@@ -538,7 +545,7 @@ export class AcDbHatch extends AcDbEntity {
    * Sets the name of the current gradient.
    */
   set gradientName(value: string) {
-    this._gradientName = value
+    this._gradientName = value ?? ''
   }
 
   /**
@@ -1272,7 +1279,7 @@ export class AcDbHatch extends AcDbEntity {
       filer.writeInt16(452, this._gradientOneColorMode ? 1 : 0)
       filer.writeAngle(460, this._gradientAngle)
       filer.writeDouble(461, this._gradientShift)
-      filer.writeString(470, this._gradientName)
+      filer.writeString(470, this.gradientName)
     }
     // TODO: Write the number of seed points
     filer.writeInt16(98, 0)

--- a/packages/data-model/src/misc/AcDbConstants.ts
+++ b/packages/data-model/src/misc/AcDbConstants.ts
@@ -50,6 +50,11 @@ export const HATCH_PATTERN_SOLID = 'SOLID'
 export const HATCH_PATTERN_USER = 'USER'
 
 /**
+ * Default gradient hatch name used when a gradient hatch has no explicit name.
+ */
+export const DEFAULT_GRADIENT_HATCH_NAME = 'LINEAR'
+
+/**
  * Special line type value that indicates the entity should use
  * the line type of its layer.
  *

--- a/packages/data-model/src/misc/pat/AcDbPatPredefined.ts
+++ b/packages/data-model/src/misc/pat/AcDbPatPredefined.ts
@@ -2832,12 +2832,12 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
   patterns: [
     {
       name: 'SOLID',
-      description: 'ʵ�����',
+      description: '',
       lines: []
     },
     {
       name: 'ANGLE',
-      description: '�Ǹ�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -2861,7 +2861,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI31',
-      description: 'ANSI ����ש��ʯ',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -2876,7 +2876,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI32',
-      description: 'ANSI ��',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -2900,7 +2900,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI33',
-      description: 'ANSI ��ͭ����ͭ����ͭ',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -2924,7 +2924,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI34',
-      description: 'ANSI ���Ϻ���',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -2966,7 +2966,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI35',
-      description: 'ANSI �ͻ�ש���ͻ����',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -2990,7 +2990,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI36',
-      description: 'ANSI ����ʯ�����ҺͲ���',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -3005,7 +3005,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI37',
-      description: 'ANSI Ǧ��п��þ����/��/���Ե��',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -3029,7 +3029,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ANSI38',
-      description: 'ANSI ��',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -3053,7 +3053,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-B816',
-      description: '8x16 ��ש˳��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3077,7 +3077,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-B816C',
-      description: '8x16 ��ש˳�����û���ӷ�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3119,7 +3119,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-B88',
-      description: '8x8 ��ש˳��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3143,7 +3143,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-BRELM',
-      description: '��׼ש��Ӣʽ�������û���ӷ�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3221,7 +3221,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-BRSTD',
-      description: '��׼ש��˳��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3245,7 +3245,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-CONC',
-      description: '����ĵ��ʯͷͼ��',
+      description: '',
       lines: [
         {
           angle: 50,
@@ -3368,7 +3368,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-HBONE',
-      description: '��׼��ש���������ͼ�� @ 45 �Ƚ�',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -3392,7 +3392,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-PARQ1',
-      description: '2x12 ��ľ�ذ�: 12x12 ��ͼ��',
+      description: '',
       lines: [
         {
           angle: 90,
@@ -3524,7 +3524,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-RROOF',
-      description: '�ݶ�ľ��ͼ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3557,7 +3557,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-RSHKE',
-      description: '�ݶ�ʵľ��ͼ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3644,7 +3644,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'AR-SAND',
-      description: '����ĵ�ͼ��',
+      description: '',
       lines: [
         {
           angle: 37.5,
@@ -3686,7 +3686,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'BOX',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 90,
@@ -3764,7 +3764,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'BRASS',
-      description: '��ͭ����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3788,7 +3788,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'BRICK',
-      description: 'שʯ���͵ı���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3821,7 +3821,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'BRSTONE',
-      description: 'ש��ʯ',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3899,7 +3899,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'CLAY',
-      description: 'ճ������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3941,7 +3941,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'CORK',
-      description: '��ľ����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -3983,7 +3983,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'CROSS',
-      description: 'һϵ��ʮ����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4007,7 +4007,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'DASH',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4022,7 +4022,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'DOLMIT',
-      description: '�ؿ��Ҳ�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4046,7 +4046,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'DOTS',
-      description: 'һϵ�е�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4061,7 +4061,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'EARTH',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4121,7 +4121,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ESCHER',
-      description: 'Escher ͼ��',
+      description: '',
       lines: [
         {
           angle: 60,
@@ -4316,7 +4316,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'FLEX',
-      description: '���Բ���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4340,7 +4340,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GOST_GLASS',
-      description: '��������',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -4373,7 +4373,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GOST_WOOD',
-      description: 'ľ�Ĳ���',
+      description: '',
       lines: [
         {
           angle: 90,
@@ -4406,7 +4406,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GOST_GROUND',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -4439,7 +4439,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GRASS',
-      description: '�ݵ�',
+      description: '',
       lines: [
         {
           angle: 90,
@@ -4472,7 +4472,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GRATE',
-      description: '��դ����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4496,7 +4496,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'GRAVEL',
-      description: 'ɳ��ͼ��',
+      description: '',
       lines: [
         {
           angle: 228.0127875,
@@ -4871,7 +4871,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'HEX',
-      description: '������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4904,7 +4904,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'HONEY',
-      description: '�䳲ͼ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4937,7 +4937,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'HOUND',
-      description: 'Ȯ������ͼ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4961,7 +4961,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'INSUL',
-      description: '��Ե����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -4994,7 +4994,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO02W100',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5009,7 +5009,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO03W100',
-      description: '�����ո���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5024,7 +5024,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO04W100',
-      description: '����������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5039,7 +5039,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO05W100',
-      description: '������˫����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5054,7 +5054,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO06W100',
-      description: '������������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5078,7 +5078,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO07W100',
-      description: '����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5093,7 +5093,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO08W100',
-      description: '�������̻���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5108,7 +5108,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO09W100',
-      description: '������˫�̻���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5123,7 +5123,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO10W100',
-      description: '��������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5138,7 +5138,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO11W100',
-      description: '˫��������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5153,7 +5153,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO12W100',
-      description: '����˫����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5168,7 +5168,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO13W100',
-      description: '˫����˫����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5192,7 +5192,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO14W100',
-      description: '����������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5216,7 +5216,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ACAD_ISO15W100',
-      description: '˫����������',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5240,7 +5240,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_LC_20',
-      description: 'LC JIS A 0150(@20)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5264,7 +5264,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_LC_20A',
-      description: 'LC JIS A 0150(@20��?)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5288,7 +5288,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_LC_8',
-      description: 'LC JIS A 0150(@8)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5312,7 +5312,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_LC_8A',
-      description: 'LC JIS A 0150(@8��?)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5336,7 +5336,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_RC_10',
-      description: 'RC JIS A 0150(@10)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5369,7 +5369,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_RC_15',
-      description: 'RC JIS A 0150(@15)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5402,7 +5402,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_RC_18',
-      description: 'RC JIS A 0150(@18)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5435,7 +5435,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_RC_30',
-      description: 'RC JIS A 0150(@30)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5468,7 +5468,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_STN_1E',
-      description: 'STONE JIS A 0150(@1)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5492,7 +5492,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_STN_2.5',
-      description: 'STONE JIS A 0150(@2.5)',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5516,7 +5516,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'JIS_WOOD',
-      description: 'WOOD JIS A 0150',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5531,7 +5531,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'LINE',
-      description: 'ƽ��ˮƽ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5546,7 +5546,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'MUDST',
-      description: '��ɳ',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5561,7 +5561,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'NET',
-      description: 'ˮƽ/��ֱդ��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5585,7 +5585,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'NET3',
-      description: '��״ͼ�� 0-60-120',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5618,7 +5618,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'PLAST',
-      description: '���ϲ���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5651,7 +5651,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'PLASTI',
-      description: '���ϲ���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5693,7 +5693,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'SACNCR',
-      description: '������',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5717,7 +5717,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'SQUARE',
-      description: '�����С����',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5741,7 +5741,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'STARS',
-      description: '��â��',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5774,7 +5774,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'STEEL',
-      description: '�ֲ���',
+      description: '',
       lines: [
         {
           angle: 45,
@@ -5798,7 +5798,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'SWAMP',
-      description: '����ش�',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5858,7 +5858,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'TRANS',
-      description: '�ȴ��ݲ���',
+      description: '',
       lines: [
         {
           angle: 0,
@@ -5882,7 +5882,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'TRIANG',
-      description: '�ȱ�������',
+      description: '',
       lines: [
         {
           angle: 60,
@@ -5915,7 +5915,7 @@ export const AcDbPredefinedAcadIsoPat: AcDbPatDocument = {
     },
     {
       name: 'ZIGZAG',
-      description: '¥��Ч��',
+      description: '',
       lines: [
         {
           angle: 0,

--- a/packages/data-model/src/misc/pat/AcDbPatSvgRenderer.ts
+++ b/packages/data-model/src/misc/pat/AcDbPatSvgRenderer.ts
@@ -1,3 +1,6 @@
+import { AcGeMathUtil } from '@mlightcad/geometry-engine'
+
+import type { AcDbGradientName } from '../../entity/AcDbHatch'
 import { HATCH_PATTERN_SOLID } from '../AcDbConstants'
 import type {
   AcDbPatLine,
@@ -20,6 +23,75 @@ interface AcDbPatSvgSegment {
   y2: number
 }
 
+export type AcDbPatGradientColor = number | string
+
+/**
+ * Optional preview options when rendering an AutoCAD hatch gradient to SVG.
+ */
+export interface AcDbPatGradientPreviewOptions {
+  /**
+   * SVG viewport width in pixels.
+   */
+  width?: number
+
+  /**
+   * SVG viewport height in pixels.
+   */
+  height?: number
+
+  /**
+   * First gradient color.
+   *
+   * A number is treated as packed RGB (`0xRRGGBB`). A string is emitted as a
+   * CSS color value.
+   */
+  startColor?: AcDbPatGradientColor
+
+  /**
+   * Second gradient color.
+   *
+   * A number is treated as packed RGB (`0xRRGGBB`). A string is emitted as a
+   * CSS color value.
+   */
+  endColor?: AcDbPatGradientColor
+
+  /**
+   * Background fill color shown behind the gradient rectangle.
+   */
+  background?: string
+
+  /**
+   * Gradient angle in radians, matching {@link AcDbHatch.gradientAngle}.
+   */
+  angle?: number
+
+  /**
+   * Relative shift applied to the gradient focus or midpoint.
+   */
+  shift?: number
+
+  /**
+   * Whether the gradient uses one base color plus a shade/tint variant.
+   */
+  oneColorMode?: boolean
+
+  /**
+   * Shade/tint value used in one-color mode. `0` maps to black, `0.5` keeps the
+   * base color, and `1` maps to white.
+   */
+  shadeTintValue?: number
+}
+
+interface AcDbPatSvgGradientColors {
+  start: string
+  end: string
+}
+
+interface AcDbPatSvgGradientStop {
+  offset: number
+  color: string
+}
+
 /**
  * Renders an {@link AcDbPatPattern} into a standalone SVG preview string.
  *
@@ -30,27 +102,138 @@ interface AcDbPatSvgSegment {
 export class AcDbPatSvgRenderer {
   /** Numerical tolerance used to avoid division-by-zero and near-zero noise. */
   private static readonly EPSILON = 1e-9
+  private static gradientIdCounter = 0
 
   /**
-   * Converts an angle from degrees to radians.
+   * Builds an SVG-local ID that avoids collisions when multiple previews are
+   * injected into the same document.
    *
-   * @param degrees - Angle in degrees.
-   * @returns The same angle expressed in radians.
+   * @param name - Gradient pattern name.
+   * @returns Unique gradient ID.
    */
-  private static toRadians(degrees: number) {
-    return (degrees * Math.PI) / 180
+  private static nextGradientId(name: string) {
+    AcDbPatSvgRenderer.gradientIdCounter += 1
+    return `acdb-pat-gradient-${name.toLowerCase()}-${AcDbPatSvgRenderer.gradientIdCounter}`
   }
 
   /**
-   * Clamps a value into an inclusive range.
+   * Converts a packed RGB value to a CSS hex color.
    *
-   * @param value - Source value.
-   * @param min - Lower bound (inclusive).
-   * @param max - Upper bound (inclusive).
-   * @returns `value` projected into `[min, max]`.
+   * @param rgb - Packed RGB value.
+   * @returns CSS hex color.
    */
-  private static clamp(value: number, min: number, max: number) {
-    return Math.min(max, Math.max(min, value))
+  private static packedRgbToCss(rgb: number) {
+    return `#${(rgb & 0xffffff).toString(16).padStart(6, '0')}`
+  }
+
+  /**
+   * Converts either packed RGB or CSS color input to a CSS color string.
+   *
+   * @param color - Source color.
+   * @param fallback - Color used when source is undefined.
+   * @returns CSS color.
+   */
+  private static gradientColorToCss(
+    color: AcDbPatGradientColor | undefined,
+    fallback: string
+  ) {
+    return typeof color === 'number'
+      ? AcDbPatSvgRenderer.packedRgbToCss(color)
+      : (color ?? fallback)
+  }
+
+  /**
+   * Computes the shade/tint variant used by one-color gradient hatches.
+   *
+   * @param rgb - Packed base RGB value.
+   * @param shadeTintValue - Interpolation from black (`0`) through base
+   * (`0.5`) to white (`1`).
+   * @returns Packed RGB shade/tint value.
+   */
+  private static applyShadeTint(rgb: number, shadeTintValue: number) {
+    const value = AcGeMathUtil.clamp(shadeTintValue, 0, 1)
+    const target = value < 0.5 ? 0x000000 : 0xffffff
+    const amount = value < 0.5 ? 1 - value * 2 : value * 2 - 1
+    const r = (rgb >> 16) & 0xff
+    const g = (rgb >> 8) & 0xff
+    const b = rgb & 0xff
+    const targetR = (target >> 16) & 0xff
+    const targetG = (target >> 8) & 0xff
+    const targetB = target & 0xff
+
+    return (
+      Math.round(r + (targetR - r) * amount) * 0x10000 +
+      Math.round(g + (targetG - g) * amount) * 0x100 +
+      Math.round(b + (targetB - b) * amount)
+    )
+  }
+
+  /**
+   * Resolves the two CSS colors used by gradient stops.
+   *
+   * @param options - Gradient preview options.
+   * @returns CSS start and end colors.
+   */
+  private static resolveGradientColors(
+    options: AcDbPatGradientPreviewOptions
+  ): AcDbPatSvgGradientColors {
+    const fallbackStart = '#2563eb'
+    const fallbackEnd = '#f8fafc'
+    const start = AcDbPatSvgRenderer.gradientColorToCss(
+      options.startColor,
+      fallbackStart
+    )
+
+    if (options.oneColorMode && options.endColor == null) {
+      if (typeof options.startColor === 'number') {
+        const tinted = AcDbPatSvgRenderer.applyShadeTint(
+          options.startColor,
+          options.shadeTintValue ?? 0.5
+        )
+        return {
+          start,
+          end: AcDbPatSvgRenderer.packedRgbToCss(tinted)
+        }
+      }
+
+      return {
+        start,
+        end: (options.shadeTintValue ?? 0.5) < 0.5 ? '#000000' : '#ffffff'
+      }
+    }
+
+    return {
+      start,
+      end: AcDbPatSvgRenderer.gradientColorToCss(options.endColor, fallbackEnd)
+    }
+  }
+
+  /**
+   * Converts normalized stop data to SVG `<stop>` elements.
+   *
+   * @param stops - Gradient stops.
+   * @returns SVG stop markup.
+   */
+  private static renderGradientStops(stops: AcDbPatSvgGradientStop[]) {
+    return stops
+      .map(stop => {
+        const offset = AcGeMathUtil.clamp(stop.offset, 0, 1) * 100
+        return `<stop offset="${offset.toFixed(2)}%" stop-color="${stop.color}" />`
+      })
+      .join('')
+  }
+
+  /**
+   * Gets the SVG coordinate direction for a gradient angle.
+   *
+   * @param angle - Angle in radians, measured in CAD coordinates.
+   * @returns Unit vector in SVG coordinates.
+   */
+  private static getGradientVector(angle: number) {
+    return {
+      x: Math.cos(angle),
+      y: -Math.sin(angle)
+    }
   }
 
   /**
@@ -185,12 +368,8 @@ export class AcDbPatSvgRenderer {
         const length = Math.abs(dashValue)
         const nextCursor = cursor + length
         if (dashValue > 0 || dashValue === 0) {
-          const drawStart = AcDbPatSvgRenderer.clamp(
-            cursor,
-            startAlong,
-            endAlong
-          )
-          const drawEnd = AcDbPatSvgRenderer.clamp(
+          const drawStart = AcGeMathUtil.clamp(cursor, startAlong, endAlong)
+          const drawEnd = AcGeMathUtil.clamp(
             nextCursor,
             startAlong,
             endAlong
@@ -234,7 +413,7 @@ export class AcDbPatSvgRenderer {
    * @returns SVG `<path>` markup containing all generated segments.
    */
   private static renderFamily(line: AcDbPatLine, maxRadius: number) {
-    const angle = AcDbPatSvgRenderer.toRadians(line.angle)
+    const angle = AcGeMathUtil.degToRad(line.angle)
     const dirX = Math.cos(angle)
     const dirY = Math.sin(angle)
     const normalX = -dirY
@@ -272,6 +451,166 @@ export class AcDbPatSvgRenderer {
     }
 
     return `<path d="${paths.join(' ')}" fill="none" />`
+  }
+
+  /**
+   * Renders an SVG `<linearGradient>` definition.
+   *
+   * @param id - Gradient ID.
+   * @param angle - Gradient angle in radians.
+   * @param shift - Relative shift applied along the gradient axis.
+   * @param extent - Coordinate extent covering the viewport.
+   * @param stops - Color stops.
+   * @returns SVG gradient definition.
+   */
+  private static renderLinearGradientDef(
+    id: string,
+    angle: number,
+    shift: number,
+    extent: number,
+    stops: AcDbPatSvgGradientStop[]
+  ) {
+    const dir = AcDbPatSvgRenderer.getGradientVector(angle)
+    const shiftDistance = AcGeMathUtil.clamp(shift, -1, 1) * extent * 0.5
+    const offsetX = dir.x * shiftDistance
+    const offsetY = dir.y * shiftDistance
+
+    return [
+      `<linearGradient id="${id}" gradientUnits="userSpaceOnUse"`,
+      ` x1="${(-dir.x * extent + offsetX).toFixed(2)}"`,
+      ` y1="${(-dir.y * extent + offsetY).toFixed(2)}"`,
+      ` x2="${(dir.x * extent + offsetX).toFixed(2)}"`,
+      ` y2="${(dir.y * extent + offsetY).toFixed(2)}">`,
+      AcDbPatSvgRenderer.renderGradientStops(stops),
+      '</linearGradient>'
+    ].join('')
+  }
+
+  /**
+   * Renders an SVG `<radialGradient>` definition.
+   *
+   * @param id - Gradient ID.
+   * @param cx - Center X coordinate.
+   * @param cy - Center Y coordinate.
+   * @param radius - Gradient radius.
+   * @param stops - Color stops.
+   * @returns SVG gradient definition.
+   */
+  private static renderRadialGradientDef(
+    id: string,
+    cx: number,
+    cy: number,
+    radius: number,
+    stops: AcDbPatSvgGradientStop[]
+  ) {
+    return [
+      `<radialGradient id="${id}" gradientUnits="userSpaceOnUse"`,
+      ` cx="${cx.toFixed(2)}" cy="${cy.toFixed(2)}" r="${radius.toFixed(2)}"`,
+      ` fx="${cx.toFixed(2)}" fy="${cy.toFixed(2)}">`,
+      AcDbPatSvgRenderer.renderGradientStops(stops),
+      '</radialGradient>'
+    ].join('')
+  }
+
+  /**
+   * Builds the SVG definition for a hatch gradient pattern.
+   *
+   * SVG supports linear and radial gradients natively, so AutoCAD-specific
+   * shapes such as CYLINDER and CURVED are represented with mirrored stops or
+   * offset radial gradients.
+   *
+   * @param id - Gradient ID.
+   * @param name - AutoCAD gradient name.
+   * @param colors - Resolved gradient colors.
+   * @param angle - Gradient angle in radians.
+   * @param shift - Relative shift.
+   * @param width - SVG viewport width.
+   * @param height - SVG viewport height.
+   * @returns SVG gradient definition.
+   */
+  private static renderGradientDef(
+    id: string,
+    name: AcDbGradientName,
+    colors: AcDbPatSvgGradientColors,
+    angle: number,
+    shift: number,
+    width: number,
+    height: number
+  ) {
+    const gradientName = name.toUpperCase() as AcDbGradientName
+    const inverse = gradientName.startsWith('INV')
+    const baseName = gradientName.replace(/^INV/, '') as AcDbGradientName
+    const first = inverse ? colors.end : colors.start
+    const second = inverse ? colors.start : colors.end
+    const extent = Math.hypot(width, height) / 2
+    const dir = AcDbPatSvgRenderer.getGradientVector(angle)
+    const centerShift = AcGeMathUtil.clamp(shift, -1, 1)
+    const centerX = dir.x * centerShift * width * 0.25
+    const centerY = dir.y * centerShift * height * 0.25
+
+    switch (baseName) {
+      case 'CYLINDER': {
+        const middle = AcGeMathUtil.clamp(0.5 + centerShift * 0.45, 0.05, 0.95)
+        return AcDbPatSvgRenderer.renderLinearGradientDef(
+          id,
+          angle,
+          0,
+          extent,
+          [
+            { offset: 0, color: first },
+            { offset: middle, color: second },
+            { offset: 1, color: first }
+          ]
+        )
+      }
+      case 'SPHERICAL':
+        return AcDbPatSvgRenderer.renderRadialGradientDef(
+          id,
+          centerX,
+          centerY,
+          extent,
+          [
+            { offset: 0, color: second },
+            { offset: 1, color: first }
+          ]
+        )
+      case 'HEMISPHERICAL':
+        return AcDbPatSvgRenderer.renderRadialGradientDef(
+          id,
+          centerX + dir.x * width * 0.18,
+          centerY + dir.y * height * 0.18,
+          extent * 0.92,
+          [
+            { offset: 0, color: second },
+            { offset: 0.72, color: first },
+            { offset: 1, color: first }
+          ]
+        )
+      case 'CURVED':
+        return AcDbPatSvgRenderer.renderRadialGradientDef(
+          id,
+          -dir.x * width * 0.95 + centerX,
+          -dir.y * height * 0.95 + centerY,
+          extent * 1.65,
+          [
+            { offset: 0, color: first },
+            { offset: 0.55, color: first },
+            { offset: 1, color: second }
+          ]
+        )
+      case 'LINEAR':
+      default:
+        return AcDbPatSvgRenderer.renderLinearGradientDef(
+          id,
+          angle,
+          shift,
+          extent,
+          [
+            { offset: 0, color: first },
+            { offset: 1, color: second }
+          ]
+        )
+    }
   }
 
   /**
@@ -331,6 +670,52 @@ export class AcDbPatSvgRenderer {
       `<g stroke="${stroke}" stroke-width="${strokeWidth.toFixed(2)}" stroke-linecap="round">`,
       content,
       '</g>',
+      '</svg>'
+    ].join('')
+  }
+
+  /**
+   * Renders an AutoCAD hatch gradient preview as a complete SVG document
+   * string.
+   *
+   * The method uses native SVG linear/radial gradients where possible and
+   * approximates AutoCAD-only gradient shapes with mirrored stops or offset
+   * radial centers.
+   *
+   * @param name - AutoCAD gradient name.
+   * @param options - Optional preview style and size settings.
+   * @returns Standalone SVG markup that can be injected directly into DOM or
+   * saved as a `.svg` asset.
+   */
+  renderGradient(
+    name: AcDbGradientName,
+    options: AcDbPatGradientPreviewOptions = {}
+  ) {
+    const width = options.width ?? 260
+    const height = options.height ?? 160
+    const background = options.background ?? '#ffffff'
+    const angle = options.angle ?? 0
+    const shift = options.shift ?? 0
+    const viewBox = `${-width / 2} ${-height / 2} ${width} ${height}`
+    const id = AcDbPatSvgRenderer.nextGradientId(name)
+    const colors = AcDbPatSvgRenderer.resolveGradientColors(options)
+    const gradientDef = AcDbPatSvgRenderer.renderGradientDef(
+      id,
+      name,
+      colors,
+      angle,
+      shift,
+      width,
+      height
+    )
+
+    return [
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" width="${width}" height="${height}">`,
+      AcDbPatSvgRenderer.renderBackground(width, height, background),
+      '<defs>',
+      gradientDef,
+      '</defs>',
+      `<rect x="${-width / 2}" y="${-height / 2}" width="${width}" height="${height}" fill="url(#${id})" />`,
       '</svg>'
     ].join('')
   }


### PR DESCRIPTION
## Summary

- Added `AcDbPatSvgRenderer.renderGradient()` for rendering AutoCAD hatch gradient previews as standalone SVG.
- Supports linear, cylinder, spherical, hemispherical, and curved gradients, including inverse variants.
- Added packed RGB/CSS color handling, one-color shade/tint previews, gradient angle/shift support, and unique SVG gradient IDs.
- Cleared corrupted predefined ISO PAT descriptions to avoid exposing mojibake text.
- Added tests covering all supported gradient names and one-color shade/tint rendering.
