### PR TITLE
feat: add AcDbFormatter for AutoCAD-style length, point, and angle display

### DIFF
--- a/packages/data-model/__tests__/AcDbFormatter.spec.ts
+++ b/packages/data-model/__tests__/AcDbFormatter.spec.ts
@@ -1,0 +1,200 @@
+import { AcGePoint2d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbAngleUnits } from '../src/misc/AcDbAngleUnits'
+import { AcDbFormatter } from '../src/misc/AcDbFormatter'
+import { AcDbLinearUnits } from '../src/misc/AcDbLinearUnits'
+import { AcDbUnitsValue } from '../src/misc/AcDbUnitsValue'
+
+describe('AcDbFormatter', () => {
+  let db: AcDbDatabase
+  let formatter: AcDbFormatter
+
+  beforeEach(() => {
+    db = new AcDbDatabase()
+    formatter = new AcDbFormatter(db)
+  })
+
+  it('exposes the same formatter via AcDbDatabase.formatter', () => {
+    expect(db.formatter).toBeInstanceOf(AcDbFormatter)
+    expect(db.formatter).toBe(db.formatter)
+    expect(db.formatter.formatLength(1)).toBe(formatter.formatLength(1))
+  })
+
+  describe('formatLength', () => {
+    it('formats decimal lengths with LUPREC', () => {
+      db.lunits = AcDbLinearUnits.Decimal
+      db.luprec = 2
+      db.insunits = AcDbUnitsValue.Millimeters
+
+      expect(formatter.formatLength(12.3456)).toBe('12.35')
+      expect(formatter.formatLength(12.3456, { showUnits: true })).toBe(
+        '12.35 mm'
+      )
+    })
+
+    it('prefixes approximate decimal lengths when showApproximate is true', () => {
+      db.lunits = AcDbLinearUnits.Decimal
+      db.luprec = 2
+
+      expect(formatter.formatLength(12.3456, { showApproximate: true })).toBe(
+        '~ 12.35'
+      )
+      expect(formatter.formatLength(12.35, { showApproximate: true })).toBe(
+        '12.35'
+      )
+      expect(
+        formatter.formatLength(12.3456, {
+          showApproximate: true,
+          showUnits: true
+        })
+      ).toBe('~ 12.35 mm')
+    })
+
+    it('formats scientific lengths', () => {
+      db.lunits = AcDbLinearUnits.Scientific
+      db.luprec = 2
+
+      expect(formatter.formatLength(123.456)).toBe('1.23E+02')
+    })
+
+    it('formats engineering lengths in feet and inches', () => {
+      db.lunits = AcDbLinearUnits.Engineering
+      db.luprec = 2
+
+      expect(formatter.formatLength(15.5)).toBe("1'-3.5")
+      expect(formatter.formatLength(15.5, { showUnits: true })).toBe('1\'-3.5"')
+    })
+
+    it('formats architectural lengths with fractional inches', () => {
+      db.lunits = AcDbLinearUnits.Architectural
+      db.luprec = 2
+
+      expect(formatter.formatLength(15.5)).toBe("1'-3 1/2")
+    })
+
+    it('formats fractional linear lengths', () => {
+      db.lunits = AcDbLinearUnits.Fractional
+      db.luprec = 1
+
+      expect(formatter.formatLength(15.5)).toBe('15 1/2')
+    })
+  })
+
+  describe('formatPoint', () => {
+    it('formats 2d and 3d points from coordinates', () => {
+      db.lunits = AcDbLinearUnits.Decimal
+      db.luprec = 1
+
+      expect(formatter.formatPoint2d(new AcGePoint2d(1.23, 4.56))).toBe(
+        '1.2, 4.6'
+      )
+      expect(formatter.formatPoint3d(new AcGePoint3d(1.23, 4.56, 7.89))).toBe(
+        '1.2, 4.6, 7.9'
+      )
+    })
+
+    it('prefixes approximate coordinates independently when showApproximate is true', () => {
+      db.lunits = AcDbLinearUnits.Decimal
+      db.luprec = 1
+
+      expect(
+        formatter.formatPoint2d(new AcGePoint2d(1.23, 4), {
+          showApproximate: true
+        })
+      ).toBe('~ 1.2, 4')
+    })
+  })
+
+  describe('formatAngle', () => {
+    it('formats decimal degrees', () => {
+      db.aunits = AcDbAngleUnits.DecimalDegrees
+      db.auprec = 2
+
+      expect(formatter.formatAngle(Math.PI / 4)).toBe('45')
+      expect(formatter.formatAngle(Math.PI / 4, { showUnits: true })).toBe(
+        '45°'
+      )
+    })
+
+    it('prefixes approximate angles when showApproximate is true', () => {
+      db.aunits = AcDbAngleUnits.DecimalDegrees
+      db.auprec = 0
+
+      const radians = (45.4 * Math.PI) / 180
+      expect(
+        formatter.formatAngle(radians, { showApproximate: true })
+      ).toBe('~ 45')
+      expect(
+        formatter.formatAngle(Math.PI / 4, { showApproximate: true })
+      ).toBe('45')
+    })
+
+    it('formats degrees minutes seconds', () => {
+      db.aunits = AcDbAngleUnits.DegreesMinutesSeconds
+      db.auprec = 0
+
+      expect(formatter.formatAngle(Math.PI / 2)).toBe("90d0'0")
+    })
+
+    it('formats radians and gradians', () => {
+      db.aunits = AcDbAngleUnits.Radians
+      db.auprec = 3
+      expect(formatter.formatAngle(Math.PI / 2)).toBe('1.571')
+
+      db.aunits = AcDbAngleUnits.Gradians
+      db.auprec = 1
+      expect(formatter.formatAngle(Math.PI / 2)).toBe('100')
+    })
+
+    it('applies ANGBASE and ANGDIR before formatting', () => {
+      db.aunits = AcDbAngleUnits.DecimalDegrees
+      db.auprec = 0
+      db.angbase = 0
+      db.angdir = 0
+
+      expect(formatter.formatAngle(Math.PI / 4)).toBe('45')
+
+      db.angdir = 1
+      expect(formatter.formatAngle(Math.PI / 4)).toBe('315')
+
+      db.angbase = Math.PI / 2
+      db.angdir = 0
+      expect(formatter.formatAngle(Math.PI / 2)).toBe('0')
+    })
+
+    it('skips ANGBASE and ANGDIR when applyAngbaseAngdir is false', () => {
+      db.aunits = AcDbAngleUnits.DecimalDegrees
+      db.auprec = 0
+      db.angbase = Math.PI / 2
+      db.angdir = 0
+
+      expect(formatter.formatAngle(Math.PI / 4)).toBe('315')
+      expect(
+        formatter.formatAngle(Math.PI / 4, { applyAngbaseAngdir: false })
+      ).toBe('45')
+    })
+  })
+
+  describe('UNITMODE and MEASUREMENT', () => {
+    it('uses UNITMODE input delimiters for architectural lengths', () => {
+      db.lunits = AcDbLinearUnits.Architectural
+      db.luprec = 2
+      db.unitmode = 1
+
+      expect(formatter.formatLength(15.5)).toBe("1'3-1/2")
+    })
+
+    it('uses MEASUREMENT when INSUNITS is unitless', () => {
+      db.lunits = AcDbLinearUnits.Decimal
+      db.luprec = 0
+      db.insunits = AcDbUnitsValue.Undefined
+      db.measurement = 1
+
+      expect(formatter.formatLength(10, { showUnits: true })).toBe('10 mm')
+
+      db.measurement = 0
+      expect(formatter.formatLength(10, { showUnits: true })).toBe('10"')
+    })
+  })
+})

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -480,6 +480,8 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
     if (header['$AUPREC'] != null) db.auprec = header['$AUPREC']
     if (header['$LUNITS'] != null) db.lunits = header['$LUNITS']
     if (header['$LUPREC'] != null) db.luprec = header['$LUPREC']
