### PR TITLE
 fix(converters): build entity color via assignment to support AcDbHatch override

### DIFF
--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -1,4 +1,4 @@
-import { AcCmTransparency } from '@mlightcad/common'
+import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
 import {
   ArcEntity,
   AttdefEntity,
@@ -1391,14 +1391,29 @@ export class AcDbEntityConverter {
     if (entity.lineTypeScale != null) {
       dbEntity.linetypeScale = entity.lineTypeScale
     }
-    if (entity.color != null) {
-      dbEntity.color.setRGBValue(entity.color)
-    }
-    if (entity.colorIndex != null) {
-      dbEntity.color.colorIndex = entity.colorIndex
-    }
-    if (entity.colorName) {
-      dbEntity.color.colorName = entity.colorName
+    // Build the entity color in a fresh AcCmColor and assign it via the
+    // setter. The previous pattern (`dbEntity.color.<prop> = …`) read the
+    // getter and mutated the result, which works for entities whose getter
+    // returns the cached `_color` field but breaks for entities like
+    // AcDbHatch that override the getter to return a clone of an HPCOLOR /
+    // CECOLOR fallback (PR #78). Mutations on a clone are dropped, leaving
+    // the entity stuck on the sysvar default and losing the DXF's RGB.
+    if (
+      entity.color != null ||
+      entity.colorIndex != null ||
+      entity.colorName
+    ) {
+      const color = new AcCmColor()
+      if (entity.color != null) {
+        color.setRGBValue(entity.color)
+      }
+      if (entity.colorIndex != null) {
+        color.colorIndex = entity.colorIndex
+      }
+      if (entity.colorName) {
+        color.colorName = entity.colorName
+      }
+      dbEntity.color = color
     }
     if (entity.isVisible != null) {
       // DXF group code 60 uses 0 => visible, 1 => invisible.

--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -4,6 +4,7 @@ import {
   AcDbBlockReference,
   AcDbCircle,
   AcDbDatabase,
+  AcDbHatch,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
 
@@ -142,6 +143,66 @@ describe('libredwg AcDbEntityConverter', () => {
       // ObjectARX semantics.
       expect(tag.ownerId).toBe('INSERT_HANDLE')
       expect(area.ownerId).toBe('INSERT_HANDLE')
+    })
+  })
+
+  // The previous color-resolution path mutated the result of the entity
+  // `color` getter (`dbEntity.color.<prop> = …`). That works for entities
+  // whose getter returns the cached `_color` field, but breaks for
+  // AcDbHatch — its override returns a clone of the HPCOLOR / CECOLOR
+  // fallback when no color is explicitly set, so the mutations are
+  // dropped and the hatch ends up stuck on the sysvar default. The
+  // converter now builds a fresh AcCmColor and assigns it via the setter,
+  // so colour reaches the data-model regardless of the getter's caching
+  // strategy.
+  describe('hatch color preservation (regression #228)', () => {
+    it('persists explicit truecolor RGB on a HATCH entity', () => {
+      acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+      const converter = new AcDbEntityConverter()
+
+      const hatch = converter.convert({
+        type: 'HATCH',
+        handle: 'H1',
+        layer: 'WALLS',
+        ownerBlockRecordSoftId: 'MS',
+        color: 0x00ff00,
+        elevation: 0,
+        extrusionDirection: { x: 0, y: 0, z: 1 },
+        patternName: 'SOLID',
+        solidFill: 1,
+        gradientFlag: 0,
+        boundaryPaths: []
+      } as any) as AcDbHatch
+
+      expect(hatch).toBeInstanceOf(AcDbHatch)
+      // RGB must reach the data-model — not be lost on the clone.
+      expect(hatch.color.RGB).toBe(0x00ff00)
+      expect(hatch.color.isByColor).toBe(true)
+    })
+
+    it('persists ACI 7 (foreground) on a HATCH entity', () => {
+      acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+      const converter = new AcDbEntityConverter()
+
+      const hatch = converter.convert({
+        type: 'HATCH',
+        handle: 'H2',
+        layer: 'WALLS',
+        ownerBlockRecordSoftId: 'MS',
+        colorIndex: 7,
+        elevation: 0,
+        extrusionDirection: { x: 0, y: 0, z: 1 },
+        patternName: 'SOLID',
+        solidFill: 1,
+        gradientFlag: 0,
+        boundaryPaths: []
+      } as any) as AcDbHatch
+
+      expect(hatch).toBeInstanceOf(AcDbHatch)
+      // ACI 7 must surface as foreground so the renderer keeps the
+      // theme-aware behaviour (fuse-with-bg for solid hatches).
+      expect(hatch.color.colorIndex).toBe(7)
+      expect(hatch.color.isForeground).toBe(true)
     })
   })
 })

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -1,4 +1,5 @@
 import {
+  AcCmColor,
   AcCmTransparency,
   AcDb2dPolyline,
   AcDb3dPolyline,
@@ -1213,27 +1214,42 @@ export class AcDbEntityConverter {
     if (entity.lineTypeScale != null) {
       dbEntity.linetypeScale = entity.lineTypeScale
     }
-    if (entity.color != null) {
-      dbEntity.color.setRGBValue(entity.color)
-    }
-    if (entity.colorIndex != null) {
-      // ACI color precedence rule:
-      // - If the libredwg binding already resolved a concrete RGB for the
-      //   entity (entity.color != null), that RGB reflects the DWG's own
-      //   color table — trust it and do NOT overwrite with ACI resolution
-      //   from our default palette (which loses custom-palette mappings,
-      //   e.g. ACI 254 → #d8f5c2 in the source DWG vs. near-black in our
-      //   default palette).
-      // - Exception: colorIndex === 7 is semantically special (the
-      //   "foreground" color that flips with COLORTHEME). Preserve it as
-      //   ByACI(7) so that AcCmColor.isForeground stays true and text
-      //   keeps inverting with the theme.
-      if (entity.color == null || entity.colorIndex === 7) {
-        dbEntity.color.colorIndex = entity.colorIndex
+    // Build the entity color in a fresh AcCmColor and assign it via the
+    // setter. The previous pattern (`dbEntity.color.<prop> = …`) read the
+    // getter and mutated the result, which works for entities whose getter
+    // returns the cached `_color` field but breaks for entities like
+    // AcDbHatch that override the getter to return a clone of an HPCOLOR /
+    // CECOLOR fallback (PR #78). Mutations on a clone are dropped, leaving
+    // the entity stuck on the sysvar default and losing the DWG's RGB.
+    if (
+      entity.color != null ||
+      entity.colorIndex != null ||
+      entity.colorName
+    ) {
+      const color = new AcCmColor()
+      if (entity.color != null) {
+        color.setRGBValue(entity.color)
       }
-    }
-    if (entity.colorName) {
-      dbEntity.color.colorName = entity.colorName
+      if (entity.colorIndex != null) {
+        // ACI color precedence rule:
+        // - If the libredwg binding already resolved a concrete RGB for
+        //   the entity (entity.color != null), that RGB reflects the
+        //   DWG's own color table — trust it and do NOT overwrite with
+        //   ACI resolution from our default palette (which loses custom
+        //   palette mappings, e.g. ACI 254 → #d8f5c2 in the source DWG
+        //   vs. near-black in our default palette).
+        // - Exception: colorIndex === 7 is semantically special (the
+        //   "foreground" color that flips with COLORTHEME). Preserve it
+        //   as ByACI(7) so that AcCmColor.isForeground stays true and
+        //   text keeps inverting with the theme.
+        if (entity.color == null || entity.colorIndex === 7) {
+          color.colorIndex = entity.colorIndex
+        }
+      }
+      if (entity.colorName) {
+        color.colorName = entity.colorName
+      }
+      dbEntity.color = color
     }
     if (entity.isVisible != null) {
       dbEntity.visibility = entity.isVisible


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                        
   
  The previous color-resolution path in both `libredwg-converter` and the DXF converter mutated the result of the entity `color` getter:                                                                                                         
                                                                                                                                                       
  ```ts                                                           
  dbEntity.color.setRGBValue(entity.color)
  dbEntity.color.colorIndex = entity.colorIndex
  dbEntity.color.colorName = entity.colorName             
  ```                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  This works for entities whose getter returns the cached `_color` field, but breaks for `AcDbHatch` — its override (introduced in #78) returns a **clone** of the HPCOLOR / CECOLOR fallback when no color is explicitly set, to support live tracking of those sysvars. Mutations on a clone are dropped, so the hatch ends up stuck on the sysvar default and loses the DWG/DXF's explicit colour.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  End-user symptom: hatches that AutoCAD shows in green / red / blue render as the HPCOLOR default (typically ByLayer-resolved white) and visually disappear into the paper.                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  - Build the entity color in a fresh `AcCmColor` and assign it via the setter, so the value reaches the data-model regardless of the getter's caching strategy.                                                                                                                                  
  - Identical refactor in both converters (`libredwg-converter` for DWG and `data-model` for DXF) for consistency.
  - The override semantics of `AcDbHatch.color` are **unchanged** — including the HPCOLOR / CECOLOR live-tracking contract added in #78.                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  ## Tests                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  - New `hatch color preservation` describe block in `packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts` asserts both an explicit truecolor RGB and ACI 7 (foreground) survive through conversion onto the `AcDbHatch` entity.                                                                                                                                                                                                                                                                 
  - All 662 existing tests still pass, including the `resolves color from HPCOLOR before CECOLOR until color is explicitly set` test added in #78 (override semantics intact).                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  ## Note on coverage gap                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
  The unit test added in #78 created `AcDbHatch` directly and assigned `hatch.color = …` (full assignment) — it never exercised the mutation pattern that the converters use. The two new specs in this PR close that gap.