### PR TITLE
feat: LUNITS/LUPREC/AUPREC, VPORT fallbacks, angbase/angdir; pnpm 10 + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
+      - uses: pnpm/action-setup@v4
       
       # Cache node_modules
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",
   "type": "module",
+  "packageManager": "pnpm@10.33.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/mlightcad/realdwg-web.git"
@@ -26,7 +27,17 @@
     "test:coverage": "jest --coverage"
   },
   "engines": {
-    "pnpm": ">=8"
+    "pnpm": ">=10"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "nx"
+    ],
+    "overrides": {
+      "@mlightcad/dxf-json": "^1.2.0"
+    }
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -246,9 +246,7 @@ describe('AcDbTable', () => {
 
     expect(renderer.mtext).toHaveBeenCalledTimes(1)
     const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
-    expect((mtextCall[0] as { text: string }).text).toBe(
-      'BLOCK_TABLE_TEXT'
-    )
+    expect((mtextCall[0] as { text: string }).text).toBe('BLOCK_TABLE_TEXT')
     expect((mtextCall[0] as { height: number }).height).toBe(4.5)
     expect(renderer.lineSegments).not.toHaveBeenCalled()
   })

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -57,7 +57,12 @@ import {
   ByLayer,
   DEFAULT_MLEADER_STYLE,
   DEFAULT_MLINE_STYLE,
-  DEFAULT_TEXT_STYLE
+  DEFAULT_TEXT_STYLE,
+  VPORT_FALLBACK_CENTER_2D,
+  VPORT_FALLBACK_LLC,
+  VPORT_FALLBACK_URC,
+  VPORT_FALLBACK_VIEW_DIR,
+  VPORT_FALLBACK_VIEW_TARGET
 } from '../misc'
 import { AcDbBatchProcessing } from './AcDbBatchProcessing'
 import { AcDbDxfParser } from './AcDbDxfParser'
@@ -469,9 +474,12 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
 
     // Color index 256 is 'ByLayer'
     db.cecolor.colorIndex = header['$CECOLOR'] || 256
-    db.angBase = header['$ANGBASE'] || 0
-    db.angDir = header['$ANGDIR'] || 0
+    db.angbase = header['$ANGBASE'] || 0
+    db.angdir = header['$ANGDIR'] || 0
     if (header['$AUNITS'] != null) db.aunits = header['$AUNITS']
+    if (header['$AUPREC'] != null) db.auprec = header['$AUPREC']
+    if (header['$LUNITS'] != null) db.lunits = header['$LUNITS']
+    if (header['$LUPREC'] != null) db.luprec = header['$LUPREC']
     db.celtype = header['$CELTYPE'] || ByLayer
     AcDbSysVarManager.instance().setVar(
       AcDbSystemVariables.CETRANSPARENCY,
@@ -638,9 +646,13 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
             record.circleSides = item.circleSides
           }
           record.standardFlag = item.standardFlag
-          record.center.copy(item.center)
-          record.lowerLeftCorner.copy(item.lowerLeftCorner)
-          record.upperRightCorner.copy(item.upperRightCorner)
+          record.center.copy(item.center ?? VPORT_FALLBACK_CENTER_2D)
+          record.lowerLeftCorner.copy(
+            item.lowerLeftCorner ?? VPORT_FALLBACK_LLC
+          )
+          record.upperRightCorner.copy(
+            item.upperRightCorner ?? VPORT_FALLBACK_URC
+          )
           if (item.snapBasePoint) {
             record.snapBase.copy(item.snapBasePoint)
           }
@@ -660,11 +672,13 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
             record.backgroundObjectId = item.backgroundObjectId
           }
 
-          record.gsView.center.copy(item.center)
+          record.gsView.center.copy(item.center ?? VPORT_FALLBACK_CENTER_2D)
           record.gsView.viewDirectionFromTarget.copy(
-            item.viewDirectionFromTarget
+            item.viewDirectionFromTarget ?? VPORT_FALLBACK_VIEW_DIR
           )