+    if (header['$UNITMODE'] != null) db.unitmode = header['$UNITMODE']
+    if (header['$MEASUREMENT'] != null) db.measurement = header['$MEASUREMENT']
     db.celtype = header['$CELTYPE'] || ByLayer
     AcDbSysVarManager.instance().setVar(
       AcDbSystemVariables.CETRANSPARENCY,

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -19,6 +19,7 @@ import {
   ACAD_APPID,
   AcDbAngleUnits,
   AcDbDataGenerator,
+  AcDbFormatter,
   AcDbLinearUnits,
   AcDbUnitsValue,
   ByBlock,
@@ -346,6 +347,10 @@ export class AcDbDatabase extends AcDbObject {
   private _extents: AcGeBox3d
   /** Insertion units for the database */
   private _insunits: AcDbUnitsValue
+  /** Feet-inch / fractional delimiter style (UNITMODE) */
+  private _unitmode: number
+  /** Legacy metric vs imperial flag (MEASUREMENT) */
+  private _measurement: number
   /** Global linetype scale */
   private _ltscale: number
   /** The flag whether to display line weight */
@@ -371,6 +376,8 @@ export class AcDbDatabase extends AcDbObject {
   private _currentSpace?: AcDbBlockTableRecord
   /** The maximum handle value in the database, used for generating unique object IDs */
   private _maxHandle: number
+  /** Lazily created formatter for lengths, angles, and coordinates */
+  private _formatter?: AcDbFormatter
 
   /**
    * Events that can be triggered by the database.
@@ -428,6 +435,8 @@ export class AcDbDatabase extends AcDbObject {
     this._extents = new AcGeBox3d()
     // TODO: Default value is 1 (imperial) or 4 (metric)
     this._insunits = AcDbUnitsValue.Millimeters
+    this._unitmode = 0
+    this._measurement = 1
     this._ltscale = 1
     this._lwdisplay = false
     this._pdmode = 0
@@ -483,6 +492,21 @@ export class AcDbDatabase extends AcDbObject {
    */
   get objects() {
     return this._objects
+  }
+
+  /**
+   * Formatter for linear distances, point coordinates, and angles using this database's
+   * **LUNITS**, **AUNITS**, and related system variables.
+   *
+   * @example
+   * ```typescript
+   * database.formatter.formatLength(12.3456);
+   * database.formatter.formatPoint3d(point);
+   * database.formatter.formatAngle(angleRadians, { showUnits: true });
+   * ```
+   */
+  get formatter(): AcDbFormatter {
+    return (this._formatter ??= new AcDbFormatter(this))
   }
 
   /**
@@ -791,6 +815,49 @@ export class AcDbDatabase extends AcDbObject {
       value ?? 4,
       nextValue => {
         this._insunits = nextValue
+      }
+    )
+  }
+
+  /**
+   * Controls how feet-inch and fractional linear values are delimited (**UNITMODE**).
+   *
+   * - `0`: Report format (for example `1'-3 1/2"`)
+   * - `1`: Input format (for example `1'-3-1/2"`, fewer spaces)
+   *
+   * @see {@link https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-C52134E8-10EB-4AE7-A0C0-8F798C68F823 | AutoCAD Help: UNITMODE}
+   */
+  get unitmode(): number {
+    return this._unitmode
+  }
+
+  set unitmode(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.UNITMODE,
+      this._unitmode,
+      value ?? 0,
+      nextValue => {
+        this._unitmode = nextValue
+      }
+    )
+  }
+
+  /**
+   * Legacy drawing measurement system (**MEASUREMENT**): `0` = English, `1` = metric.
+   *
+   * When **INSUNITS** is unitless, this selects the default real-world unit family for labels.
+   */
+  get measurement(): number {
+    return this._measurement
+  }
+
+  set measurement(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.MEASUREMENT,
+      this._measurement,
+      value ?? 1,
+      nextValue => {
+        this._measurement = nextValue
       }
     )
   }
@@ -1771,6 +1838,10 @@ export class AcDbDatabase extends AcDbObject {
     filer.writeInt16(70, this.lunits)
     filer.writeString(9, '$LUPREC')
     filer.writeInt16(70, this.luprec)
+    filer.writeString(9, '$UNITMODE')
+    filer.writeInt16(70, this.unitmode)
+    filer.writeString(9, '$MEASUREMENT')
+    filer.writeInt16(70, this.measurement)
     filer.writeString(9, '$LTSCALE')
     filer.writeDouble(40, this.ltscale)
     filer.writeString(9, '$LWDISPLAY')

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -108,7 +108,57 @@ export class AcDbSysVarManager {
     sysVarChanged: new AcCmEventManager<AcDbSysVarEventArgs>()
   }
 
+  /** Registers all known system variables in alphabetical order by name. */
   private constructor() {
+    /**
+     * Base angle for zero direction (**ANGBASE**), in radians.
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.ANGBASE,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
+    /**
+     * Direction of positive angles (**ANGDIR**).
+     * - `0`: Counterclockwise
+     * - `1`: Clockwise
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.ANGDIR,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
+    /**
+     * Sets the angular unit display format for angles (not the geometric angle itself).
+     * Integer codes match AutoCAD and {@link AcDbAngleUnits}:
+     * - `0`: Decimal degrees
+     * - `1`: Degrees/minutes/seconds
+     * - `2`: Gradians
+     * - `3`: Radians
+     * - `4`: Surveyor's units
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-C7C0F6A5-7982-43DB-97F9-5B9B0044E9FA-htm.html
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.AUNITS,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: AcDbAngleUnits.DecimalDegrees
+    })
+    /**
+     * Sets the display precision for angles (number of decimal places or equivalent), used together
+     * with {@link AcDbDatabase.aunits | AUNITS}. Typical range in AutoCAD is **0–8**; initial value **0**.
+     *
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-EE1ED20C-1096-4299-820F-83F1BC9B96F3
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.AUPREC,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
     this.registerVar({
       name: AcDbSystemVariables.CECOLOR,
       type: 'color',
@@ -146,13 +196,13 @@ export class AcDbSysVarManager {
       defaultValue: '0'
     })
     /**
-     * Sets the multiline style that governs the appearance of the multiline.
+     * Sets the name of the current multileader style.
      */
     this.registerVar({
-      name: AcDbSystemVariables.CMLSTYLE,
+      name: AcDbSystemVariables.CMLEADERSTYLE,
       type: 'string',
       isDbVar: true,
-      defaultValue: DEFAULT_MLINE_STYLE
+      defaultValue: DEFAULT_MLEADER_STYLE
     })
     /**
      * Controls the overall width of a multiline.
@@ -164,13 +214,13 @@ export class AcDbSysVarManager {
       defaultValue: 1
     })
     /**
-     * Sets the name of the current multileader style.
+     * Sets the multiline style that governs the appearance of the multiline.
      */
     this.registerVar({
-      name: AcDbSystemVariables.CMLEADERSTYLE,
+      name: AcDbSystemVariables.CMLSTYLE,
       type: 'string',
       isDbVar: true,
-      defaultValue: DEFAULT_MLEADER_STYLE
+      defaultValue: DEFAULT_MLINE_STYLE
     })
     /**
      * Color theme of UI elements
@@ -202,6 +252,15 @@ export class AcDbSysVarManager {
       defaultValue: true
     })
     /**
+     * Sets the default angle, in radians, for new hatch patterns in this session.
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.HPANG,
+      type: 'number',
+      isDbVar: false,
+      defaultValue: 0
+    })
+    /**
      * Controls whether newly created hatches and fills are associative.
      * - 0: Not associative
      * - 1: Associative
@@ -211,15 +270,6 @@ export class AcDbSysVarManager {
       type: 'number',
       isDbVar: false,
       defaultValue: 1
-    })
-    /**
-     * Sets the default angle, in radians, for new hatch patterns in this session.
-     */
-    this.registerVar({
-      name: AcDbSystemVariables.HPANG,
-      type: 'number',
-      isDbVar: false,
-      defaultValue: 0
     })
     /**
      * Sets the default background color for new hatch patterns in the current drawing.
@@ -317,44 +367,17 @@ export class AcDbSysVarManager {
       defaultValue: new AcCmTransparency()
     })
     /**
-     * Direction of positive angles (**ANGDIR**).
-     * - `0`: Counterclockwise
-     * - `1`: Clockwise
-     */
-    this.registerVar({
-      name: AcDbSystemVariables.ANGDIR,
-      type: 'number',
-      isDbVar: true,
-      defaultValue: 0
-    })
-    /**
-     * Sets the angular unit display format for angles (not the geometric angle itself).
-     * Integer codes match AutoCAD and {@link AcDbAngleUnits}:
-     * - `0`: Decimal degrees
-     * - `1`: Degrees/minutes/seconds
-     * - `2`: Gradians
-     * - `3`: Radians
-     * - `4`: Surveyor's units
+     * Specifies a drawing-units value for automatic scaling of blocks, images, or xrefs
+     * inserted or attached into this drawing. Integer codes match AutoCAD (0 = unitless,
+     * 1 = inches, 4 = millimeters, etc.); see {@link AcDbUnitsValue}.
      *
-     * @see https://help.autodesk.com/view/ACD/2027/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-C7C0F6A5-7982-43DB-97F9-5B9B0044E9FA-htm.html
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8
      */
     this.registerVar({
-      name: AcDbSystemVariables.AUNITS,
+      name: AcDbSystemVariables.INSUNITS,
       type: 'number',
       isDbVar: true,
-      defaultValue: AcDbAngleUnits.DecimalDegrees
-    })
-    /**
-     * Sets the display precision for angles (number of decimal places or equivalent), used together
-     * with {@link AcDbDatabase.aunits | AUNITS}. Typical range in AutoCAD is **0–8**; initial value **0**.
-     *
-     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-EE1ED20C-1096-4299-820F-83F1BC9B96F3
-     */
-    this.registerVar({
-      name: AcDbSystemVariables.AUPREC,
-      type: 'number',
-      isDbVar: true,
-      defaultValue: 0
+      defaultValue: AcDbUnitsValue.Millimeters
     })
     /**
      * Sets the linear unit display format for coordinates and distances (not insertion scaling).
@@ -386,24 +409,20 @@ export class AcDbSysVarManager {
       isDbVar: true,
       defaultValue: 4
     })
-    /**
-     * Specifies a drawing-units value for automatic scaling of blocks, images, or xrefs
-     * inserted or attached into this drawing. Integer codes match AutoCAD (0 = unitless,
-     * 1 = inches, 4 = millimeters, etc.); see {@link AcDbUnitsValue}.
-     *
-     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8
-     */
-    this.registerVar({
-      name: AcDbSystemVariables.INSUNITS,
-      type: 'number',
-      isDbVar: true,
-      defaultValue: AcDbUnitsValue.Millimeters
-    })
     this.registerVar({
       name: AcDbSystemVariables.LWDISPLAY,
       type: 'boolean',
       isDbVar: true,
       defaultValue: false
+    })
+    /**
+     * Legacy metric vs imperial flag (`0` English, `1` metric).
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.MEASUREMENT,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 1
     })
     /**
      * Color used for measurement tool overlays (distance, area, arc).
@@ -458,6 +477,15 @@ export class AcDbSysVarManager {
       type: 'string',
       isDbVar: true,
       defaultValue: DEFAULT_TEXT_STYLE
+    })
+    /**
+     * Feet-inch / fractional delimiter style used with **LUNITS** (`0` report, `1` input).
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.UNITMODE,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
     })
     this.registerVar({
       /**

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -27,22 +27,22 @@ export const AcDbSystemVariables = {
   AUPREC: 'AUPREC',
   /** Current color applied to newly created entities. */
   CECOLOR: 'CECOLOR',
-  /** Current linetype name used when creating new entities. */
-  CELTYPE: 'CELTYPE',
   /** Current entity linetype scale multiplier for newly created entities. */
   CELTSCALE: 'CELTSCALE',
+  /** Current linetype name used when creating new entities. */
+  CELTYPE: 'CELTYPE',
   /** Current lineweight applied to newly created entities. */
   CELWEIGHT: 'CELWEIGHT',
   /** Current transparency level for newly created entities. */
   CETRANSPARENCY: 'CETRANSPARENCY',
   /** Current layer name used when creating new entities. */
   CLAYER: 'CLAYER',
-  /** Current multiline style name used when creating new MLINE entities. */
-  CMLSTYLE: 'CMLSTYLE',
-  /** Current multiline scale used when creating new MLINE entities. */
-  CMLSCALE: 'CMLSCALE',
   /** Current multileader style name used when creating new MLEADER entities. */
   CMLEADERSTYLE: 'CMLEADERSTYLE',
+  /** Current multiline scale used when creating new MLINE entities. */
+  CMLSCALE: 'CMLSCALE',
+  /** Current multiline style name used when creating new MLINE entities. */
+  CMLSTYLE: 'CMLSTYLE',
   /** UI color theme selector used by the application shell or viewer integration. */
   COLORTHEME: 'COLORTHEME',
   /**
@@ -56,10 +56,10 @@ export const AcDbSystemVariables = {
   EXTMAX: 'EXTMAX',
   /** Lower-left corner of the model-space drawing extents. */
   EXTMIN: 'EXTMIN',
-  /** Controls whether newly created hatches are associative. */
-  HPASSOC: 'HPASSOC',
   /** Default angle, in radians, for newly created hatch patterns. */
   HPANG: 'HPANG',
+  /** Controls whether newly created hatches are associative. */
+  HPASSOC: 'HPASSOC',
   /** Default background color for newly created hatch patterns. */
   HPBACKGROUNDCOLOR: 'HPBACKGROUNDCOLOR',
   /** Default color for newly created hatches. */
@@ -88,6 +88,11 @@ export const AcDbSystemVariables = {
   LUPREC: 'LUPREC',
   /** Flag indicating whether lineweights are displayed in the editor/viewer. */
   LWDISPLAY: 'LWDISPLAY',
+  /**
+   * Legacy drawing measurement system: `0` = English (imperial), `1` = metric.
+   * Used with unitless **INSUNITS** to choose default unit labeling.
+   */
+  MEASUREMENT: 'MEASUREMENT',
   /** Color used for measurement tool overlays (distance, area, arc). */
   MEASUREMENTCOLOR: 'MEASUREMENTCOLOR',
   /** Running object snap mode bitmask (OSNAP settings). */
@@ -102,6 +107,11 @@ export const AcDbSystemVariables = {
   SHORTCUTMENU: 'SHORTCUTMENU',
   /** Current text style name used when creating new text entities. */
   TEXTSTYLE: 'TEXTSTYLE',
+  /**
+   * Controls feet-inch and fractional display delimiters together with **LUNITS**
+   * (`0` = report format, `1` = input format).
+   */
+  UNITMODE: 'UNITMODE',
   /** Flag indicating whether the drawing background should be rendered as white. */
   WHITEBKCOLOR: 'WHITEBKCOLOR'
 } as const

--- a/packages/data-model/src/misc/AcDbFormatter.ts
+++ b/packages/data-model/src/misc/AcDbFormatter.ts
@@ -1,0 +1,1051 @@
+import {
+  AcGeMathUtil,
+  AcGePoint2d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
+
+import { AcDbDatabase } from '../database/AcDbDatabase'
+import { AcDbAngleUnits } from './AcDbAngleUnits'
+import { AcDbLinearUnits } from './AcDbLinearUnits'
+import {
+  AcDbUnitsValue,
+  isImperialUnits,
+  isMetricUnits
+} from './AcDbUnitsValue'
+
+/**
+ * Per-call options for {@link AcDbFormatter} methods.
+ *
+ * These options layer on top of the drawing system variables held by the bound
+ * {@link AcDbDatabase}; they do not change the database itself.
+ */
+export interface AcDbFormatterOptions {
+  /**
+   * Whether to append real-world unit suffixes to formatted values.
+   *
+   * When `true`:
+   * - Decimal/scientific/fractional linear values may receive a suffix derived from
+   *   {@link AcDbDatabase.insunits | INSUNITS} (or {@link AcDbDatabase.measurement | MEASUREMENT}
+   *   when **INSUNITS** is unitless), for example `12.35 mm` or `10"`.
+   * - Angles may receive `°`, `g`, `rad`, or inch marks in DMS/surveyor formats.
+   * - Engineering and architectural lengths already embed `'` / `"` in the **LUNITS** pattern;
+   *   this flag mainly adds the inch quote for those modes when appropriate.
+   *
+   * When `false` (default), only the numeric pattern dictated by **LUNITS** / **AUNITS** is
+   * returned (for example `12.35`, `1'-3 1/2`, `45d30'15"`).
+   */
+  showUnits?: boolean
+  /**
+   * Whether to prefix the formatted value with `~ ` when display precision rounds the input.
+   *
+   * When `true`, values that are not exactly representable at the current **LUPREC** / **AUPREC**
+   * (or fractional denominator for architectural modes) are returned as `~ ${formatted}` — for
+   * example `~ 12.35` instead of `12.35` for `12.3456` with two decimal places.
+   *
+   * When `false` (default), no approximate prefix is added.
+   */
+  showApproximate?: boolean
+  /**
+   * Whether to apply {@link AcDbDatabase.angbase | ANGBASE} and
+   * {@link AcDbDatabase.angdir | ANGDIR} before formatting an angle.
+   *
+   * When `true` (default), the input is treated as an absolute WCS angle (counterclockwise
+   * from +X before adjustment), matching status-bar bearing-style display.
+   *
+   * When `false`, the input radians are formatted directly (after normalization to
+   * \([0, 2\pi)\)), for included angles, relative rotations, rubber-band sweep angles,
+   * and dynamic-input relative angle values.
+   */
+  applyAngbaseAngdir?: boolean
+}
+
+/** Radians per gradian (400 grads = full circle). */
+const RAD_PER_GRAD = Math.PI / 200
+
+/**
+ * Formats linear distances, point coordinates, and angles for display in the UI,
+ * matching AutoCAD drawing-unit behavior as closely as the supported system variables allow.
+ *
+ * An instance is bound to one {@link AcDbDatabase}. On each call it reads the current values of
+ * the relevant header/system variables from that database (not a snapshot taken at construction).
+ *
+ * ### Linear distances and coordinates
+ *
+ * | Variable | Role |
+ * |----------|------|
+ * | **LUNITS** | Display format (scientific, decimal, engineering, …); see {@link AcDbDatabase.lunits} |
+ * | **LUPREC** | Precision (decimal places or fractional denominator); see {@link AcDbDatabase.luprec} |
+ * | **INSUNITS** | Unit suffix when {@link AcDbFormatterOptions.showUnits} is `true`; see {@link AcDbDatabase.insunits} |
+ * | **UNITMODE** | Report vs input delimiters for feet-inch and fractions; see {@link AcDbDatabase.unitmode} |
+ * | **MEASUREMENT** | Imperial vs metric suffix when **INSUNITS** is unitless; see {@link AcDbDatabase.measurement} |
+ *
+ * Engineering (**LUNITS** = 3) and architectural (**LUNITS** = 4) formats treat the numeric
+ * value as **inches**, consistent with AutoCAD.
+ *
+ * ### Angles
+ *
+ * Input angles are **radians in WCS**. Before formatting, the value is adjusted by
+ * {@link AcDbDatabase.angbase | ANGBASE} and {@link AcDbDatabase.angdir | ANGDIR}, then converted
+ * per {@link AcDbDatabase.aunits | AUNITS} and {@link AcDbDatabase.auprec | AUPREC}.
+ *
+ * ### Out of scope
+ *
+ * Dimension entity text uses per-style **DIM\*** variables (for example **DIMLUNIT**, **DIMDEC**),
+ * not this class. **SNAPANG** and UCS settings affect snapping/input, not WCS coordinate strings here.
+ *
+ * @example
+ * ```typescript
+ * database.lunits = AcDbLinearUnits.Decimal;
+ * database.luprec = 2;
+ *
+ * database.formatter.formatLength(12.3456); // "12.35"
+ * database.formatter.formatLength(12.3456, { showUnits: true }); // "12.35 mm" (with INSUNITS = mm)
+ * database.formatter.formatPoint2d(new AcGePoint2d(1, 2)); // "1, 2"
+ * database.formatter.formatAngle(Math.PI / 4, { showUnits: true }); // "45°"
+ * ```
+ */
+export class AcDbFormatter {
+  /**
+   * Creates a formatter that reads unit settings from the given database.
+   *
+   * @param database - Drawing database whose **LUNITS**, **AUNITS**, and related variables
+   *   are consulted on every format call.
+   */
+  constructor(private readonly database: AcDbDatabase) {}
+
+  /**
+   * Formats a single linear distance in **drawing units**.
+   *
+   * The output pattern follows {@link AcDbDatabase.lunits | LUNITS} and
+   * {@link AcDbDatabase.luprec | LUPREC}. When {@link AcDbFormatterOptions.showUnits} is `true`,
+   * a suffix may be appended based on {@link AcDbDatabase.insunits | INSUNITS} and
+   * {@link AcDbDatabase.measurement | MEASUREMENT}.
+   *
+   * | **LUNITS** | Typical output (no unit suffix) |
+   * |-----------:|--------------------------------|
+   * | `1` Scientific | `1.23E+02` |
+   * | `2` Decimal | `12.35` |
+   * | `3` Engineering | `1'-3.5` (value interpreted as inches) |
+   * | `4` Architectural | `1'-3 1/2` |
+   * | `5` Fractional | `15 1/2` |
+   * | `6` Windows desktop | Same as decimal |
+   *
+   * {@link AcDbDatabase.unitmode | UNITMODE} changes delimiters for engineering, architectural,
+   * and fractional modes (for example `1'3-1/2` when **UNITMODE** = 1).
+   *
+   * @param value - Distance in drawing units (WCS length, not pre-converted to feet or degrees).
+   * @param options - Optional display flags; see {@link AcDbFormatterOptions}.
+   * @returns Formatted string suitable for status bars, measurement overlays, or tooltips.
+   *
+   * @remarks
+   * Non-finite values (`NaN`, `±Infinity`) are formatted as `"0"`.
+   *
+   * @example
+   * ```typescript
+   * database.lunits = AcDbLinearUnits.Architectural;
+   * database.luprec = 2;
+   * formatter.formatLength(15.5); // "1'-3 1/2"
+   * ```
+   */
+  formatLength(value: number, options?: AcDbFormatterOptions): string {
+    const ctx = this.createContext(options)
+    return formatLengthWithContext(value, ctx)
+  }
+
+  /**
+   * Formats a 2D point as `"x, y"`, formatting each component with {@link formatLength}.
+   *
+   * Both coordinates use the same {@link AcDbDatabase.lunits | LUNITS} / **LUPREC** rules and the
+   * same {@link AcDbFormatterOptions} for the call. The separator is a comma followed by a space
+   * (`, `), which matches common Cartesian display in measurement UIs.
+   *
+   * @param point - Point in drawing units (WCS **x** / **y**).
+   * @param options - Optional display flags applied to each coordinate.
+   * @returns Formatted coordinate pair, for example `"1.2, 4.6"` or `"1'-0, 2'-6"` depending on **LUNITS**.
+   *
+   * @example
+   * ```typescript
+   * database.lunits = AcDbLinearUnits.Decimal;
+   * database.luprec = 1;
+   * formatter.formatPoint2d(new AcGePoint2d(1.23, 4.56)); // "1.2, 4.6"
+   * ```
+   */
+  formatPoint2d(point: AcGePoint2d, options?: AcDbFormatterOptions): string {
+    const ctx = this.createContext(options)
+    return `${formatLengthWithContext(point.x, ctx)}, ${formatLengthWithContext(point.y, ctx)}`
+  }
+
+  /**
+   * Formats a 3D point as `"x, y, z"`, formatting each component with {@link formatLength}.
+   *
+   * Behavior is the same as {@link formatPoint2d} for **x** and **y**, with **z** appended using
+   * the same linear formatting and options.
+   *
+   * @param point - Point in drawing units (WCS **x** / **y** / **z**).
+   * @param options - Optional display flags applied to each coordinate.
+   * @returns Formatted coordinate triple, for example `"1.2, 4.6, 7.9"`.
+   *
+   * @example
+   * ```typescript
+   * formatter.formatPoint3d(new AcGePoint3d(1, 2, 3)); // "1, 2, 3" (with default decimal LUNITS)
+   * ```
+   */
+  formatPoint3d(point: AcGePoint3d, options?: AcDbFormatterOptions): string {
+    const ctx = this.createContext(options)
+    return `${formatLengthWithContext(point.x, ctx)}, ${formatLengthWithContext(point.y, ctx)}, ${formatLengthWithContext(point.z, ctx)}`
+  }
+
+  /**
+   * Formats an angle given in **radians** (WCS), for display according to the drawing angle units.
+   *
+   * Processing order:
+   * 1. Subtract {@link AcDbDatabase.angbase | ANGBASE} (zero direction).
+   * 2. Negate if {@link AcDbDatabase.angdir | ANGDIR} = 1 (clockwise positive).
+   * 3. Normalize to \([0, 2\pi)\) via {@link AcGeMathUtil.normalizeAngle}.
+   * 4. Format using {@link AcDbDatabase.aunits | AUNITS} and {@link AcDbDatabase.auprec | AUPREC}.
+   *
+   * | **AUNITS** | Typical output (no unit suffix) |
+   * |-----------:|--------------------------------|
+   * | `0` Decimal degrees | `45` or `45.5` |
+   * | `1` Degrees/minutes/seconds | `45d30'15"` |
+   * | `2` Gradians | `50` |
+   * | `3` Radians | `0.785` |
+   * | `4` Surveyor's | `N 45d30'15" E` |
+   *
+   * @param radians - Angle in radians. When {@link AcDbFormatterOptions.applyAngbaseAngdir} is
+   *   `true` (default), this is an absolute WCS angle (counterclockwise from +X before
+   *   **ANGBASE** / **ANGDIR** adjustment). When `false`, this is the scalar angle to display.
+   * @param options - Optional display flags; when {@link AcDbFormatterOptions.showUnits} is `true`,
+   *   unit markers such as `°`, `g`, or `rad` may be appended.
+   * @returns Formatted angle string.
+   *
+   * @remarks
+   * For included or relative angles, pass {@link AcDbFormatterOptions.applyAngbaseAngdir} = `false`.
+   * For arc sweep or dimension overrides, supply the appropriate radians value and flags.
+   *
+   * @example
+   * ```typescript
+   * database.aunits = AcDbAngleUnits.DecimalDegrees;
+   * database.auprec = 0;
+   * formatter.formatAngle(Math.PI / 4); // "45"
+   * formatter.formatAngle(Math.PI / 4, { showUnits: true }); // "45°"
+   * ```
+   */
+  formatAngle(radians: number, options?: AcDbFormatterOptions): string {
+    const ctx = this.createContext(options)
+    const applyAngbaseAngdir = options?.applyAngbaseAngdir ?? true
+    const displayRadians = applyAngbaseAngdir
+      ? toDisplayAngleRadians(
+          radians,
+          this.database.angbase,
+          this.database.angdir
+        )
+      : AcGeMathUtil.normalizeAngle(radians)
+    return formatAngleWithContext(displayRadians, ctx)
+  }
+
+  /**
+   * Builds the formatting context from the bound database and call options.
+   *
+   * @param options - Per-call overrides; omitted fields use database defaults.
+   * @returns Snapshot of linear and angular unit settings for one format call.
+   * @internal
+   */
+  private createContext(options?: AcDbFormatterOptions): AcDbFormatContext {
+    return {
+      lunits: this.database.lunits,
+      luprec: clampPrecision(this.database.luprec),
+      insunits: this.database.insunits as AcDbUnitsValue,
+      unitmode: this.database.unitmode,
+      measurement: this.database.measurement,
+      aunits: this.database.aunits,
+      auprec: clampPrecision(this.database.auprec),
+      showUnits: options?.showUnits ?? false,
+      showApproximate: options?.showApproximate ?? false
+    }
+  }
+}
+
+/**
+ * Snapshot of drawing unit settings used for one format operation.
+ *
+ * @internal
+ */
+interface AcDbFormatContext {
+  /** Current **LUNITS** value; see {@link AcDbLinearUnits}. */
+  lunits: number
+  /** Clamped **LUPREC** precision for linear output. */
+  luprec: number
+  /** Current **INSUNITS** insertion/drawing units. */
+  insunits: AcDbUnitsValue
+  /** Current **UNITMODE** delimiter style (`0` report, `1` input). */
+  unitmode: number
+  /** Current **MEASUREMENT** flag (`0` English, `1` metric). */
+  measurement: number
+  /** Current **AUNITS** value; see {@link AcDbAngleUnits}. */
+  aunits: number
+  /** Clamped **AUPREC** precision for angular output. */
+  auprec: number
+  /** Whether to append unit suffixes for this call. */
+  showUnits: boolean
+  /** Whether to prefix `~ ` when the formatted value is rounded from the input. */
+  showApproximate: boolean
+}
+
+/**
+ * Delimiters and suffixes for engineering/architectural/feet-inch linear formats.
+ *
+ * @internal
+ */
+interface ImperialDelimiterStyle {
+  /** Separator between feet and inches (for example `'-'` or empty). */
+  feetInchSeparator: string
+  /** Separator between whole inches and fractional part (space or `'-'`). */
+  fractionSeparator: string
+  /** Inch mark appended when {@link AcDbFormatContext.showUnits} is `true`. */
+  inchSuffix: string
+}
+
+/**
+ * Formats one linear distance using a pre-built {@link AcDbFormatContext}.
+ *
+ * @param value - Distance in drawing units.
+ * @param ctx - Unit settings snapshot for this call.
+ * @returns Formatted linear string.
+ * @internal
+ */
+function formatLengthWithContext(
+  value: number,
+  ctx: AcDbFormatContext
+): string {
+  let formatted: string
+  switch (ctx.lunits) {
+    case AcDbLinearUnits.Scientific:
+      formatted = appendLinearUnitSuffix(
+        formatScientific(value, ctx.luprec),
+        ctx
+      )
+      break
+    case AcDbLinearUnits.Engineering:
+      formatted = formatEngineering(value, ctx)
+      break
+    case AcDbLinearUnits.Architectural:
+      formatted = formatArchitectural(value, ctx)
+      break
+    case AcDbLinearUnits.Fractional:
+      formatted = appendLinearUnitSuffix(
+        formatFractionalLinear(value, ctx),
+        ctx
+      )
+      break
+    case AcDbLinearUnits.WindowsDesktop:
+    case AcDbLinearUnits.Decimal:
+    default:
+      formatted = appendLinearUnitSuffix(formatDecimal(value, ctx.luprec), ctx)
+  }
+  return applyApproximatePrefix(
+    formatted,
+    isLinearValueApproximate(value, ctx),
+    ctx
+  )
+}
+
+/**
+ * Formats one angle (already adjusted for **ANGBASE** / **ANGDIR**) using {@link AcDbFormatContext}.
+ *
+ * @param radians - Display angle in radians, in range \([0, 2\pi)\).
+ * @param ctx - Unit settings snapshot for this call.
+ * @returns Formatted angle string.
+ * @internal
+ */
+function formatAngleWithContext(
+  radians: number,
+  ctx: AcDbFormatContext
+): string {
+  let formatted: string
+  switch (ctx.aunits) {
+    case AcDbAngleUnits.DegreesMinutesSeconds:
+      formatted = formatAngleDms(radians, ctx)
+      break
+    case AcDbAngleUnits.Gradians:
+      formatted = formatAngleGradians(radians, ctx)
+      break
+    case AcDbAngleUnits.Radians:
+      formatted = formatAngleRadians(radians, ctx)
+      break
+    case AcDbAngleUnits.SurveyorsUnits:
+      formatted = formatAngleSurveyor(radians, ctx)
+      break
+    case AcDbAngleUnits.DecimalDegrees:
+    default:
+      formatted = formatAngleDecimalDegrees(radians, ctx)
+  }
+  return applyApproximatePrefix(
+    formatted,
+    isAngleValueApproximate(radians, ctx),
+    ctx
+  )
+}
+
+/**
+ * Converts a WCS angle to the drawing's display angle before **AUNITS** formatting.
+ *
+ * @param radians - Raw angle in radians (WCS, counterclockwise from +X).
+ * @param angbase - **ANGBASE** zero direction in radians.
+ * @param angdir - **ANGDIR** (`0` = CCW positive, `1` = CW positive).
+ * @returns Normalized display angle in radians.
+ * @internal
+ */
+function toDisplayAngleRadians(
+  radians: number,
+  angbase: number,
+  angdir: number
+): number {
+  let angle = radians - angbase
+  if (angdir === 1) {
+    angle = -angle
+  }
+  return AcGeMathUtil.normalizeAngle(angle)
+}
+
+/**
+ * Resolves feet-inch delimiters from **UNITMODE** and {@link AcDbFormatContext.showUnits}.
+ *
+ * @param ctx - Formatting context.
+ * @returns Delimiter pattern for imperial linear modes.
+ * @internal
+ */
+function imperialDelimiterStyle(
+  ctx: AcDbFormatContext
+): ImperialDelimiterStyle {
+  const inchSuffix = ctx.showUnits ? '"' : ''
+  if (ctx.unitmode === 1) {
+    return {
+      feetInchSeparator: '',
+      fractionSeparator: '-',
+      inchSuffix
+    }
+  }
+  return {
+    feetInchSeparator: '-',
+    fractionSeparator: ' ',
+    inchSuffix
+  }
+}
+
+/**
+ * Rounds and clamps a precision value to a safe integer range.
+ *
+ * @param value - Raw precision (for example **LUPREC** or **AUPREC**).
+ * @param min - Minimum allowed precision (default `0`).
+ * @param max - Maximum allowed precision (default `8`).
+ * @returns Clamped integer precision, or `min` when `value` is non-finite.
+ * @internal
+ */
+function clampPrecision(value: number, min = 0, max = 8): number {
+  if (!Number.isFinite(value)) return min
+  return Math.max(min, Math.min(max, Math.round(value)))
+}
+
+/**
+ * Maps negative zero to positive zero for consistent string output.
+ *
+ * @param value - Input number.
+ * @returns `0` when `value` is `-0`, otherwise `value`.
+ * @internal
+ */
+function normalizeZero(value: number): number {
+  return Object.is(value, -0) ? 0 : value
+}
+
+/**
+ * Prefixes `~ ` when approximate display is enabled and the value was rounded.
+ *
+ * @param formatted - Fully formatted display string (including unit suffixes).
+ * @param approximate - Whether the input differs from the quantized display value.
+ * @param ctx - Formatting context.
+ * @returns Original text, or `~ ${formatted}` when flagged approximate.
+ * @internal
+ */
+function applyApproximatePrefix(
+  formatted: string,
+  approximate: boolean,
+  ctx: AcDbFormatContext
+): string {
+  if (!ctx.showApproximate || !approximate) return formatted
+  return `~ ${formatted}`
+}
+
+/**
+ * Returns whether a linear value differs from its **LUPREC**-quantized representation.
+ *
+ * @param value - Raw distance in drawing units.
+ * @param ctx - Formatting context.
+ * @internal
+ */
+function isLinearValueApproximate(
+  value: number,
+  ctx: AcDbFormatContext
+): boolean {
+  if (!Number.isFinite(value)) return false
+  const quantized = quantizeLinearValue(value, ctx)
+  return differsAfterQuantization(value, quantized)
+}
+
+/**
+ * Returns whether an angle differs from its **AUPREC**-quantized representation.
+ *
+ * @param radians - Display angle in radians (after **ANGBASE** / **ANGDIR**).
+ * @param ctx - Formatting context.
+ * @internal
+ */
+function isAngleValueApproximate(
+  radians: number,
+  ctx: AcDbFormatContext
+): boolean {
+  if (!Number.isFinite(radians)) return false
+  if (ctx.aunits === AcDbAngleUnits.SurveyorsUnits) {
+    return isSurveyorAngleApproximate(radians, ctx.auprec)
+  }
+  const quantized = quantizeAngleValue(radians, ctx)
+  return differsAfterQuantization(radians, quantized)
+}
+
+/**
+ * Returns whether the surveyor deflection angle would be rounded in DMS output.
+ *
+ * @internal
+ */
+function isSurveyorAngleApproximate(
+  radians: number,
+  auprec: number
+): boolean {
+  const degrees = AcGeMathUtil.radToDeg(radians)
+  const bearing = (((90 - degrees) % 360) + 360) % 360
+  const quadrant = bearingToQuadrant(bearing)
+  const deflection = Math.min(
+    Math.abs(bearing - quadrant.base),
+    Math.abs(quadrant.base + 90 - bearing)
+  )
+  const deflectionRadians = AcGeMathUtil.degToRad(deflection)
+  const quantizedDeflection = quantizeAngleDmsRadians(
+    deflectionRadians,
+    auprec
+  )
+  return differsAfterQuantization(deflectionRadians, quantizedDeflection)
+}
+
+/**
+ * Quantizes a linear value to the precision implied by **LUNITS** and **LUPREC**.
+ *
+ * @internal
+ */
+function quantizeLinearValue(value: number, ctx: AcDbFormatContext): number {
+  const normalized = normalizeZero(value)
+  switch (ctx.lunits) {
+    case AcDbLinearUnits.Scientific:
+      return quantizeScientific(normalized, ctx.luprec)
+    case AcDbLinearUnits.Engineering:
+    case AcDbLinearUnits.Architectural:
+    case AcDbLinearUnits.Fractional:
+      return quantizeImperialInches(normalized, ctx)
+    case AcDbLinearUnits.WindowsDesktop:
+    case AcDbLinearUnits.Decimal:
+    default:
+      return quantizeDecimal(normalized, ctx.luprec)
+  }
+}
+
+/**
+ * Quantizes an angle to the precision implied by **AUNITS** and **AUPREC**.
+ *
+ * @internal
+ */
+function quantizeAngleValue(radians: number, ctx: AcDbFormatContext): number {
+  const normalized = normalizeZero(radians)
+  switch (ctx.aunits) {
+    case AcDbAngleUnits.DegreesMinutesSeconds:
+      return quantizeAngleDmsRadians(normalized, ctx.auprec)
+    case AcDbAngleUnits.Gradians:
+      return quantizeDecimal(normalized / RAD_PER_GRAD, ctx.auprec) * RAD_PER_GRAD
+    case AcDbAngleUnits.Radians:
+      return quantizeDecimal(normalized, ctx.auprec)
+    case AcDbAngleUnits.DecimalDegrees:
+    default:
+      return AcGeMathUtil.degToRad(
+        quantizeDecimal(AcGeMathUtil.radToDeg(normalized), ctx.auprec)
+      )
+  }
+}
+
+/**
+ * Rounds a number to a fixed number of decimal places.
+ *
+ * @internal
+ */
+function quantizeDecimal(value: number, precision: number): number {
+  if (!Number.isFinite(value)) return 0
+  const factor = 10 ** precision
+  return Math.round(normalizeZero(value) * factor) / factor
+}
+
+/**
+ * Rounds a value to the mantissa precision used by {@link formatScientific}.
+ *
+ * @internal
+ */
+function quantizeScientific(value: number, precision: number): number {
+  if (!Number.isFinite(value)) return 0
+  const normalized = normalizeZero(value)
+  if (normalized === 0) return 0
+  const formatted = normalized.toExponential(precision)
+  return Number(formatted)
+}
+
+/**
+ * Quantizes an inch-based length for engineering, architectural, or fractional **LUNITS**.
+ *
+ * @internal
+ */
+function quantizeImperialInches(
+  inches: number,
+  ctx: AcDbFormatContext
+): number {
+  if (!Number.isFinite(inches)) return 0
+  const sign = inches < 0 ? -1 : 1
+  const absInches = Math.abs(inches)
+  const feet = Math.floor(absInches / 12)
+  const inchPart = absInches - feet * 12
+
+  if (
+    ctx.lunits === AcDbLinearUnits.Architectural ||
+    ctx.lunits === AcDbLinearUnits.Fractional
+  ) {
+    const denominator = 1 << clampPrecision(ctx.luprec, 0, 8)
+    const quantizedInches = quantizeFractionalInches(inchPart, denominator)
+    return sign * (feet * 12 + quantizedInches)
+  }
+
+  return sign * (feet * 12 + quantizeDecimal(inchPart, ctx.luprec))
+}
+
+/**
+ * Quantizes the inch component using the same rounding as {@link formatFractionalInches}.
+ *
+ * @internal
+ */
+function quantizeFractionalInches(
+  inches: number,
+  denominator: number
+): number {
+  const whole = Math.floor(inches)
+  const remainder = inches - whole
+  const numerator = Math.round(remainder * denominator)
+  if (numerator >= denominator) {
+    return whole + 1
+  }
+  return whole + numerator / denominator
+}
+
+/**
+ * Quantizes an angle in radians using DMS seconds precision (**AUPREC**).
+ *
+ * @internal
+ */
+function quantizeAngleDmsRadians(radians: number, auprec: number): number {
+  const degrees = AcGeMathUtil.radToDeg(radians)
+  const sign = degrees < 0 ? -1 : 1
+  const absDegrees = Math.abs(degrees)
+  const d = Math.floor(absDegrees)
+  const minutesFloat = (absDegrees - d) * 60
+  const m = Math.floor(minutesFloat)
+  const seconds = quantizeDecimal((minutesFloat - m) * 60, auprec)
+  const quantizedDegrees = d + m / 60 + seconds / 3600
+  return AcGeMathUtil.degToRad(sign * quantizedDegrees)
+}
+
+/**
+ * Returns whether quantization changed the numeric value (beyond float noise).
+ *
+ * @internal
+ */
+function differsAfterQuantization(original: number, quantized: number): boolean {
+  if (original === quantized) return false
+  const scale = Math.max(Math.abs(original), Math.abs(quantized), 1)
+  return Math.abs(original - quantized) > scale * Number.EPSILON * 8
+}
+
+/**
+ * Formats a number in plain decimal form with trailing zeros trimmed.
+ *
+ * @param value - Numeric value to format.
+ * @param precision - Number of decimal places (**LUPREC** / **AUPREC**).
+ * @returns Decimal string, or `"0"` for non-finite input.
+ * @internal
+ */
+function formatDecimal(value: number, precision: number): string {
+  if (!Number.isFinite(value)) return '0'
+  const normalized = normalizeZero(value)
+  if (Number.isInteger(normalized) && precision === 0) {
+    return String(normalized)
+  }
+  const fixed = normalized.toFixed(precision)
+  const trimmed = fixed.replace(/\.?0+$/, '')
+  if (trimmed === '' || trimmed === '-') return '0'
+  return trimmed
+}
+
+/**
+ * Formats a number in scientific notation (**LUNITS** = scientific).
+ *
+ * @param value - Numeric value to format.
+ * @param precision - Mantissa decimal places.
+ * @returns Uppercase exponent string (for example `1.23E+02`), or `"0"` for non-finite/zero input.
+ * @internal
+ */
+function formatScientific(value: number, precision: number): string {
+  if (!Number.isFinite(value)) return '0'
+  const normalized = normalizeZero(value)
+  if (normalized === 0) return '0'
+  const match = normalized.toExponential(precision).match(/^(.+)e([+-])(\d+)$/i)
+  if (!match) return '0'
+  const [, mantissa, sign, exponentDigits] = match
+  const paddedExponent =
+    exponentDigits.length < 2 ? exponentDigits.padStart(2, '0') : exponentDigits
+  return `${mantissa}E${sign}${paddedExponent}`.toUpperCase()
+}
+
+/**
+ * Formats a length in engineering feet-and-decimal-inches (**LUNITS** = 3).
+ *
+ * @param inches - Length interpreted as inches.
+ * @param ctx - Formatting context (**LUPREC**, **UNITMODE**, suffix flags).
+ * @returns Engineering string (for example `1'-3.5`).
+ * @internal
+ */
+function formatEngineering(inches: number, ctx: AcDbFormatContext): string {
+  if (!Number.isFinite(inches)) return '0'
+  const style = imperialDelimiterStyle(ctx)
+  const sign = inches < 0 ? '-' : ''
+  const absInches = Math.abs(inches)
+  const feet = Math.floor(absInches / 12)
+  const inchPart = absInches - feet * 12
+  const inchText = formatDecimal(inchPart, ctx.luprec)
+  if (feet === 0) {
+    return `${sign}${inchText}${style.inchSuffix}`
+  }
+  return `${sign}${feet}'${style.feetInchSeparator}${inchText}${style.inchSuffix}`
+}
+
+/**
+ * Formats a length in architectural feet-and-fractional-inches (**LUNITS** = 4).
+ *
+ * @param inches - Length interpreted as inches.
+ * @param ctx - Formatting context; **LUPREC** selects fractional denominator \(2^{LUPREC}\).
+ * @returns Architectural string (for example `1'-3 1/2`).
+ * @internal
+ */
+function formatArchitectural(inches: number, ctx: AcDbFormatContext): string {
+  if (!Number.isFinite(inches)) return '0'
+  const style = imperialDelimiterStyle(ctx)
+  const sign = inches < 0 ? '-' : ''
+  const absInches = Math.abs(inches)
+  const feet = Math.floor(absInches / 12)
+  const inchPart = absInches - feet * 12
+  const denominator = 1 << clampPrecision(ctx.luprec, 0, 8)
+  const inchText = formatFractionalInches(
+    inchPart,
+    denominator,
+    style.fractionSeparator
+  )
+  if (feet === 0) {
+    return `${sign}${inchText}${style.inchSuffix}`
+  }
+  return `${sign}${feet}'${style.feetInchSeparator}${inchText}${style.inchSuffix}`
+}
+
+/**
+ * Formats a length as a whole number plus fraction (**LUNITS** = fractional).
+ *
+ * @param inches - Length interpreted as inches.
+ * @param ctx - Formatting context.
+ * @returns Fractional string (for example `15 1/2`).
+ * @internal
+ */
+function formatFractionalLinear(
+  inches: number,
+  ctx: AcDbFormatContext
+): string {
+  if (!Number.isFinite(inches)) return '0'
+  const style = imperialDelimiterStyle(ctx)
+  const sign = inches < 0 ? '-' : ''
+  const absInches = Math.abs(inches)
+  const denominator = 1 << clampPrecision(ctx.luprec, 0, 8)
+  return `${sign}${formatFractionalInches(absInches, denominator, style.fractionSeparator)}`
+}
+
+/**
+ * Formats the inch component as a whole number and reduced fraction.
+ *
+ * @param inches - Inch value in \([0, 12)\) (caller supplies fractional part of feet-inch).
+ * @param denominator - Fraction denominator (power of two from **LUPREC**).
+ * @param fractionSeparator - Space or dash between whole inches and fraction.
+ * @returns Inch-only fractional text (for example `3 1/2`).
+ * @internal
+ */
+function formatFractionalInches(
+  inches: number,
+  denominator: number,
+  fractionSeparator: string
+): string {
+  const whole = Math.floor(inches)
+  const remainder = inches - whole
+  let numerator = Math.round(remainder * denominator)
+
+  if (numerator >= denominator) {
+    return String(whole + 1)
+  }
+  if (numerator === 0) {
+    return String(whole)
+  }
+
+  const divisor = gcd(numerator, denominator)
+  numerator /= divisor
+  const reducedDenominator = denominator / divisor
+  const fraction = `${numerator}/${reducedDenominator}`
+  if (whole === 0) {
+    return fraction
+  }
+  return `${whole}${fractionSeparator}${fraction}`
+}
+
+/**
+ * Formats an angle as decimal degrees (**AUNITS** = 0).
+ *
+ * @param radians - Display angle in radians.
+ * @param ctx - Formatting context.
+ * @returns Decimal degree string, optionally suffixed with `°`.
+ * @internal
+ */
+function formatAngleDecimalDegrees(
+  radians: number,
+  ctx: AcDbFormatContext
+): string {
+  const degrees = AcGeMathUtil.radToDeg(radians)
+  return `${formatDecimal(degrees, ctx.auprec)}${ctx.showUnits ? '°' : ''}`
+}
+
+/**
+ * Formats an angle as radians (**AUNITS** = 3).
+ *
+ * @param radians - Display angle in radians.
+ * @param ctx - Formatting context.
+ * @returns Radian string, optionally suffixed with ` rad`.
+ * @internal
+ */
+function formatAngleRadians(radians: number, ctx: AcDbFormatContext): string {
+  return `${formatDecimal(radians, ctx.auprec)}${ctx.showUnits ? ' rad' : ''}`
+}
+
+/**
+ * Formats an angle as gradians (**AUNITS** = 2).
+ *
+ * @param radians - Display angle in radians.
+ * @param ctx - Formatting context.
+ * @returns Gradian string, optionally suffixed with `g`.
+ * @internal
+ */
+function formatAngleGradians(radians: number, ctx: AcDbFormatContext): string {
+  const grads = radians / RAD_PER_GRAD
+  return `${formatDecimal(grads, ctx.auprec)}${ctx.showUnits ? 'g' : ''}`
+}
+
+/**
+ * Formats an angle as degrees, minutes, and seconds (**AUNITS** = 1).
+ *
+ * @param radians - Display angle in radians.
+ * @param ctx - Formatting context; **AUPREC** applies to the seconds field.
+ * @returns DMS string (for example `45d30'15"`).
+ * @internal
+ */
+function formatAngleDms(radians: number, ctx: AcDbFormatContext): string {
+  const degrees = AcGeMathUtil.radToDeg(radians)
+  const sign = degrees < 0 ? '-' : ''
+  const absDegrees = Math.abs(degrees)
+  const d = Math.floor(absDegrees)
+  const minutesFloat = (absDegrees - d) * 60
+  const m = Math.floor(minutesFloat)
+  const seconds = (minutesFloat - m) * 60
+  const secondsText = formatDecimal(seconds, ctx.auprec)
+  const secondSuffix = ctx.showUnits ? '"' : ''
+  return `${sign}${d}d${m}'${secondsText}${secondSuffix}`
+}
+
+/**
+ * Formats an angle in surveyor's bearing notation (**AUNITS** = 4).
+ *
+ * @param radians - Display angle in radians.
+ * @param ctx - Formatting context; DMS portion uses {@link formatAngleDms}.
+ * @returns Bearing string (for example `N 45d30'15" E`).
+ * @internal
+ */
+function formatAngleSurveyor(radians: number, ctx: AcDbFormatContext): string {
+  const degrees = AcGeMathUtil.radToDeg(radians)
+  const bearing = (((90 - degrees) % 360) + 360) % 360
+  const quadrant = bearingToQuadrant(bearing)
+  const deflection = Math.min(
+    Math.abs(bearing - quadrant.base),
+    Math.abs(quadrant.base + 90 - bearing)
+  )
+  const dms = formatAngleDms(AcGeMathUtil.degToRad(deflection), ctx)
+  const dmsBody = dms.replace(/^-/, '')
+  return `${quadrant.prefix} ${dmsBody} ${quadrant.suffix}`.trim()
+}
+
+/**
+ * Maps a north-based bearing in degrees to a surveyor quadrant label and reference azimuth.
+ *
+ * @param bearing - Bearing from north, clockwise, in \([0, 360)\) degrees.
+ * @returns Quadrant prefix/suffix (N/S + E/W) and the quadrant's base bearing in degrees.
+ * @internal
+ */
+function bearingToQuadrant(bearing: number): {
+  /** Cardinal prefix (`N` or `S`). */
+  prefix: string
+  /** Cardinal suffix (`E` or `W`). */
+  suffix: string
+  /** Base bearing of the quadrant in degrees (`0`, `90`, `180`, or `270`). */
+  base: number
+} {
+  if (bearing < 90) {
+    return { prefix: 'N', suffix: 'E', base: 0 }
+  }
+  if (bearing < 180) {
+    return { prefix: 'S', suffix: 'E', base: 90 }
+  }
+  if (bearing < 270) {
+    return { prefix: 'S', suffix: 'W', base: 180 }
+  }
+  return { prefix: 'N', suffix: 'W', base: 270 }
+}
+
+/**
+ * Appends an **INSUNITS** / **MEASUREMENT** suffix to a linear string when enabled.
+ *
+ * Engineering and architectural strings are returned unchanged (units are already embedded).
+ *
+ * @param text - Formatted numeric linear text.
+ * @param ctx - Formatting context.
+ * @returns Text with optional suffix (for example `12.35 mm`).
+ * @internal
+ */
+function appendLinearUnitSuffix(text: string, ctx: AcDbFormatContext): string {
+  if (!ctx.showUnits) return text
+  if (
+    ctx.lunits === AcDbLinearUnits.Engineering ||
+    ctx.lunits === AcDbLinearUnits.Architectural
+  ) {
+    return text
+  }
+  const suffix = linearUnitSuffix(ctx.insunits, ctx.measurement)
+  return suffix ? `${text}${suffix}` : text
+}
+
+/**
+ * Resolves the suffix for decimal/scientific/fractional linear output.
+ *
+ * @param insunits - **INSUNITS** value.
+ * @param measurement - **MEASUREMENT** flag when **INSUNITS** is unitless.
+ * @returns Suffix string, or empty when unknown or suffix not applicable.
+ * @internal
+ */
+function linearUnitSuffix(
+  insunits: AcDbUnitsValue,
+  measurement: number
+): string {
+  if (insunits === AcDbUnitsValue.Undefined) {
+    return measurement === 0 ? '"' : ' mm'
+  }
+  if (isMetricUnits(insunits)) {
+    return metricUnitSuffix(insunits)
+  }
+  if (isImperialUnits(insunits)) {
+    return imperialUnitSuffix(insunits)
+  }
+  return ''
+}
+
+/**
+ * Returns the display suffix for a metric {@link AcDbUnitsValue}.
+ *
+ * @param insunits - Metric insertion unit code.
+ * @returns Suffix such as ` mm`, or empty for unsupported codes.
+ * @internal
+ */
+function metricUnitSuffix(insunits: AcDbUnitsValue): string {
+  switch (insunits) {
+    case AcDbUnitsValue.Millimeters:
+      return ' mm'
+    case AcDbUnitsValue.Centimeters:
+      return ' cm'
+    case AcDbUnitsValue.Meters:
+      return ' m'
+    case AcDbUnitsValue.Kilometers:
+      return ' km'
+    case AcDbUnitsValue.Decimeters:
+      return ' dm'
+    case AcDbUnitsValue.Microns:
+      return ' µm'
+    case AcDbUnitsValue.Nanometers:
+      return ' nm'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Returns the display suffix for an imperial {@link AcDbUnitsValue}.
+ *
+ * @param insunits - Imperial insertion unit code.
+ * @returns Suffix such as `"` or ` mi`, or empty for unsupported codes.
+ * @internal
+ */
+function imperialUnitSuffix(insunits: AcDbUnitsValue): string {
+  switch (insunits) {
+    case AcDbUnitsValue.Inches:
+    case AcDbUnitsValue.Microinches:
+    case AcDbUnitsValue.Mils:
+    case AcDbUnitsValue.USSurveyInch:
+      return '"'
+    case AcDbUnitsValue.Feet:
+    case AcDbUnitsValue.USSurveyFeet:
+      return '\''
+    case AcDbUnitsValue.Miles:
+    case AcDbUnitsValue.USSurveyMile:
+      return ' mi'
+    case AcDbUnitsValue.Yards:
+    case AcDbUnitsValue.USSurveyYard:
+      return ' yd'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Greatest common divisor of two integers (Euclidean algorithm).
+ *
+ * @param a - First integer.
+ * @param b - Second integer.
+ * @returns GCD of `|a|` and `|b|`, minimum `1`.
+ * @internal
+ */
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a)
+  let y = Math.abs(b)
+  while (y !== 0) {
+    const temp = y
+    y = x % y
+    x = temp
+  }
+  return x || 1
+}

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -1,4 +1,5 @@
 export * from './AcDbAngleUnits'
+export * from './AcDbFormatter'
 export * from './AcDbLinearUnits'
 export * from './AcDbRenderingCache'
 export * from './AcDbCodePage'

--- a/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
+++ b/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
@@ -359,6 +359,12 @@ export class AcDbLibdxfrwConverter extends AcDbDatabaseConverter<DRW_Database> {
     // Initial value:	1 (imperial) or 4 (metric)
     db.insunits = variant ? variant.getInt() : 1
 
+    variant = header.getVar('$UNITMODE')
+    if (variant) db.unitmode = variant.getInt()
+
+    variant = header.getVar('$MEASUREMENT')
+    if (variant) db.measurement = variant.getInt()
+
     variant = header.getVar('$PDMODE')
     // Initial value:	0
     db.pdmode = variant ? variant.getInt() : 0

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -539,6 +539,8 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     if (header.AUPREC != null) db.auprec = header.AUPREC
     if (header.LUNITS != null) db.lunits = header.LUNITS
     if (header.LUPREC != null) db.luprec = header.LUPREC
+    if (header.UNITMODE != null) db.unitmode = header.UNITMODE
+    if (header.MEASUREMENT != null) db.measurement = header.MEASUREMENT
     db.celtype = header.CELTYPE ?? ByLayer
     db.celtscale = header.CELTSCALE ?? 1
     db.ltscale = header.LTSCALE ?? 1


### PR DESCRIPTION
## Summary

Introduces **`AcDbFormatter`**, a drawing-bound formatter that turns linear distances, 2D/3D coordinates, and WCS angles into display strings aligned with AutoCAD header variables. Exposes it via **`AcDbDatabase.formatter`** and wires **`UNITMODE`** / **`MEASUREMENT`** through the database, DXF I/O, and DWG/DXF converters.

## Motivation

UI layers (status bar, dynamic input, measurement overlays) need human-readable values that respect the drawing’s unit settings—not raw doubles. This centralizes that logic next to the data model so consumers do not reimplement **LUNITS**, **AUNITS**, feet-inch rules, or angle base/direction handling.

## Changes

### `AcDbFormatter` (`packages/data-model/src/misc/AcDbFormatter.ts`)

- **`formatLength`** — scientific, decimal, engineering, architectural, and fractional **LUNITS**; precision from **LUPREC**; optional unit suffixes from **INSUNITS** (or **MEASUREMENT** when **INSUNITS** is unitless).
- **`formatPoint2d` / `formatPoint3d`** — comma-separated coordinates, each component formatted like a length.
- **`formatAngle`** — decimal degrees, DMS, gradians, radians, and surveyor’s units per **AUNITS** / **AUPREC**; applies **ANGBASE** / **ANGDIR** by default (opt-out via `applyAngbaseAngdir: false` for relative/included angles).
- **Per-call options**: `showUnits`, `showApproximate` (`~ ` prefix when rounded), `applyAngbaseAngdir`.
- Engineering/architectural modes treat values as **inches**, consistent with AutoCAD.
- **UNITMODE** toggles report vs input delimiters (e.g. `1'-3 1/2` vs `1'3-1/2`).
- Documented as **out of scope** for dimension entity text (**DIM\*** variables).

### Database & system variables

- Lazy **`database.formatter`** getter on `AcDbDatabase`.
- New **`unitmode`** and **`measurement`** properties with sysvar integration and DXF header read/write (`$UNITMODE`, `$MEASUREMENT`).
- `AcDbSysVarManager`: register **UNITMODE** and **MEASUREMENT**; reorder existing registrations alphabetically (no semantic change).

### Converters

- **`AcDbDxfConverter`**: read `$UNITMODE` and `$MEASUREMENT` from DXF header.
- **`AcDbLibdxfrwConverter`**: map `$UNITMODE` / `$MEASUREMENT` from libdxfrw header.
- **`AcDbLibreDwgConverter`**: map `UNITMODE` / `MEASUREMENT` from LibreDWG header.

### Tests & exports

- New **`AcDbFormatter.spec.ts`** (~200 lines) covering lengths, points, angles, **UNITMODE**, **MEASUREMENT**, and **ANGBASE**/**ANGDIR**.
- Export `AcDbFormatter` and `AcDbFormatterOptions` from `misc/index`.

## Usage

```typescript
const db = new AcDbDatabase();
db.lunits = AcDbLinearUnits.Decimal;
db.luprec = 2;

db.formatter.formatLength(12.3456); // "12.35"
db.formatter.formatLength(12.3456, { showUnits: true }); // "12.35 mm"
db.formatter.formatPoint3d(point);
db.formatter.formatAngle(angleRadians, { showUnits: true }); // "45°"