### PR TITLE
fix: prefer anonymous table blocks when rendering AcDbTable

### DIFF
--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -219,7 +219,7 @@ describe('AcDbTable', () => {
     expect(grouped.applyMatrix).toHaveBeenCalledTimes(1)
   })
 
-  it('rebuilds populated table cells before falling back to an anonymous block', () => {
+  it('uses the anonymous table block when available even if cells are populated', () => {
     const db = setWorkingDb()
     const renderer = createRenderer()
     const block = new AcDbBlockTableRecord()
@@ -247,10 +247,10 @@ describe('AcDbTable', () => {
     expect(renderer.mtext).toHaveBeenCalledTimes(1)
     const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
     expect((mtextCall[0] as { text: string }).text).toBe(
-      'CELL_TEXT_WITHOUT_HEIGHT'
+      'BLOCK_TABLE_TEXT'
     )
     expect((mtextCall[0] as { height: number }).height).toBe(4.5)
-    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
+    expect(renderer.lineSegments).not.toHaveBeenCalled()
   })
 
   it('renders an anonymous table block when cell content is unavailable', () => {

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -506,11 +506,7 @@ export class AcDbTable extends AcDbBlockReference {
    */
   subWorldDraw(renderer: AcGiRenderer): AcGiEntity {
     const blockTableRecord = this.blockTableRecord
-    if (
-      !this.hasRenderableCellContent() &&
-      blockTableRecord &&
-      blockTableRecord.newIterator().count > 0
-    ) {
+    if (blockTableRecord && blockTableRecord.newIterator().count > 0) {
       const block = this.drawAnonymousTableBlock(renderer, blockTableRecord)
       if (block) return block
     }
@@ -622,12 +618,6 @@ export class AcDbTable extends AcDbBlockReference {
     _tmpMatrix.compose(this.position, quaternion, this.scaleFactors)
     group.applyMatrix(_tmpMatrix)
     return group
-  }
-
-  private hasRenderableCellContent() {
-    return this._cells.some(cell => {
-      return !!cell && (!!cell.text || !!cell.blockTableRecordId)
-    })
   }
 
   private drawAnonymousTableBlock(


### PR DESCRIPTION
## Summary

This PR updates `AcDbTable` rendering to use the table's anonymous block whenever it is available, even when parsed cell content is present.

AutoCAD tables often include an anonymous `*T...` block that contains the final rendered table geometry and text placement. The previous implementation rebuilt populated tables from parsed cell metadata first, which could introduce cumulative vertical positioning errors across rows. Rendering the anonymous block preserves the original table layout more accurately.

## Changes

- Prefer `drawAnonymousTableBlock` when the referenced table block exists and contains entities.
- Keep the existing cell-based table reconstruction as a fallback when no renderable anonymous block is available.
- Update the `AcDbTable` test expectation to cover populated tables with anonymous blocks.

## Verification

- `pnpm test -- packages/data-model/__tests__/AcDbTable.spec.ts --runInBand`
- `pnpm --filter @mlightcad/data-model lint`
- `pnpm --filter @mlightcad/data-model build`