-          record.gsView.viewTarget.copy(item.viewTarget)
+          record.gsView.viewTarget.copy(
+            item.viewTarget ?? VPORT_FALLBACK_VIEW_TARGET
+          )
           if (item.lensLength) {
             record.gsView.lensLength = item.lensLength
           }

--- a/packages/data-model/src/converter/AcDbEntitiyConverter.ts
+++ b/packages/data-model/src/converter/AcDbEntitiyConverter.ts
@@ -317,8 +317,7 @@ export class AcDbEntityConverter {
     // `libredwg-converter` for the same defensive handling.
     const ap = attrib.alignmentPoint
     const isApZero =
-      !ap ||
-      (ap.x === 0 && ap.y === 0 && ((ap as { z?: number }).z ?? 0) === 0)
+      !ap || (ap.x === 0 && ap.y === 0 && ((ap as { z?: number }).z ?? 0) === 0)
     if (ap && !isApZero) {
       dbAttrib.alignmentPoint.copy(ap)
     } else {
@@ -772,8 +771,7 @@ export class AcDbEntityConverter {
     // `convertAttributeCommon`.
     const ep = text.endPoint
     const isEpZero =
-      !ep ||
-      (ep.x === 0 && ep.y === 0 && ((ep as { z?: number }).z ?? 0) === 0)
+      !ep || (ep.x === 0 && ep.y === 0 && ((ep as { z?: number }).z ?? 0) === 0)
     if (ep && !isEpZero) {
       dbEntity.alignmentPoint.copy(ep)
     } else {
@@ -1398,11 +1396,7 @@ export class AcDbEntityConverter {
     // AcDbHatch that override the getter to return a clone of an HPCOLOR /
     // CECOLOR fallback (PR #78). Mutations on a clone are dropped, leaving
     // the entity stuck on the sysvar default and losing the DXF's RGB.
-    if (
-      entity.color != null ||
-      entity.colorIndex != null ||
-      entity.colorName
-    ) {
+    if (entity.color != null || entity.colorIndex != null || entity.colorName) {
       const color = new AcCmColor()
       if (entity.color != null) {
         color.setRGBValue(entity.color)

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -19,6 +19,7 @@ import {
   ACAD_APPID,
   AcDbAngleUnits,
   AcDbDataGenerator,
+  AcDbLinearUnits,
   AcDbUnitsValue,
   ByBlock,
   ByLayer,
@@ -302,11 +303,17 @@ export class AcDbDatabase extends AcDbObject {
   /** Version of the database */
   private _version: AcDbDwgVersion
   /** Angle base for the database */
-  private _angBase: number
+  private _angbase: number
   /** Angle direction for the database */
-  private _angDir: number
+  private _angdir: number
   /** Angle units for the database */
   private _aunits: AcDbAngleUnits
+  /** Angular display precision (AUPREC), used with {@link AcDbDatabase.aunits | AUNITS}. */
+  private _auprec: number
+  /** Linear unit display format (LUNITS) for coordinates and distances. */
+  private _lunits: AcDbLinearUnits
+  /** Linear display precision (LUPREC), used with {@link lunits}. */
+  private _luprec: number
   /** Current entity color */
   private _cecolor: AcCmColor
   /** Current entity linetype scale */
@@ -398,9 +405,12 @@ export class AcDbDatabase extends AcDbObject {
   constructor() {
     super({ objectId: '0' })
     this._version = new AcDbDwgVersion('AC1014')
-    this._angBase = 0
-    this._angDir = 0
+    this._angbase = 0
+    this._angdir = 0
     this._aunits = AcDbAngleUnits.DecimalDegrees
+    this._auprec = 0
+    this._lunits = AcDbLinearUnits.Decimal
+    this._luprec = 4
     this._celtscale = 1
     this._cecolor = new AcCmColor()
     this._celtype = ByLayer
@@ -572,11 +582,27 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
-   * Gets the angle units for the database.
+   * Angular unit **display and entry** format for the drawing (AutoCAD system variable **AUNITS**).
    *
-   * This is the current AUNITS value for the database.
+   * This does not change how angles are stored internally (radians in geometry); it controls how
+   * angles are formatted in the UI and how numeric angle input is interpreted, together with
+   * {@link angbase} (**ANGBASE**) and {@link angdir} (**ANGDIR**).
    *
-   * @returns The angle units value
+   * @returns Integer code matching {@link AcDbAngleUnits}:
+   *
+   * | Value | Meaning |
+   * |------:|---------|
+   * | `0` | **Decimal degrees** — e.g. `45.5` |
+   * | `1` | **Degrees/minutes/seconds** — e.g. `45d30'15"` |
+   * | `2` | **Gradians** — e.g. `50g` (400 grads = full circle) |
+   * | `3` | **Radians** — e.g. `0.785398...` |
+   * | `4` | **Surveyor's units** — quadrant bearing notation (e.g. `N 45d30'15" E`) |
+   *
+   * @remarks
+   * Prefer assigning {@link AcDbAngleUnits} enum members for readability instead of raw integers.
+   *
+   * @see {@link AcDbAngleUnits} for the canonical enum used by this codebase.
+   * @see {@link https://help.autodesk.com/view/ACD/2027/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-C7C0F6A5-7982-43DB-97F9-5B9B0044E9FA-htm.html | AutoCAD Help: AUNITS}
    *
    * @example
    * ```typescript
@@ -588,9 +614,9 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
-   * Sets the angle units for the database.
+   * Sets **AUNITS** — the angular unit display format (see {@link aunits} getter for value meanings).
    *
-   * @param value - The new angle units value
+   * @param value - Integer `0`–`4` per {@link AcDbAngleUnits}, or `undefined`/`null` coerced to `0` by the setter chain.
    *
    * @example
    * ```typescript
@@ -604,6 +630,103 @@ export class AcDbDatabase extends AcDbObject {
       value ?? 0,
       nextValue => {
         this._aunits = nextValue
+      }
+    )
+  }
+
+  /**
+   * Angular display precision for the drawing (**AUPREC**): how many decimal places (or equivalent)
+   * are used when showing angles, in conjunction with {@link aunits}.
+   *
+   * AutoCAD typically uses integers in the range **0–8**; behavior for other values is
+   * implementation-defined in this library (stored as-is).
+   *
+   * @see {@link https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-EE1ED20C-1096-4299-820F-83F1BC9B96F3 | AutoCAD Help: AUPREC}
+   */
+  get auprec(): number {
+    return this._auprec
+  }
+
+  /**
+   * Sets **AUPREC** — angular display precision (see {@link auprec} getter).
+   */
+  set auprec(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.AUPREC,
+      this._auprec,
+      value ?? 0,
+      nextValue => {
+        this._auprec = nextValue
+      }
+    )
+  }
+
+  /**
+   * Linear unit **display and entry** format for coordinates and lengths (**LUNITS**).
+   *
+   * This does not set real-world drawing units for inserts (see {@link insunits}); it controls how
+   * linear distances are shown and parsed (scientific, decimal, engineering, and so on).
+   *
+   * @returns Integer code matching {@link AcDbLinearUnits}:
+   *
+   * | Value | Meaning |
+   * |------:|---------|
+   * | `1` | **Scientific** |
+   * | `2` | **Decimal** |
+   * | `3` | **Engineering** (feet + decimal inches) |
+   * | `4` | **Architectural** (feet + fractional inches) |
+   * | `5` | **Fractional** |
+   * | `6` | **Windows desktop** (processing / computational format) |
+   *
+   * @remarks
+   * Prefer assigning {@link AcDbLinearUnits} enum members instead of raw integers.
+   *
+   * @see {@link AcDbLinearUnits}
+   * @see {@link https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-D7C80D1F-B1C0-44A9-898E-B3100FF391CB | AutoCAD Help: LUNITS}
+   */
+  get lunits(): number {
+    return this._lunits
+  }
+
+  /**
+   * Sets **LUNITS** — linear display format (see {@link lunits} getter).
+   *
+   * @param value - Integer per {@link AcDbLinearUnits}, or coerced default {@link AcDbLinearUnits.Decimal} when `undefined`/`null`.
+   */
+  set lunits(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.LUNITS,
+      this._lunits,
+      value ?? AcDbLinearUnits.Decimal,
+      nextValue => {
+        this._lunits = nextValue
+      }
+    )
+  }
+
+  /**
+   * Linear display precision for the drawing (**LUPREC**): number of decimal places (or equivalent)
+   * used when showing linear distances, together with {@link lunits}.
+   *
+   * AutoCAD typically uses integers in the range **0–8**; initial value is commonly **4**.
+   * Values outside that range are stored as-is by this library.
+   *
+   * @see {@link https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-5FFF39D6-EFC7-49F5-B56A-6023EB5C0DE7 | AutoCAD Help: LUPREC}
+   */
+  get luprec(): number {
+    return this._luprec
+  }
+
+  /**
+   * Sets **LUPREC** — linear display precision (see {@link luprec} getter).
+   */
+  set luprec(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.LUPREC,
+      this._luprec,
+      value ?? 4,
+      nextValue => {
+        this._luprec = nextValue
       }
     )
   }
@@ -1006,16 +1129,16 @@ export class AcDbDatabase extends AcDbObject {
   /**
    * The zero (0) base angle with respect to the current UCS in radians.
    */
-  get angBase(): number {
-    return this._angBase
+  get angbase(): number {
+    return this._angbase
   }
-  set angBase(value: number) {
+  set angbase(value: number) {
     this.updateSysVar(
       AcDbSystemVariables.ANGBASE,
-      this._angBase,
+      this._angbase,
       value ?? 0,
       nextValue => {
-        this._angBase = nextValue
+        this._angbase = nextValue
       }
     )
   }
@@ -1025,16 +1148,16 @@ export class AcDbDatabase extends AcDbObject {
    * - 0: Counterclockwise
    * - 1: Clockwise
    */
-  get angDir(): number {
-    return this._angDir
+  get angdir(): number {
+    return this._angdir
   }
-  set angDir(value: number) {
+  set angdir(value: number) {
     this.updateSysVar(
       AcDbSystemVariables.ANGDIR,
-      this._angDir,
+      this._angdir,
       value ?? 0,
       nextValue => {
-        this._angDir = nextValue
+        this._angdir = nextValue
       }
     )
   }
@@ -1644,6 +1767,10 @@ export class AcDbDatabase extends AcDbObject {
     }
     filer.writeString(9, '$INSUNITS')
     filer.writeInt16(70, this.insunits)
+    filer.writeString(9, '$LUNITS')
+    filer.writeInt16(70, this.lunits)
+    filer.writeString(9, '$LUPREC')
+    filer.writeInt16(70, this.luprec)
     filer.writeString(9, '$LTSCALE')
     filer.writeDouble(40, this.ltscale)
     filer.writeString(9, '$LWDISPLAY')
@@ -1679,9 +1806,13 @@ export class AcDbDatabase extends AcDbObject {
     filer.writeString(9, '$TEXTSTYLE')
     filer.writeString(7, this.textstyle)
     filer.writeString(9, '$ANGBASE')
-    filer.writeAngle(50, this.angBase)
+    filer.writeAngle(50, this.angbase)
     filer.writeString(9, '$ANGDIR')
-    filer.writeInt16(70, this.angDir)
+    filer.writeInt16(70, this.angdir)
+    filer.writeString(9, '$AUNITS')
+    filer.writeInt16(70, this.aunits)
+    filer.writeString(9, '$AUPREC')
+    filer.writeInt16(70, this.auprec)
     filer.writeString(9, '$EXTMIN')
     filer.writePoint3d(10, this.extmin)
     filer.writeString(9, '$EXTMAX')

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -8,6 +8,9 @@ import { AcGePointLike } from '@mlightcad/geometry-engine'
 import { AcGiLineWeight } from '@mlightcad/graphic-interface'
 
 import {
+  AcDbAngleUnits,
+  AcDbLinearUnits,
+  AcDbUnitsValue,
   ByLayer,
   DEFAULT_HATCH_PATTERN_METRIC,
   DEFAULT_MLEADER_STYLE,
@@ -312,6 +315,89 @@ export class AcDbSysVarManager {
       type: 'transparency',
       isDbVar: true,
       defaultValue: new AcCmTransparency()
+    })
+    /**
+     * Direction of positive angles (**ANGDIR**).
+     * - `0`: Counterclockwise
+     * - `1`: Clockwise
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.ANGDIR,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
+    /**
+     * Sets the angular unit display format for angles (not the geometric angle itself).
+     * Integer codes match AutoCAD and {@link AcDbAngleUnits}:
+     * - `0`: Decimal degrees
+     * - `1`: Degrees/minutes/seconds
+     * - `2`: Gradians
+     * - `3`: Radians
+     * - `4`: Surveyor's units
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-C7C0F6A5-7982-43DB-97F9-5B9B0044E9FA-htm.html
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.AUNITS,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: AcDbAngleUnits.DecimalDegrees
+    })
+    /**
+     * Sets the display precision for angles (number of decimal places or equivalent), used together
+     * with {@link AcDbDatabase.aunits | AUNITS}. Typical range in AutoCAD is **0–8**; initial value **0**.
+     *
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-EE1ED20C-1096-4299-820F-83F1BC9B96F3
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.AUPREC,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
+    /**
+     * Sets the linear unit display format for coordinates and distances (not insertion scaling).
+     * Integer codes match AutoCAD and {@link AcDbLinearUnits}:
+     * - `1`: Scientific
+     * - `2`: Decimal
+     * - `3`: Engineering
+     * - `4`: Architectural
+     * - `5`: Fractional
+     * - `6`: Windows desktop (processing units)
+     *
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-D7C80D1F-B1C0-44A9-898E-B3100FF391CB
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.LUNITS,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: AcDbLinearUnits.Decimal
+    })
+    /**
+     * Sets the display precision for linear distances (decimal places or equivalent), used together
+     * with {@link AcDbDatabase.lunits | LUNITS}. Typical range in AutoCAD is **0–8**; common initial value **4**.
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-5FFF39D6-EFC7-49F5-B56A-6023EB5C0DE7
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.LUPREC,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 4
+    })
+    /**
+     * Specifies a drawing-units value for automatic scaling of blocks, images, or xrefs
+     * inserted or attached into this drawing. Integer codes match AutoCAD (0 = unitless,
+     * 1 = inches, 4 = millimeters, etc.); see {@link AcDbUnitsValue}.
+     *
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.INSUNITS,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: AcDbUnitsValue.Millimeters
     })
     this.registerVar({
       name: AcDbSystemVariables.LWDISPLAY,

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -23,6 +23,8 @@ export const AcDbSystemVariables = {
   ANGDIR: 'ANGDIR',
   /** Angular unit display mode, such as decimal degrees or degrees/minutes/seconds. */
   AUNITS: 'AUNITS',
+  /** Number of decimal places (or display precision) for angular values; used together with AUNITS. */
+  AUPREC: 'AUPREC',
   /** Current color applied to newly created entities. */
   CECOLOR: 'CECOLOR',
   /** Current linetype name used when creating new entities. */
@@ -80,6 +82,10 @@ export const AcDbSystemVariables = {
   INSUNITS: 'INSUNITS',
   /** Global linetype scale multiplier for the drawing database. */
   LTSCALE: 'LTSCALE',
+  /** Linear unit display format for coordinates and distances (scientific, decimal, engineering, etc.). */
+  LUNITS: 'LUNITS',
+  /** Decimal places (or display precision) for linear values; used together with LUNITS. */
+  LUPREC: 'LUPREC',
   /** Flag indicating whether lineweights are displayed in the editor/viewer. */
   LWDISPLAY: 'LWDISPLAY',
   /** Color used for measurement tool overlays (distance, area, arc). */

--- a/packages/data-model/src/misc/AcDbConstants.ts
+++ b/packages/data-model/src/misc/AcDbConstants.ts
@@ -81,3 +81,13 @@ export const MLIGHTCAD_APPID = 'mlightcad'
  * Built-in AutoCAD application ID used for standard XData registration.
  */
 export const ACAD_APPID = 'ACAD'
+
+/**
+ * Frozen 2D/3D placeholders when a VPORT table row omits geometry (partial DXF
+ * groups, incomplete DWG decode). Used before `AcGePoint2d.copy` / `AcGePoint3d.copy`.
+ */
+export const VPORT_FALLBACK_CENTER_2D = Object.freeze({ x: 0, y: 0 })
+export const VPORT_FALLBACK_LLC = Object.freeze({ x: 0, y: 0 })
+export const VPORT_FALLBACK_URC = Object.freeze({ x: 1, y: 1 })
+export const VPORT_FALLBACK_VIEW_DIR = Object.freeze({ x: 0, y: 0, z: 1 })
+export const VPORT_FALLBACK_VIEW_TARGET = Object.freeze({ x: 0, y: 0, z: 0 })

--- a/packages/data-model/src/misc/AcDbLinearUnits.ts
+++ b/packages/data-model/src/misc/AcDbLinearUnits.ts
@@ -1,0 +1,20 @@
+/**
+ * Linear unit **display** formats for coordinates and distances (AutoCAD **LUNITS**).
+ *
+ * Integer codes match the values stored in the drawing header and system variable **LUNITS**.
+ * They describe how lengths are formatted for display and entry, not insertion-unit scaling (**INSUNITS**).
+ */
+export enum AcDbLinearUnits {
+  /** Scientific notation (e.g. `1.5E+01`) */
+  Scientific = 1,
+  /** Decimal units (e.g. `15.5`) */
+  Decimal = 2,
+  /** Engineering format: feet as decimal with inches (e.g. `1'-3.5"`) */
+  Engineering = 3,
+  /** Architectural format: feet and fractional inches */
+  Architectural = 4,
+  /** Fractional format (e.g. `15-1/2`) */
+  Fractional = 5,
+  /** Windows desktop / processing format (computational units) */
+  WindowsDesktop = 6
+}

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -1,4 +1,5 @@
 export * from './AcDbAngleUnits'
+export * from './AcDbLinearUnits'
 export * from './AcDbRenderingCache'
 export * from './AcDbCodePage'
 export * from './AcDbConstants'

--- a/packages/data-model/src/misc/pat/AcDbPatSvgRenderer.ts
+++ b/packages/data-model/src/misc/pat/AcDbPatSvgRenderer.ts
@@ -369,11 +369,7 @@ export class AcDbPatSvgRenderer {
         const nextCursor = cursor + length
         if (dashValue > 0 || dashValue === 0) {
           const drawStart = AcGeMathUtil.clamp(cursor, startAlong, endAlong)
-          const drawEnd = AcGeMathUtil.clamp(
-            nextCursor,
-            startAlong,
-            endAlong
-          )
+          const drawEnd = AcGeMathUtil.clamp(nextCursor, startAlong, endAlong)
           if (drawEnd > drawStart) {
             segments.push({
               x1: originX + dirX * drawStart,

--- a/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
+++ b/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
@@ -345,7 +345,7 @@ export class AcDbLibdxfrwConverter extends AcDbDatabaseConverter<DRW_Database> {
 
     variant = header.getVar('$ANGDIR')
     // Initial value:	0
-    db.angDir = variant ? variant.getInt() : 0
+    db.angdir = variant ? variant.getInt() : 0
 
     variant = header.getVar('$AUNITS')
     // Initial value:	0

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -1221,11 +1221,7 @@ export class AcDbEntityConverter {
     // AcDbHatch that override the getter to return a clone of an HPCOLOR /
     // CECOLOR fallback (PR #78). Mutations on a clone are dropped, leaving
     // the entity stuck on the sysvar default and losing the DWG's RGB.
-    if (
-      entity.color != null ||
-      entity.colorIndex != null ||
-      entity.colorName
-    ) {
+    if (entity.color != null || entity.colorIndex != null || entity.colorName) {
       const color = new AcCmColor()
       if (entity.color != null) {
         color.setRGBValue(entity.color)

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -30,7 +30,12 @@ import {
   AcGiRenderMode,
   ByLayer,
   createWorkerApi,
-  DEFAULT_TEXT_STYLE
+  DEFAULT_TEXT_STYLE,
+  VPORT_FALLBACK_CENTER_2D,
+  VPORT_FALLBACK_LLC,
+  VPORT_FALLBACK_URC,
+  VPORT_FALLBACK_VIEW_DIR,
+  VPORT_FALLBACK_VIEW_TARGET
 } from '@mlightcad/data-model'
 import {
   DwgBlockRecordTableEntry,
@@ -310,9 +315,9 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         record.circleSides = item.circleSides
       }
       record.standardFlag = item.standardFlag
-      record.center.copy(item.center)
-      record.lowerLeftCorner.copy(item.lowerLeftCorner)
-      record.upperRightCorner.copy(item.upperRightCorner)
+      record.center.copy(item.center ?? VPORT_FALLBACK_CENTER_2D)
+      record.lowerLeftCorner.copy(item.lowerLeftCorner ?? VPORT_FALLBACK_LLC)
+      record.upperRightCorner.copy(item.upperRightCorner ?? VPORT_FALLBACK_URC)
       if (item.snapBasePoint) {
         record.snapBase.copy(item.snapBasePoint)
       }
@@ -332,9 +337,13 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         record.backgroundObjectId = item.backgroundObjectId
       }
 
-      record.gsView.center.copy(item.center)
-      record.gsView.viewDirectionFromTarget.copy(item.viewDirectionFromTarget)
-      record.gsView.viewTarget.copy(item.viewTarget)
+      record.gsView.center.copy(item.center ?? VPORT_FALLBACK_CENTER_2D)
+      record.gsView.viewDirectionFromTarget.copy(
+        item.viewDirectionFromTarget ?? VPORT_FALLBACK_VIEW_DIR
+      )
+      record.gsView.viewTarget.copy(
+        item.viewTarget ?? VPORT_FALLBACK_VIEW_TARGET
+      )
       if (item.lensLength) {
         record.gsView.lensLength = item.lensLength
       }
@@ -524,9 +533,12 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         db.cecolor.setRGBValue(header.CECOLOR.rgb)
       }
     }
-    db.angBase = header.ANGBASE ?? 0
-    db.angDir = header.ANGDIR ?? 0
+    db.angbase = header.ANGBASE ?? 0
+    db.angdir = header.ANGDIR ?? 0
     db.aunits = header.AUNITS ?? 0
+    if (header.AUPREC != null) db.auprec = header.AUPREC
+    if (header.LUNITS != null) db.lunits = header.LUNITS
+    if (header.LUPREC != null) db.luprec = header.LUPREC
     db.celtype = header.CELTYPE ?? ByLayer
     db.celtscale = header.CELTSCALE ?? 1
     db.ltscale = header.LTSCALE ?? 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@mlightcad/dxf-json': ^1.2.0
+
 importers:
 
   .:


### PR DESCRIPTION
## Summary

- Adds AutoCAD-aligned drawing settings **AUPREC**, **LUNITS**, and **LUPREC** to the data model: new `AcDbDatabase` properties, `AcDbSystemVariables` entries, `AcDbSysVarManager` registration (with expanded documentation for related variables such as **INSUNITS**), and a new `AcDbLinearUnits` enum.
- Renames angle accessors from `angBase` / `angDir` to **`angbase` / `angdir`** for consistency with system-variable naming; updates DXF, LibreDWG, and libdxfrw converters accordingly.
- Hardens viewport import when geometry is missing: shared **`VPORT_*_FALLBACK`** constants and nullish coalescing in `AcDbDxfConverter` and `AcDbLibreDwgConverter` before copying into `AcGe` points.
- Tooling: requires **pnpm >= 10**, adds `pnpm.onlyBuiltDependencies` and an **`@mlightcad/dxf-json`** override; upgrades GitHub Actions to **`pnpm/action-setup@v4`** in CI and publish workflows; lockfile updated.