### PR TITLE
feat: add AcDbCurve::getOffsetCurves and planar polyline offset (Clipper2)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   verbose: true,
   preset: "ts-jest",
   testEnvironment: "node",
+  setupFiles: ["<rootDir>/packages/geometry-engine/__tests__/setupClipper2Mock.ts"],
   moduleNameMapper: {
     "^@mlightcad/common$": "<rootDir>/packages/common/src/index.ts",
     "^@mlightcad/geometry-engine$": "<rootDir>/packages/geometry-engine/src/index.ts",
@@ -15,6 +16,7 @@ const config: Config = {
   },
   testPathIgnorePatterns: [
     "packages/dxf-json/",
+    "setupClipper2Mock",
   ]
 }
 

--- a/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
@@ -1,7 +1,7 @@
 import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../src/base'
-import { AcDb2dPolyline, AcDbPoly2dType } from '../src/entity'
+import { AcDb2dPolyline, AcDbPoly2dType, AcDbPolyline } from '../src/entity'
 import { AcDbOsnapMode } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 import {
@@ -266,5 +266,34 @@ describe('AcDb2dPolyline', () => {
     expect(out).toContain('\n100\nAcDb2dVertex\n')
     expect(out).toContain('\n42\n0.5\n')
     expect(out).toContain('\n30\n3\n')
+  })
+
+  it('offsets a simple 2d polyline path', () => {
+    const poly = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0)],
+      0,
+      false
+    )
+    const [result] = poly.getOffsetCurves(1) as AcDbPolyline[]
+    expect(result.numberOfVertices).toBeGreaterThanOrEqual(2)
+  })
+
+  it('offsets a 2d polyline path that contains bulge arcs', () => {
+    const poly = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [new AcGePoint3d(0, 0, 0), new AcGePoint3d(10, 0, 0)],
+      0,
+      false,
+      0,
+      0,
+      [1, 0]
+    )
+    const [result] = poly.getOffsetCurves(1) as AcDbPolyline[]
+    let minY = Infinity
+    for (let i = 0; i < result.numberOfVertices; i++) {
+      minY = Math.min(minY, result.getPoint2dAt(i).y)
+    }
+    expect(minY).toBeLessThan(-5)
   })
 })

--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -269,4 +269,15 @@ describe('AcDbArc', () => {
     expect(out).toContain('51\n90')
     expect(out).toContain('230\n-1')
   })
+
+  it('increases radius when offsetting outward', () => {
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 5, 0, Math.PI)
+    const [result] = arc.getOffsetCurves(2) as AcDbArc[]
+    expect(result.radius).toBeCloseTo(7)
+  })
+
+  it('returns empty array when inward offset collapses radius', () => {
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 2, 0, Math.PI)
+    expect(arc.getOffsetCurves(-3)).toEqual([])
+  })
 })

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -252,4 +252,9 @@ describe('AcDbCircle', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbCircle(new AcGePoint3d(), 1))
   })
+
+  it('increases radius when offsetting outward', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 5)
+    expect((circle.getOffsetCurves(3)[0] as AcDbCircle).radius).toBeCloseTo(8)
+  })
 })

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -294,4 +294,19 @@ describe('AcDbEllipse', () => {
     expect(dxf).toContain('41\n0.25')
     expect(dxf).toContain('42\n1.5')
   })
+
+  it('increases both radii when offsetting outward', () => {
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      new AcGeVector3d(0, 0, 1),
+      new AcGeVector3d(1, 0, 0),
+      10,
+      5,
+      0,
+      Math.PI * 2
+    )
+    const [result] = ellipse.getOffsetCurves(2) as AcDbEllipse[]
+    expect(result.majorAxisRadius).toBeCloseTo(12)
+    expect(result.minorAxisRadius).toBeCloseTo(7)
+  })
 })

--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -2,7 +2,11 @@ import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbLeader, AcDbLeaderAnnotationType } from '../src/entity'
+import {
+  AcDbLeader,
+  AcDbLeaderAnnotationType,
+  AcDbPolyline
+} from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const createWorkingDb = () => {
@@ -185,5 +189,14 @@ describe('AcDbLeader', () => {
 
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbLeader())
+  })
+
+  it('offsets straight leader vertices as a polyline path', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    const [result] = leader.getOffsetCurves(2) as AcDbPolyline[]
+    expect(result.numberOfVertices).toBeGreaterThanOrEqual(2)
   })
 })

--- a/packages/data-model/__tests__/AcDbLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbLine.spec.ts
@@ -235,4 +235,40 @@ describe('AcDbLine', () => {
       () => new AcDbLine(new AcGePoint3d(), new AcGePoint3d(1, 1, 0))
     )
   })
+
+  it('offsets a horizontal line upward by distance 2', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    const [result] = line.getOffsetCurves(2) as AcDbLine[]
+    expect(result.startPoint.y).toBeCloseTo(2)
+    expect(result.endPoint.y).toBeCloseTo(2)
+  })
+
+  it('offsets a horizontal line downward with negative distance', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    const [result] = line.getOffsetCurves(-2) as AcDbLine[]
+    expect(result.startPoint.y).toBeCloseTo(-2)
+    expect(result.endPoint.y).toBeCloseTo(-2)
+  })
+
+  it('returns 1 for point above a horizontal line in getOffsetSideAtPoint', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    expect(line.getOffsetSideAtPoint(new AcGePoint3d(5, 3, 0))).toBe(1)
+  })
+
+  it('returns -1 for point below a horizontal line in getOffsetSideAtPoint', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    expect(line.getOffsetSideAtPoint(new AcGePoint3d(5, -3, 0))).toBe(-1)
+  })
 })

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -375,4 +375,37 @@ describe('AcDbPolyline', () => {
     const dxf = filer.toString()
     expect(getDxfGroupValues(dxf, 70)).toContain('0')
   })
+
+  it('offsets a closed square outward', () => {
+    const poly = new AcDbPolyline()
+    poly.addVertexAt(0, new AcGePoint2d(0, 0))
+    poly.addVertexAt(1, new AcGePoint2d(10, 0))
+    poly.addVertexAt(2, new AcGePoint2d(10, 10))
+    poly.addVertexAt(3, new AcGePoint2d(0, 10))
+    poly.closed = true
+    const [result] = poly.getOffsetCurves(1) as AcDbPolyline[]
+    expect(result.numberOfVertices).toBeGreaterThanOrEqual(4)
+  })
+
+  it('offsets an open polyline with 2 vertices', () => {
+    const poly = new AcDbPolyline()
+    poly.addVertexAt(0, new AcGePoint2d(0, 0))
+    poly.addVertexAt(1, new AcGePoint2d(10, 0))
+    const [result] = poly.getOffsetCurves(2) as AcDbPolyline[]
+    expect(result.numberOfVertices).toBe(2)
+    expect(result.getPoint2dAt(0).y).toBeCloseTo(2)
+    expect(result.getPoint2dAt(1).y).toBeCloseTo(2)
+  })
+
+  it('offsets an open polyline with a bulge arc segment', () => {
+    const poly = new AcDbPolyline()
+    poly.addVertexAt(0, new AcGePoint2d(0, 0), 1)
+    poly.addVertexAt(1, new AcGePoint2d(10, 0))
+    const [result] = poly.getOffsetCurves(1) as AcDbPolyline[]
+    let minY = Infinity
+    for (let i = 0; i < result.numberOfVertices; i++) {
+      minY = Math.min(minY, result.getPoint2dAt(i).y)
+    }
+    expect(minY).toBeLessThan(-5)
+  })
 })

--- a/packages/data-model/__tests__/AcDbRay.spec.ts
+++ b/packages/data-model/__tests__/AcDbRay.spec.ts
@@ -180,4 +180,13 @@ describe('AcDbRay', () => {
     createWorkingDb()
     expectDetachedClone(() => new AcDbRay())
   })
+
+  it('offsets base point perpendicular to direction', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(0, 0, 0)
+    ray.unitDir = new AcGeVector3d(1, 0, 0)
+    const [result] = ray.getOffsetCurves(3) as AcDbRay[]
+    expect(result.basePoint.y).toBeCloseTo(3)
+    expect(result.unitDir.x).toBeCloseTo(1)
+  })
 })

--- a/packages/data-model/__tests__/AcDbSpline.spec.ts
+++ b/packages/data-model/__tests__/AcDbSpline.spec.ts
@@ -226,4 +226,17 @@ describe('AcDbSpline', () => {
         )
     )
   })
+
+  it('offsets a control-point spline as a sampled polyline', () => {
+    const spline = new AcDbSpline(
+      [
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(1, 1, 0),
+        new AcGePoint3d(2, -1, 0),
+        new AcGePoint3d(3, 0, 0)
+      ],
+      [0, 0, 0, 0, 1, 1, 1, 1]
+    )
+    expect(spline.getOffsetCurves(1).length).toBeGreaterThan(0)
+  })
 })

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -1,6 +1,7 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
@@ -12,6 +13,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { AcDbPolyline } from './AcDbPolyline'
 
 /**
  * Represents the curve/spline-fit type for one 2d polyline.
@@ -451,5 +453,55 @@ export class AcDb2dPolyline extends AcDbCurve {
     filer.writeDouble(20, 0)
     filer.writeDouble(30, this.elevation)
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Approximates the legacy 2D polyline in the XY plane, offsets that path, and
+   * returns a single {@link AcDbPolyline}. Elevation is not preserved on the result.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Projects the entity to a sampled 2D path and delegates the side test to a
+   * temporary {@link AcDbPolyline}.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectPath2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, this.closed).getOffsetSideAtPoint(
+      point
+    )
+  }
+
+  /**
+   * Builds the offset result as a lightweight {@link AcDbPolyline}.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline, or `null` when the sampled path is too short or offset fails
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    const results = this._geo.offset(offsetDist)
+    if (results.length === 0) return null
+    return AcDbPolyline.fromGePolyline(results[0])
+  }
+
+  /**
+   * Samples the underlying {@link AcGePolyline2d} into a dense 2D path for offsetting.
+   *
+   * Sample count scales with vertex count so curved or fitted segments are represented
+   * adequately in the planar approximation.
+   *
+   * @returns XY points along the polyline geometry
+   */
+  private collectPath2d(): AcGePoint2d[] {
+    const sampleCount = Math.max(32, this.numberOfVertices * 4)
+    return this._geo.getPoints(sampleCount)
   }
 }

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -1,6 +1,7 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
@@ -12,6 +13,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { AcDbPolyline } from './AcDbPolyline'
 
 /**
  * Represents the spline-fit type for this 3D polyline.
@@ -359,5 +361,105 @@ export class AcDb3dPolyline extends AcDbCurve {
     filer.writeInt16(66, this.numberOfVertices > 0 ? 1 : 0)
     filer.writeInt16(70, flag)
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Offsets the XY projection of the 3D path, then restores elevation on each result
+   * vertex by interpolating Z from the original polyline segments.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Uses the sampled 2D projection of this polyline for the side test.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectPath2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, this.closed).getOffsetSideAtPoint(
+      point
+    )
+  }
+
+  /**
+   * Offsets in XY and lifts vertices back to 3D with {@link interpolateZ}.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns A new 3D polyline with the same spline-fit type and closed flag, or `null`
+   * when offsetting fails
+   */
+  private createOffsetCurve(offsetDist: number): AcDb3dPolyline | null {
+    const results = this._geo.offset(offsetDist)
+    if (results.length === 0) return null
+
+    const offsetPolyline = results[0]
+    const vertices: AcGePoint3dLike[] = []
+    for (let i = 0; i < offsetPolyline.numberOfVertices; i++) {
+      const point2d = offsetPolyline.getPointAt(i)
+      vertices.push(
+        new AcGePoint3d(
+          point2d.x,
+          point2d.y,
+          this.interpolateZ(point2d.x, point2d.y)
+        )
+      )
+    }
+    return new AcDb3dPolyline(this.polyType, vertices, this.closed)
+  }
+
+  /**
+   * Samples the underlying geometry into a 2D path used for planar offset.
+   *
+   * @returns XY points along the 3D polyline projection
+   */
+  private collectPath2d(): AcGePoint2d[] {
+    const sampleCount = Math.max(32, this.numberOfVertices * 4)
+    return this._geo.getPoints(sampleCount)
+  }
+
+  /**
+   * Estimates the Z coordinate at a planar point by projecting onto the original segments.
+   *
+   * For each segment (respecting {@link closed}), finds the closest point in XY and
+   * linearly interpolates Z between the segment endpoints. Used when promoting a 2D
+   * offset polyline back to {@link AcDb3dPolyline}.
+   *
+   * @param x - X coordinate in WCS
+   * @param y - Y coordinate in WCS
+   * @returns Interpolated elevation, or `0` when the polyline has no vertices
+   */
+  private interpolateZ(x: number, y: number): number {
+    const count = this.numberOfVertices
+    if (count <= 0) return 0
+
+    let bestDist = Infinity
+    let bestZ = this.getPointAt(0).z
+    const segCount = this.closed ? count : count - 1
+    for (let i = 0; i < segCount; i++) {
+      const a = this.getPointAt(i)
+      const b = this.getPointAt((i + 1) % count)
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const len2 = dx * dx + dy * dy
+      if (len2 === 0) continue
+      const t = Math.max(
+        0,
+        Math.min(1, ((x - a.x) * dx + (y - a.y) * dy) / len2)
+      )
+      const px = a.x + dx * t
+      const py = a.y + dy * t
+      const dist = (x - px) ** 2 + (y - py) ** 2
+      if (dist < bestDist) {
+        bestDist = dist
+        bestZ = a.z + (b.z - a.z) * t
+      }
+    }
+    return bestZ
   }
 }

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -589,4 +589,27 @@ export class AcDbArc extends AcDbCurve {
     filer.writeVector3d(210, this.normal)
     return this
   }
+
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const c = this.center
+    const r = this.radius
+    return Math.sqrt((point.x - c.x) ** 2 + (point.y - c.y) ** 2) >= r ? 1 : -1
+  }
+
+  private createOffsetCurve(offsetDist: number): AcDbArc | null {
+    const geo = this._geo.offset(offsetDist)
+    if (!geo) return null
+    return new AcDbArc(
+      geo.center,
+      geo.radius,
+      geo.startAngle,
+      geo.endAngle,
+      geo.normal
+    )
+  }
 }

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -426,4 +426,21 @@ export class AcDbCircle extends AcDbCurve {
     filer.writeVector3d(210, this.normal)
     return this
   }
+
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const c = this.center
+    const r = this.radius
+    return Math.sqrt((point.x - c.x) ** 2 + (point.y - c.y) ** 2) >= r ? 1 : -1
+  }
+
+  private createOffsetCurve(offsetDist: number): AcDbCircle | null {
+    const geo = this._geo.offset(offsetDist)
+    if (!geo) return null
+    return new AcDbCircle(geo.center, geo.radius, geo.normal)
+  }
 }

--- a/packages/data-model/src/entity/AcDbCurve.ts
+++ b/packages/data-model/src/entity/AcDbCurve.ts
@@ -1,3 +1,5 @@
+import { AcGePoint3dLike } from '@mlightcad/geometry-engine'
+
 import { AcDbEntity } from './AcDbEntity'
 
 /**
@@ -40,4 +42,26 @@ export abstract class AcDbCurve extends AcDbEntity {
    * ```
    */
   abstract get closed(): boolean
+
+  /**
+   * Creates offset curves at the given signed distance, similar to ObjectARX
+   * `AcDbCurve::getOffsetCurves`.
+   *
+   * The sign of `offsetDist` determines the offset side relative to the curve
+   * direction in the curve plane. Returns an empty array when offsetting fails.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset curve entities (equivalent to `AcDbVoidPtrArray`)
+   */
+  abstract getOffsetCurves(offsetDist: number): AcDbCurve[]
+
+  /**
+   * Determines which side of this curve a point lies on for offset operations.
+   *
+   * @param point - Test point in WCS
+   * @returns `1` for the positive offset side, `-1` for the negative side
+   */
+  getOffsetSideAtPoint(_point: AcGePoint3dLike): 1 | -1 {
+    return 1
+  }
 }

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -151,6 +151,10 @@ export class AcDbEllipse extends AcDbCurve {
    * console.log(`Major radius: ${majorRadius}`);
    * ```
    */
+  get majorAxis(): AcGeVector3dLike {
+    return this._geo.majorAxis
+  }
+
   get majorAxisRadius(): number {
     return this._geo.majorAxisRadius
   }
@@ -549,5 +553,41 @@ export class AcDbEllipse extends AcDbCurve {
     filer.writeDouble(41, this.startAngle)
     filer.writeDouble(42, this.endAngle)
     return this
+  }
+
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const c = this.center
+    const dx = point.x - c.x
+    const dy = point.y - c.y
+    const major = this.majorAxis
+    const majorLen = Math.hypot(major.x, major.y) || 1
+    const minorLen =
+      (this.minorAxisRadius / this.majorAxisRadius) * majorLen || 1
+    const ux = major.x / majorLen
+    const uy = major.y / majorLen
+    const vx = -uy
+    const vy = ux
+    const u = dx * ux + dy * uy
+    const v = dx * vx + dy * vy
+    return (u / majorLen) ** 2 + (v / minorLen) ** 2 >= 1 ? 1 : -1
+  }
+
+  private createOffsetCurve(offsetDist: number): AcDbEllipse | null {
+    const geo = this._geo.offset(offsetDist)
+    if (!geo) return null
+    return new AcDbEllipse(
+      geo.center,
+      geo.normal,
+      geo.majorAxis,
+      geo.majorAxisRadius,
+      geo.minorAxisRadius,
+      geo.startAngle,
+      geo.endAngle
+    )
   }
 }

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -1,6 +1,7 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeSpline3d,
@@ -11,6 +12,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
 import { AcDbCurve } from './AcDbCurve'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Defines the annotation type for leader entities.
@@ -490,6 +492,54 @@ export class AcDbLeader extends AcDbCurve {
       filer.writeVector3d(213, this._offsetFromAnnotation)
     }
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Offsets the leader's vertex path in the XY plane and returns an {@link AcDbPolyline}.
+   * Splined leaders are sampled before offsetting; the leader is always treated as an
+   * open path.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Side test follows the straight or sampled spline path as an open polyline.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectPath2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, false).getOffsetSideAtPoint(point)
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline along the leader path, or `null` when offset fails
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    return offsetVertexPathAsPolyline(this.collectPath2d(), false, offsetDist)
+  }
+
+  /**
+   * Flattens the leader geometry to a 2D vertex list for offset operations.
+   *
+   * Uses 64 samples from the fit spline when {@link isSplined} is true; otherwise
+   * returns the stored WCS vertices projected to XY.
+   *
+   * @returns Leader path in the XY plane
+   */
+  private collectPath2d(): AcGePoint2d[] {
+    if (this.isSplined && this.splineGeo) {
+      return this.splineGeo
+        .getPoints(64)
+        .map(point => new AcGePoint2d(point.x, point.y))
+    }
+    return this._vertices.map(vertex => new AcGePoint2d(vertex.x, vertex.y))
   }
 
   private transformVector(vector: AcGeVector3d, matrix: AcGeMatrix3d) {

--- a/packages/data-model/src/entity/AcDbLine.ts
+++ b/packages/data-model/src/entity/AcDbLine.ts
@@ -391,4 +391,17 @@ export class AcDbLine extends AcDbCurve {
     filer.writePoint3d(11, this.endPoint)
     return this
   }
+
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const geo = this._geo.offset(offsetDist)
+    return [new AcDbLine(geo.startPoint, geo.endPoint)]
+  }
+
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const s = this.startPoint
+    const e = this.endPoint
+    return (e.x - s.x) * (point.y - s.y) - (e.y - s.y) * (point.x - s.x) >= 0
+      ? 1
+      : -1
+  }
 }

--- a/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
@@ -1,6 +1,7 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -10,6 +11,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Represents a polyface mesh vertex in AutoCAD.
@@ -355,5 +357,67 @@ export class AcDbPolyFaceMesh extends AcDbCurve {
     filer.writeObjectId(330, this.objectId)
     filer.writeSubclassMarker('AcDbEntity')
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Offsets the XY boundary of the largest face in the mesh as a closed
+   * {@link AcDbPolyline}. When no face records exist, falls back to all mesh vertices
+   * in storage order.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Side test uses the same largest-face boundary as {@link getOffsetCurves}.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectLargestFaceBoundary2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, true).getOffsetSideAtPoint(point)
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline around the dominant face boundary, or `null` on failure
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    return offsetVertexPathAsPolyline(
+      this.collectLargestFaceBoundary2d(),
+      true,
+      offsetDist
+    )
+  }
+
+  /**
+   * Selects the face with the most referenced vertices and returns its XY outline.
+   *
+   * Face vertex indices follow mesh face records; negative indices are ignored. If no
+   * suitable face is found, every mesh vertex position is projected to XY in index order.
+   *
+   * @returns Closed or open 2D loop used for offset approximation
+   */
+  private collectLargestFaceBoundary2d(): AcGePoint2d[] {
+    let bestIndices: number[] = []
+    for (const face of this._faces) {
+      const indices = face.vertexIndices.filter(index => index >= 0)
+      if (indices.length > bestIndices.length) {
+        bestIndices = indices
+      }
+    }
+    if (bestIndices.length < 2) {
+      return this._vertices.map(
+        vertex => new AcGePoint2d(vertex.position.x, vertex.position.y)
+      )
+    }
+    return bestIndices.map(index => {
+      const position = this.getVertexAt(index).position
+      return new AcGePoint2d(position.x, position.y)
+    })
   }
 }

--- a/packages/data-model/src/entity/AcDbPolygonMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolygonMesh.ts
@@ -1,6 +1,7 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
@@ -10,6 +11,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Represents a polygon mesh vertex in AutoCAD.
@@ -392,5 +394,88 @@ export class AcDbPolygonMesh extends AcDbCurve {
     filer.writeObjectId(330, this.objectId)
     filer.writeSubclassMarker('AcDbEntity')
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Offsets the mesh perimeter in XY: a single row/column for degenerate meshes, or a
+   * counter-clockwise walk around the M×N grid when both dimensions exceed one.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Uses the same perimeter path and closed flag as {@link getOffsetCurves}.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectBoundary2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(
+      path,
+      this.isBoundaryClosed()
+    ).getOffsetSideAtPoint(point)
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline along the mesh boundary, or `null` on failure
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    return offsetVertexPathAsPolyline(
+      this.collectBoundary2d(),
+      this.isBoundaryClosed(),
+      offsetDist
+    )
+  }
+
+  /**
+   * Whether the collected perimeter should be offset as a closed polygon.
+   *
+   * Requires both M and N closure flags and at least two vertices along each direction.
+   */
+  private isBoundaryClosed(): boolean {
+    return (
+      this._closedM && this._closedN && this._mCount > 1 && this._nCount > 1
+    )
+  }
+
+  /**
+   * Builds the XY perimeter of the polygon mesh for offset operations.
+   *
+   * For `M === 1` or `N === 1`, returns the sole row or column. Otherwise traces the
+   * outer ring: first column up, last row across, last column down, first row back.
+   *
+   * @returns Boundary vertices in traversal order
+   */
+  private collectBoundary2d(): AcGePoint2d[] {
+    const m = this._mCount
+    const n = this._nCount
+    if (m < 1 || n < 1) return []
+
+    const points: AcGePoint2d[] = []
+    const push = (mi: number, ni: number) => {
+      const position = this.getVertexAtMN(mi, ni).position
+      points.push(new AcGePoint2d(position.x, position.y))
+    }
+
+    if (m === 1) {
+      for (let j = 0; j < n; j++) push(0, j)
+      return points
+    }
+    if (n === 1) {
+      for (let i = 0; i < m; i++) push(i, 0)
+      return points
+    }
+
+    for (let j = 0; j < n; j++) push(0, j)
+    for (let i = 1; i < m; i++) push(i, n - 1)
+    for (let j = n - 2; j >= 0; j--) push(m - 1, j)
+    for (let i = m - 2; i >= 1; i--) push(i, 0)
+    return points
   }
 }

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -7,7 +7,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
-  AcGePolyline2dVertex
+  AcGePolyline2dVertex,
+  offsetVertexPath
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -600,6 +601,98 @@ export class AcDbPolyline extends AcDbCurve {
       new AcGePoint2d(endVertex.x, endVertex.y)
     ]
   }
+
+  /**
+   * Constructs a temporary {@link AcDbPolyline} from a planar vertex list.
+   *
+   * Other curve types use this factory when they need polyline offset or side-test
+   * behavior without persisting an intermediate entity in the database. Vertices are
+   * added in list order with zero bulge; arc segments are not represented.
+   *
+   * @param points - 2D vertices in WCS (XY), at least one point
+   * @param closed - Whether the path forms a closed loop for offset and side tests
+   * @returns A new lightweight polyline with the given topology
+   */
+  static from2dPoints(points: AcGePoint2d[], closed: boolean): AcDbPolyline {
+    const polyline = new AcDbPolyline()
+    points.forEach((point, index) => polyline.addVertexAt(index, point))
+    polyline.closed = closed
+    return polyline
+  }
+
+  /**
+   * Creates a polyline entity from {@link AcGePolyline2d} geometry.
+   *
+   * @param geo - Source polyline geometry
+   * @returns Polyline entity with matching vertices and closed flag
+   */
+  static fromGePolyline(geo: AcGePolyline2d): AcDbPolyline {
+    const polyline = new AcDbPolyline()
+    geo.vertices.forEach((vertex, index) => {
+      polyline.addVertexAt(
+        index,
+        new AcGePoint2d(vertex.x, vertex.y),
+        vertex.bulge ?? 0
+      )
+    })
+    polyline.closed = geo.closed
+    return polyline
+  }
+
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const n = this.numberOfVertices
+    let bestDist = Infinity
+    let bestSide: 1 | -1 = 1
+    const segCount = this.closed ? n : n - 1
+    for (let i = 0; i < segCount; i++) {
+      const a = this.getPoint2dAt(i)
+      const b = this.getPoint2dAt((i + 1) % n)
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const len2 = dx * dx + dy * dy
+      if (len2 === 0) continue
+      const t = Math.max(
+        0,
+        Math.min(1, ((point.x - a.x) * dx + (point.y - a.y) * dy) / len2)
+      )
+      const d = (point.x - a.x - t * dx) ** 2 + (point.y - a.y - t * dy) ** 2
+      if (d < bestDist) {
+        bestDist = d
+        bestSide = dx * (point.y - a.y) - dy * (point.x - a.x) >= 0 ? 1 : -1
+      }
+    }
+    return bestSide
+  }
+
+  private createOffsetCurve(offsetDist: number): AcDbPolyline | null {
+    const results = this._geo.offset(offsetDist)
+    if (results.length === 0) return null
+    return AcDbPolyline.fromGePolyline(results[0])
+  }
+}
+
+/**
+ * Offsets a planar vertex path using {@link offsetVertexPath} and wraps the
+ * result as an {@link AcDbPolyline}.
+ *
+ * @param points - Sampled or vertex-derived 2D path in WCS (XY)
+ * @param closed - Whether the path is treated as a closed polygon for offsetting
+ * @param offsetDist - Signed offset distance in drawing units (see {@link AcDbCurve#getOffsetCurves})
+ * @returns The first offset polyline, or `null` when the path has fewer than two points
+ * or offsetting fails
+ */
+export function offsetVertexPathAsPolyline(
+  points: AcGePoint2d[],
+  closed: boolean,
+  offsetDist: number
+): AcDbPolyline | null {
+  const geo = offsetVertexPath(points, closed, offsetDist)
+  return geo ? AcDbPolyline.fromGePolyline(geo) : null
 }
 
 const WIDTH_EPSILON = 1e-6

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -3,7 +3,8 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGeVector3d
+  AcGeVector3d,
+  offsetPointByDirectionInXY
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -339,5 +340,50 @@ export class AcDbRay extends AcDbCurve {
     filer.writePoint3d(10, this.basePoint)
     filer.writeVector3d(11, this.unitDir)
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Returns a parallel ray: the base point shifts perpendicular to the XY projection
+   * of {@link unitDir} by `offsetDist`, while direction is unchanged. Fails when the
+   * direction is degenerate in the XY plane.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Uses the 2D cross product of the ray direction with the vector from
+   * {@link basePoint} to `point`, normalized by the XY length of the direction.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const bp = this.basePoint
+    const dir = this.unitDir
+    const len = Math.hypot(dir.x, dir.y)
+    if (len <= 1e-9) return 1
+    return (dir.x * (point.y - bp.y) - dir.y * (point.x - bp.x)) / len >= 0
+      ? 1
+      : -1
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units (perpendicular in XY)
+   * @returns Parallel ray, or `null` when {@link unitDir} has negligible XY component
+   */
+  private createOffsetCurve(offsetDist: number): AcDbRay | null {
+    const offsetPoint = offsetPointByDirectionInXY(
+      this.basePoint,
+      this.unitDir,
+      offsetDist
+    )
+    if (!offsetPoint) return null
+    const ray = new AcDbRay()
+    ray.basePoint = offsetPoint
+    ray.unitDir = this.unitDir.clone()
+    return ray
   }
 }

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -2,6 +2,7 @@ import { AcCmErrors } from '@mlightcad/common'
 import {
   AcGeKnotParameterizationType,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3dLike,
   AcGeSpline3d
 } from '@mlightcad/geometry-engine'
@@ -10,6 +11,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Represents a spline entity in AutoCAD.
@@ -336,5 +338,52 @@ export class AcDbSpline extends AcDbCurve {
       filer.writePoint3d(11, point)
     }
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Approximates the spline with a sampled polyline in XY, then offsets that path.
+   * The result is an {@link AcDbPolyline}, not a spline entity.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Evaluates side relative to the sampled 2D approximation of the spline.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectPath2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, this.closed).getOffsetSideAtPoint(
+      point
+    )
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline approximating this spline, or `null` on failure
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    return offsetVertexPathAsPolyline(
+      this.collectPath2d(),
+      this.closed,
+      offsetDist
+    )
+  }
+
+  /**
+   * Samples {@link AcGeSpline3d} into a fixed-density 2D path for planar offset.
+   *
+   * @returns 64 XY points along the spline
+   */
+  private collectPath2d(): AcGePoint2d[] {
+    return this._geo
+      .getPoints(64)
+      .map(point => new AcGePoint2d(point.x, point.y))
   }
 }

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -2,6 +2,7 @@ import {
   AcGeArea2d,
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
@@ -12,6 +13,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Represents a trace entity in AutoCAD.
@@ -311,5 +313,48 @@ export class AcDbTrace extends AcDbCurve {
     filer.writePoint3d(12, this.getPointAt(2))
     filer.writePoint3d(13, this.getPointAt(3))
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Offsets the quadrilateral boundary (four corners in vertex order) as a closed
+   * {@link AcDbPolyline} in the XY plane.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Treats the trace outline as a closed polygon in XY.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const path = this.collectBoundary2d()
+    if (path.length < 2) return 1
+    return AcDbPolyline.from2dPoints(path, true).getOffsetSideAtPoint(point)
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polyline around the trace boundary, or `null` on failure
+   */
+  private createOffsetCurve(offsetDist: number): AcDbCurve | null {
+    return offsetVertexPathAsPolyline(
+      this.collectBoundary2d(),
+      true,
+      offsetDist
+    )
+  }
+
+  /**
+   * Projects the four trace corners to a closed 2D loop (codes 10–13 order).
+   *
+   * @returns XY boundary vertices
+   */
+  private collectBoundary2d(): AcGePoint2d[] {
+    return this._vertices.map(vertex => new AcGePoint2d(vertex.x, vertex.y))
   }
 }

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -2,7 +2,9 @@ import {
   AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
-  AcGeVector3d
+  AcGePoint3dLike,
+  AcGeVector3d,
+  offsetPointByDirectionInXY
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -313,5 +315,49 @@ export class AcDbXline extends AcDbCurve {
     filer.writePoint3d(10, this.basePoint)
     filer.writeVector3d(11, this.unitDir)
     return this
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetCurves}
+   *
+   * Returns a parallel construction line: {@link basePoint} moves perpendicular to the
+   * XY projection of {@link unitDir} by `offsetDist`; direction is unchanged. Returns an
+   * empty array when the XY direction is degenerate.
+   */
+  override getOffsetCurves(offsetDist: number): AcDbCurve[] {
+    const curve = this.createOffsetCurve(offsetDist)
+    return curve ? [curve] : []
+  }
+
+  /**
+   * {@inheritDoc AcDbCurve.getOffsetSideAtPoint}
+   *
+   * Same planar left/right test as {@link AcDbRay.getOffsetSideAtPoint}.
+   */
+  override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
+    const bp = this.basePoint
+    const dir = this.unitDir
+    const len = Math.hypot(dir.x, dir.y)
+    if (len <= 1e-9) return 1
+    return (dir.x * (point.y - bp.y) - dir.y * (point.x - bp.x)) / len >= 0
+      ? 1
+      : -1
+  }
+
+  /**
+   * @param offsetDist - Signed offset distance in drawing units (perpendicular in XY)
+   * @returns Parallel xline, or `null` when {@link unitDir} has negligible XY component
+   */
+  private createOffsetCurve(offsetDist: number): AcDbXline | null {
+    const offsetPoint = offsetPointByDirectionInXY(
+      this.basePoint,
+      this.unitDir,
+      offsetDist
+    )
+    if (!offsetPoint) return null
+    const xline = new AcDbXline()
+    xline.basePoint = offsetPoint
+    xline.unitDir = this.unitDir.clone()
+    return xline
   }
 }

--- a/packages/data-model/src/entity/index.ts
+++ b/packages/data-model/src/entity/index.ts
@@ -77,7 +77,7 @@ export {
   AcDbTextVerticalMode
 } from './AcDbText'
 export { AcDbTrace } from './AcDbTrace'
-export { AcDbPolyline } from './AcDbPolyline'
+export { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 export { AcDbPoint } from './AcDbPoint'
 export {
   AcDbRasterImage,

--- a/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
@@ -1,4 +1,4 @@
-import { AcGeMatrix2d, AcGePolyline2d } from '../src'
+import { AcGeCircArc2d, AcGeMatrix2d, AcGePolyline2d } from '../src'
 
 describe('Test AcGePolyline2d', () => {
   it('computes length correctly', () => {
@@ -84,5 +84,66 @@ describe('Test AcGePolyline2d', () => {
 
     cloned.vertices[0].x = 9
     expect(polyline.vertices[0].x).toBe(0)
+  })
+
+  it('offsets an open semicircle bulge segment outward', () => {
+    const polyline = new AcGePolyline2d()
+    polyline.addVertexAt(0, { x: 0, y: 0, bulge: 1 })
+    polyline.addVertexAt(1, { x: 10, y: 0 })
+    const [result] = polyline.offset(1)
+    const minY = Math.min(...result.vertices.map(vertex => vertex.y))
+    expect(minY).toBeCloseTo(-6, 0)
+  })
+
+  it('offsets a mixed line-arc polyline to the same side of the path', () => {
+    const polyline = new AcGePolyline2d()
+    polyline.addVertexAt(0, { x: 0, y: 0 })
+    polyline.addVertexAt(1, { x: 80, y: 15, bulge: 0.6 })
+    polyline.addVertexAt(2, { x: 160, y: 15, bulge: -0.6 })
+    polyline.addVertexAt(3, { x: 240, y: 5 })
+
+    const [result] = polyline.offset(2)
+    expect(result.numberOfVertices).toBeGreaterThan(4)
+
+    const lineEndOffset = {
+      x: 80 + (-15 / Math.hypot(80, 15)) * 2,
+      y: 15 + (80 / Math.hypot(80, 15)) * 2
+    }
+    const junction = result.vertices.find(
+      vertex =>
+        Math.hypot(vertex.x - lineEndOffset.x, vertex.y - lineEndOffset.y) < 3
+    )
+    expect(junction).toBeDefined()
+    expect(junction!.y).toBeGreaterThan(15)
+
+    const arc = new AcGeCircArc2d({ x: 80, y: 15 }, { x: 160, y: 15 }, 0.6)
+    const offsetArc = new AcGeCircArc2d(
+      arc.center,
+      arc.radius - 2,
+      arc.startAngle,
+      arc.endAngle,
+      arc.clockwise
+    )
+    const distToLineEnd = Math.hypot(
+      junction!.x - lineEndOffset.x,
+      junction!.y - lineEndOffset.y
+    )
+    const distToArcStart = Math.hypot(
+      junction!.x - offsetArc.startPoint.x,
+      junction!.y - offsetArc.startPoint.y
+    )
+    expect(distToLineEnd).toBeLessThan(3)
+    expect(distToArcStart).toBeLessThan(3)
+  })
+
+  it('offsets a closed polyline that contains a bulge arc segment', () => {
+    const polyline = new AcGePolyline2d()
+    polyline.addVertexAt(0, { x: 0, y: 0 })
+    polyline.addVertexAt(1, { x: 10, y: 0, bulge: 1 })
+    polyline.addVertexAt(2, { x: 10, y: 10 })
+    polyline.addVertexAt(3, { x: 0, y: 10 })
+    polyline.closed = true
+    const [result] = polyline.offset(1)
+    expect(result.numberOfVertices).toBeGreaterThanOrEqual(4)
   })
 })

--- a/packages/geometry-engine/__tests__/setupClipper2Mock.ts
+++ b/packages/geometry-engine/__tests__/setupClipper2Mock.ts
@@ -1,0 +1,9 @@
+jest.mock(
+  'clipper2-ts',
+  () => ({
+    EndType: { Polygon: 0, Butt: 1 },
+    JoinType: { Miter: 0 },
+    inflatePaths: (paths: unknown) => paths
+  }),
+  { virtual: true }
+)

--- a/packages/geometry-engine/package.json
+++ b/packages/geometry-engine/package.json
@@ -40,5 +40,8 @@
   },
   "peerDependencies": {
     "@mlightcad/common": "workspace:*"
+  },
+  "dependencies": {
+    "clipper2-ts": "2.0.1-15"
   }
 }

--- a/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
@@ -609,6 +609,25 @@ export class AcGeCircArc3d extends AcGeCurve3d {
     const distance = new AcGeVector3d(this.center).distanceTo(ORIGIN_POINT_3D)
     return new AcGePlane(this.normal, distance)
   }
+
+  /**
+   * Returns a concentric copy with radius adjusted by `offsetDist`.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset arc, or `null` when the resulting radius is not positive
+   */
+  offset(offsetDist: number): AcGeCircArc3d | null {
+    const radius = this.radius + offsetDist
+    if (radius <= 0) return null
+    return new AcGeCircArc3d(
+      this.center,
+      radius,
+      this.startAngle,
+      this.endAngle,
+      this.normal,
+      this.refVec
+    )
+  }
 }
 
 const _vector3 = /*@__PURE__*/ new AcGeVector3d()

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -549,4 +549,25 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
     const distance = new AcGeVector3d(this.center).distanceTo(ORIGIN_POINT_3D)
     return new AcGePlane(this.normal, distance)
   }
+
+  /**
+   * Returns a copy with major and minor radii adjusted by `offsetDist`.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset ellipse arc, or `null` when either radius is not positive
+   */
+  offset(offsetDist: number): AcGeEllipseArc3d | null {
+    const majorAxisRadius = this.majorAxisRadius + offsetDist
+    const minorAxisRadius = this.minorAxisRadius + offsetDist
+    if (majorAxisRadius <= 0 || minorAxisRadius <= 0) return null
+    return new AcGeEllipseArc3d(
+      this.center,
+      this.normal,
+      this.majorAxis,
+      majorAxisRadius,
+      minorAxisRadius,
+      this.startAngle,
+      this.endAngle
+    )
+  }
 }

--- a/packages/geometry-engine/src/geometry/AcGeLine3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeLine3d.ts
@@ -303,6 +303,29 @@ export class AcGeLine3d extends AcGeCurve3d {
   clone() {
     return new AcGeLine3d(this._start.clone(), this._end.clone())
   }
+
+  /**
+   * Returns a parallel copy offset perpendicular to the XY projection of this line.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset line; degenerate XY segments return a clone at the same location
+   */
+  offset(offsetDist: number): AcGeLine3d {
+    const s = this.startPoint
+    const e = this.endPoint
+    const len = Math.hypot(e.x - s.x, e.y - s.y)
+    if (len === 0) return this.clone()
+    const dir = new AcGeVector3d(e.x - s.x, e.y - s.y, 0).normalize()
+    const perp = new AcGeVector3d(-dir.y, dir.x, 0)
+    return new AcGeLine3d(
+      new AcGePoint3d(
+        s.x + perp.x * offsetDist,
+        s.y + perp.y * offsetDist,
+        s.z
+      ),
+      new AcGePoint3d(e.x + perp.x * offsetDist, e.y + perp.y * offsetDist, e.z)
+    )
+  }
 }
 
 const _vector = /*@__PURE__*/ new AcGeVector3d()

--- a/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
@@ -1,6 +1,7 @@
 import { AcGeBox2d, AcGeMatrix2d, AcGePoint2d, AcGePoint3d } from '../math'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGeCurve2d } from './AcGeCurve2d'
+import { offsetAcGePolyline2d } from './AcGePolyline2dOffset'
 
 /**
  * The class represents one vertex of the polyline geometry.
@@ -281,5 +282,15 @@ export class AcGePolyline2d<
       }
     }
     return points
+  }
+
+  /**
+   * Creates offset curves for this polyline in the XY plane.
+   *
+   * @param offsetDist - Signed offset distance in drawing units
+   * @returns Offset polylines; empty when offsetting fails
+   */
+  offset(offsetDist: number): AcGePolyline2d[] {
+    return offsetAcGePolyline2d(this, offsetDist)
   }
 }

--- a/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
@@ -1,0 +1,667 @@
+import {
+  EndType,
+  inflatePaths,
+  JoinType,
+  type Path64,
+  type Paths64
+} from 'clipper2-ts'
+
+import { AcGePoint2d } from '../math/AcGePoint2d'
+import { AcGeMathUtil, TAU } from '../util'
+import { AcGeCircArc2d } from './AcGeCircArc2d'
+import { AcGePolyline2d } from './AcGePolyline2d'
+
+const POLYLINE_OFFSET_CLIPPER_SCALE = 1e6
+const PATH_EPSILON = 1e-9
+
+type PolylineOffsetSegment = {
+  start: AcGePoint2d
+  end: AcGePoint2d
+  dx: number
+  dy: number
+}
+
+type PlanarSegment =
+  | { kind: 'line'; start: AcGePoint2d; end: AcGePoint2d }
+  | { kind: 'arc'; arc: AcGeCircArc2d }
+
+type OffsetSegment =
+  | {
+      kind: 'line'
+      start: AcGePoint2d
+      end: AcGePoint2d
+      dx: number
+      dy: number
+    }
+  | { kind: 'arc'; arc: AcGeCircArc2d }
+
+/**
+ * Creates offset curves for a 2D polyline in the XY plane.
+ *
+ * Arc segments (non-zero bulge) are offset concentrically; straight segments use
+ * parallel offsets. Mixed paths are joined at segment boundaries.
+ *
+ * @param polyline - Source polyline geometry
+ * @param offsetDist - Signed offset distance in drawing units
+ * @returns Offset polylines; empty when offsetting fails
+ */
+export function offsetAcGePolyline2d(
+  polyline: AcGePolyline2d,
+  offsetDist: number
+): AcGePolyline2d[] {
+  if (hasArcSegments(polyline)) {
+    const result = offsetPolylineWithArcSegments(polyline, offsetDist)
+    return result ? [result] : []
+  }
+
+  const source = normalizeVertexPolyline(polyline)
+  const n = source.numberOfVertices
+  if (n < 2) return []
+
+  if (!source.closed) {
+    const result = createOpenPolylineOffset(source, offsetDist)
+    return result ? [result] : []
+  }
+
+  const path: Path64 = []
+  for (let i = 0; i < n; i++) {
+    const pt = source.getPointAt(i)
+    path.push({
+      x: Math.round(pt.x * POLYLINE_OFFSET_CLIPPER_SCALE),
+      y: Math.round(pt.y * POLYLINE_OFFSET_CLIPPER_SCALE)
+    })
+  }
+  const sourcePaths: Paths64 = [path]
+  const paths = inflatePaths(
+    sourcePaths,
+    offsetDist * POLYLINE_OFFSET_CLIPPER_SCALE,
+    JoinType.Miter,
+    EndType.Polygon
+  )
+  if (!paths || paths.length === 0) return []
+
+  const result = new AcGePolyline2d()
+  paths[0].forEach((pt: { x: number; y: number }, i: number) => {
+    result.addVertexAt(i, {
+      x: pt.x / POLYLINE_OFFSET_CLIPPER_SCALE,
+      y: pt.y / POLYLINE_OFFSET_CLIPPER_SCALE
+    })
+  })
+  result.closed = source.closed
+  return [result]
+}
+
+/**
+ * Normalizes a vertex-only polyline path by removing duplicate closure points.
+ */
+export function preparePolylineForOffset(
+  polyline: AcGePolyline2d
+): AcGePolyline2d {
+  return normalizeVertexPolyline(polyline)
+}
+
+function offsetPolylineWithArcSegments(
+  polyline: AcGePolyline2d,
+  offsetDist: number
+): AcGePolyline2d | null {
+  const segments = collectPlanarSegments(polyline)
+  if (segments.length === 0) return null
+
+  const offsetSegments: OffsetSegment[] = []
+  for (const segment of segments) {
+    const offsetSegment = offsetPlanarSegment(segment, offsetDist)
+    if (!offsetSegment) return null
+    offsetSegments.push(offsetSegment)
+  }
+
+  const joinVertices = collectJoinVertices(polyline)
+  const points = buildJoinedOffsetPath(
+    offsetSegments,
+    joinVertices,
+    polyline.closed
+  )
+  if (points.length < 2) return null
+
+  const result = new AcGePolyline2d()
+  points.forEach((point, index) => {
+    result.addVertexAt(index, { x: point.x, y: point.y })
+  })
+  result.closed = polyline.closed
+  return result
+}
+
+function collectPlanarSegments(polyline: AcGePolyline2d): PlanarSegment[] {
+  const segments: PlanarSegment[] = []
+  const count = polyline.numberOfVertices
+  const segmentCount = polyline.closed ? count : count - 1
+
+  for (let i = 0; i < segmentCount; i++) {
+    const start = polyline.vertices[i]
+    const end = polyline.vertices[(i + 1) % count]
+    if (Math.abs(start.bulge ?? 0) > PATH_EPSILON) {
+      segments.push({
+        kind: 'arc',
+        arc: new AcGeCircArc2d(start, end, start.bulge!)
+      })
+    } else {
+      segments.push({
+        kind: 'line',
+        start: new AcGePoint2d(start.x, start.y),
+        end: new AcGePoint2d(end.x, end.y)
+      })
+    }
+  }
+
+  return segments
+}
+
+function collectJoinVertices(polyline: AcGePolyline2d): AcGePoint2d[] {
+  const vertices: AcGePoint2d[] = []
+  for (let i = 0; i < polyline.numberOfVertices; i++) {
+    vertices.push(polyline.getPointAt(i))
+  }
+  return vertices
+}
+
+function offsetPlanarSegment(
+  segment: PlanarSegment,
+  offsetDist: number
+): OffsetSegment | null {
+  if (segment.kind === 'line') {
+    const offsetLine = offsetLineSegment(segment.start, segment.end, offsetDist)
+    if (!offsetLine) return null
+    return { kind: 'line', ...offsetLine }
+  }
+
+  const offsetArc = offsetCircArc2d(
+    segment.arc,
+    segment.arc.startPoint,
+    segment.arc.endPoint,
+    offsetDist
+  )
+  if (!offsetArc) return null
+  return { kind: 'arc', arc: offsetArc }
+}
+
+function offsetCircArc2d(
+  arc: AcGeCircArc2d,
+  start: AcGePoint2d,
+  end: AcGePoint2d,
+  offsetDist: number
+): AcGeCircArc2d | null {
+  const radiusDelta = getArcRadiusDelta(arc, start, end, offsetDist)
+  const radius = arc.radius + radiusDelta
+  if (radius <= PATH_EPSILON) return null
+  return new AcGeCircArc2d(
+    arc.center,
+    radius,
+    arc.startAngle,
+    arc.endAngle,
+    arc.clockwise
+  )
+}
+
+/**
+ * Applies the same left-hand offset rule used for line segments: positive
+ * `offsetDist` shifts the arc to the left of its travel direction.
+ *
+ * Concentric offset direction depends on which side of the chord the center
+ * lies: when the center is on the left, shrink the radius; when on the right,
+ * expand it.
+ */
+function getArcRadiusDelta(
+  arc: AcGeCircArc2d,
+  start: AcGePoint2d,
+  end: AcGePoint2d,
+  offsetDist: number
+): number {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const len = Math.hypot(dx, dy)
+  if (len <= PATH_EPSILON) {
+    return arc.clockwise ? -offsetDist : offsetDist
+  }
+
+  const leftNx = -dy / len
+  const leftNy = dx / len
+  const toCenterX = arc.center.x - (start.x + end.x) / 2
+  const toCenterY = arc.center.y - (start.y + end.y) / 2
+  const centerOnLeft = toCenterX * leftNx + toCenterY * leftNy > 0
+
+  return centerOnLeft ? -offsetDist : offsetDist
+}
+
+function offsetLineSegment(
+  start: AcGePoint2d,
+  end: AcGePoint2d,
+  offsetDist: number
+): { start: AcGePoint2d; end: AcGePoint2d; dx: number; dy: number } | null {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const len = Math.hypot(dx, dy)
+  if (len <= PATH_EPSILON) return null
+
+  const nx = (-dy / len) * offsetDist
+  const ny = (dx / len) * offsetDist
+  return {
+    start: new AcGePoint2d(start.x + nx, start.y + ny),
+    end: new AcGePoint2d(end.x + nx, end.y + ny),
+    dx,
+    dy
+  }
+}
+
+function buildJoinedOffsetPath(
+  offsetSegments: OffsetSegment[],
+  joinVertices: AcGePoint2d[],
+  closed: boolean
+): AcGePoint2d[] {
+  const count = offsetSegments.length
+  if (count === 0) return []
+
+  const junctions = computeJunctionPoints(offsetSegments, joinVertices, closed)
+  const points: AcGePoint2d[] = [junctions[0].clone()]
+
+  for (let i = 0; i < count; i++) {
+    const segment = offsetSegments[i]
+    const endJunction =
+      i === count - 1 && !closed
+        ? getOffsetSegmentEnd(segment)
+        : junctions[(i + 1) % count]
+
+    if (segment.kind === 'arc') {
+      const arcSamples = sampleArcBetweenPoints(
+        segment.arc,
+        junctions[i],
+        endJunction,
+        Math.max(16, 32)
+      )
+      for (let j = 1; j < arcSamples.length; j++) {
+        points.push(arcSamples[j])
+      }
+    } else {
+      points.push(endJunction.clone())
+    }
+  }
+
+  return dedupeConsecutivePoints(points)
+}
+
+function computeJunctionPoints(
+  offsetSegments: OffsetSegment[],
+  joinVertices: AcGePoint2d[],
+  closed: boolean
+): AcGePoint2d[] {
+  const count = offsetSegments.length
+  const junctions: AcGePoint2d[] = []
+
+  for (let i = 0; i < count; i++) {
+    if (i === 0) {
+      junctions.push(
+        closed
+          ? joinOffsetSegments(
+              offsetSegments[count - 1],
+              offsetSegments[0],
+              joinVertices[0]
+            )
+          : getOffsetSegmentStart(offsetSegments[0])
+      )
+    } else {
+      junctions.push(
+        joinOffsetSegments(
+          offsetSegments[i - 1],
+          offsetSegments[i],
+          joinVertices[i]
+        )
+      )
+    }
+  }
+
+  return junctions
+}
+
+function sampleArcBetweenPoints(
+  arc: AcGeCircArc2d,
+  start: AcGePoint2d,
+  end: AcGePoint2d,
+  numPoints: number
+): AcGePoint2d[] {
+  const startOnArc = arc.nearestPoint(start)
+  const endOnArc = arc.nearestPoint(end)
+  const startInternal = internalAngleAtPoint(arc, startOnArc)
+  const endInternal = internalAngleAtPoint(arc, endOnArc)
+  const sweep = sweepAlongArc(arc, startInternal, endInternal)
+  const points: AcGePoint2d[] = []
+
+  for (let i = 0; i <= numPoints; i++) {
+    const t = i / numPoints
+    const internalAngle = arc.clockwise
+      ? startInternal - sweep * t
+      : startInternal + sweep * t
+    points.push(
+      arc.getPointAtAngle(publicAngleFromInternal(arc, internalAngle))
+    )
+  }
+
+  return points
+}
+
+function internalAngleAtPoint(arc: AcGeCircArc2d, point: AcGePoint2d): number {
+  return Math.atan2(point.y - arc.center.y, point.x - arc.center.x)
+}
+
+function publicAngleFromInternal(
+  arc: AcGeCircArc2d,
+  internalAngle: number
+): number {
+  const normalized = AcGeMathUtil.normalizeAngle(internalAngle)
+  return arc.clockwise ? mirrorAngle(normalized) : normalized
+}
+
+function mirrorAngle(angle: number): number {
+  const degrees = (angle * 180) / Math.PI
+  return ((360 - degrees) % 360) * (Math.PI / 180)
+}
+
+function sweepAlongArc(
+  arc: AcGeCircArc2d,
+  fromInternal: number,
+  toInternal: number
+): number {
+  if (arc.clockwise) {
+    let sweep = fromInternal - toInternal
+    if (sweep <= PATH_EPSILON) {
+      sweep += TAU
+    }
+    return sweep
+  }
+
+  let sweep = toInternal - fromInternal
+  if (sweep <= PATH_EPSILON) {
+    sweep += TAU
+  }
+  return sweep
+}
+
+function getOffsetSegmentStart(segment: OffsetSegment): AcGePoint2d {
+  return segment.kind === 'line'
+    ? segment.start.clone()
+    : segment.arc.startPoint.clone()
+}
+
+function getOffsetSegmentEnd(segment: OffsetSegment): AcGePoint2d {
+  return segment.kind === 'line'
+    ? segment.end.clone()
+    : segment.arc.endPoint.clone()
+}
+
+function joinOffsetSegments(
+  previous: OffsetSegment,
+  next: OffsetSegment,
+  _near: AcGePoint2d
+): AcGePoint2d {
+  if (previous.kind === 'line' && next.kind === 'line') {
+    return intersectPolylineOffsetSegments(
+      {
+        start: previous.start,
+        end: previous.end,
+        dx: previous.dx,
+        dy: previous.dy
+      },
+      {
+        start: next.start,
+        end: next.end,
+        dx: next.dx,
+        dy: next.dy
+      }
+    )
+  }
+
+  if (previous.kind === 'line' && next.kind === 'arc') {
+    return intersectLineWithCircle(
+      previous,
+      next.arc,
+      midpoint(previous.end, next.arc.startPoint)
+    )
+  }
+
+  if (previous.kind === 'arc' && next.kind === 'line') {
+    return intersectLineWithCircle(
+      next,
+      previous.arc,
+      midpoint(previous.arc.endPoint, next.start)
+    )
+  }
+
+  if (previous.kind === 'arc' && next.kind === 'arc') {
+    return intersectCircles(
+      previous.arc,
+      next.arc,
+      midpoint(previous.arc.endPoint, next.arc.startPoint)
+    )
+  }
+
+  return _near.clone()
+}
+
+function intersectLineWithCircle(
+  line: { start: AcGePoint2d; end: AcGePoint2d; dx: number; dy: number },
+  arc: AcGeCircArc2d,
+  near: AcGePoint2d
+): AcGePoint2d {
+  const dirLen = Math.hypot(line.dx, line.dy)
+  if (dirLen <= PATH_EPSILON) {
+    return near.clone()
+  }
+
+  const ux = line.dx / dirLen
+  const uy = line.dy / dirLen
+  const fx = line.start.x - arc.center.x
+  const fy = line.start.y - arc.center.y
+  const b = 2 * (fx * ux + fy * uy)
+  const c = fx * fx + fy * fy - arc.radius * arc.radius
+  const discriminant = b * b - 4 * c
+
+  if (discriminant < 0) {
+    return near.clone()
+  }
+
+  const sqrtDisc = Math.sqrt(discriminant)
+  const candidates = [(-b - sqrtDisc) / 2, (-b + sqrtDisc) / 2].map(
+    t => new AcGePoint2d(line.start.x + ux * t, line.start.y + uy * t)
+  )
+
+  const onArc = candidates.filter(candidate => isPointOnArc(arc, candidate))
+  return pickClosestPoint(onArc.length > 0 ? onArc : candidates, near)
+}
+
+function isPointOnArc(arc: AcGeCircArc2d, point: AcGePoint2d): boolean {
+  const radiusDelta = Math.abs(
+    Math.hypot(point.x - arc.center.x, point.y - arc.center.y) - arc.radius
+  )
+  if (radiusDelta > 1e-6) {
+    return false
+  }
+
+  const internalAngle = internalAngleAtPoint(arc, point)
+  const internalStart = arc.clockwise
+    ? mirrorAngle(AcGeMathUtil.normalizeAngle(arc.startAngle))
+    : AcGeMathUtil.normalizeAngle(arc.startAngle)
+  const internalEnd = arc.clockwise
+    ? mirrorAngle(AcGeMathUtil.normalizeAngle(arc.endAngle))
+    : AcGeMathUtil.normalizeAngle(arc.endAngle)
+
+  return AcGeMathUtil.isBetweenAngle(
+    internalAngle,
+    internalStart,
+    internalEnd,
+    arc.clockwise
+  )
+}
+
+function intersectCircles(
+  a: AcGeCircArc2d,
+  b: AcGeCircArc2d,
+  near: AcGePoint2d
+): AcGePoint2d {
+  const dx = b.center.x - a.center.x
+  const dy = b.center.y - a.center.y
+  const dist = Math.hypot(dx, dy)
+  if (dist <= PATH_EPSILON || dist > a.radius + b.radius) {
+    return near.clone()
+  }
+
+  const aTerm =
+    (a.radius * a.radius - b.radius * b.radius + dist * dist) / (2 * dist)
+  const hSquared = a.radius * a.radius - aTerm * aTerm
+  if (hSquared < 0) {
+    return near.clone()
+  }
+
+  const h = Math.sqrt(hSquared)
+  const mx = a.center.x + (aTerm * dx) / dist
+  const my = a.center.y + (aTerm * dy) / dist
+  const rx = (-dy * h) / dist
+  const ry = (dx * h) / dist
+
+  return pickClosestPoint(
+    [new AcGePoint2d(mx + rx, my + ry), new AcGePoint2d(mx - rx, my - ry)],
+    near
+  )
+}
+
+function pickClosestPoint(
+  points: AcGePoint2d[],
+  near: AcGePoint2d
+): AcGePoint2d {
+  let best = points[0]
+  let bestDist = best.distanceToSquared(near)
+  for (let i = 1; i < points.length; i++) {
+    const dist = points[i].distanceToSquared(near)
+    if (dist < bestDist) {
+      best = points[i]
+      bestDist = dist
+    }
+  }
+  return best.clone()
+}
+
+function midpoint(a: AcGePoint2d, b: AcGePoint2d): AcGePoint2d {
+  return new AcGePoint2d((a.x + b.x) / 2, (a.y + b.y) / 2)
+}
+
+function hasArcSegments(polyline: AcGePolyline2d): boolean {
+  const count = polyline.numberOfVertices
+  const segmentCount = polyline.closed ? count : count - 1
+  for (let i = 0; i < segmentCount; i++) {
+    const vertex = polyline.vertices[i]
+    if (Math.abs(vertex.bulge ?? 0) > PATH_EPSILON) {
+      return true
+    }
+  }
+  return false
+}
+
+function normalizeVertexPolyline(polyline: AcGePolyline2d): AcGePolyline2d {
+  const points = normalizePathPoints(
+    polyline.vertices.map(vertex => new AcGePoint2d(vertex.x, vertex.y)),
+    polyline.closed
+  )
+  if (points.length === polyline.numberOfVertices) {
+    return polyline
+  }
+  return new AcGePolyline2d(
+    points.map(point => ({ x: point.x, y: point.y })),
+    polyline.closed
+  )
+}
+
+function normalizePathPoints(
+  points: AcGePoint2d[],
+  closed: boolean
+): AcGePoint2d[] {
+  const deduped = dedupeConsecutivePoints(points)
+  if (!closed || deduped.length < 2) return deduped
+
+  const first = deduped[0]
+  const last = deduped[deduped.length - 1]
+  if (Math.hypot(first.x - last.x, first.y - last.y) <= PATH_EPSILON) {
+    deduped.pop()
+  }
+  return deduped
+}
+
+function dedupeConsecutivePoints(points: AcGePoint2d[]): AcGePoint2d[] {
+  const result: AcGePoint2d[] = []
+  points.forEach(point => {
+    const last = result[result.length - 1]
+    if (
+      !last ||
+      Math.hypot(last.x - point.x, last.y - point.y) > PATH_EPSILON
+    ) {
+      result.push(new AcGePoint2d(point.x, point.y))
+    }
+  })
+  return result
+}
+
+function createOpenPolylineOffset(
+  polyline: AcGePolyline2d,
+  offsetDist: number
+): AcGePolyline2d | null {
+  const sourcePoints: AcGePoint2d[] = []
+  for (let i = 0; i < polyline.numberOfVertices; i++) {
+    sourcePoints.push(polyline.getPointAt(i))
+  }
+
+  const offsetSegments: PolylineOffsetSegment[] = []
+  for (let i = 0; i < sourcePoints.length - 1; i++) {
+    const start = sourcePoints[i]
+    const end = sourcePoints[i + 1]
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const len = Math.hypot(dx, dy)
+    if (len <= PATH_EPSILON) continue
+
+    const nx = (-dy / len) * offsetDist
+    const ny = (dx / len) * offsetDist
+    offsetSegments.push({
+      start: new AcGePoint2d(start.x + nx, start.y + ny),
+      end: new AcGePoint2d(end.x + nx, end.y + ny),
+      dx,
+      dy
+    })
+  }
+
+  if (offsetSegments.length === 0) return null
+
+  const resultPoints: AcGePoint2d[] = [offsetSegments[0].start]
+  for (let i = 1; i < offsetSegments.length; i++) {
+    resultPoints.push(
+      intersectPolylineOffsetSegments(offsetSegments[i - 1], offsetSegments[i])
+    )
+  }
+  resultPoints.push(offsetSegments[offsetSegments.length - 1].end)
+
+  const result = new AcGePolyline2d()
+  resultPoints.forEach((point, index) => {
+    result.addVertexAt(index, { x: point.x, y: point.y })
+  })
+  result.closed = false
+  return result
+}
+
+function intersectPolylineOffsetSegments(
+  a: PolylineOffsetSegment,
+  b: PolylineOffsetSegment
+): AcGePoint2d {
+  const det = a.dx * b.dy - a.dy * b.dx
+  if (Math.abs(det) <= PATH_EPSILON) {
+    return new AcGePoint2d((a.end.x + b.start.x) / 2, (a.end.y + b.start.y) / 2)
+  }
+
+  const qpx = b.start.x - a.start.x
+  const qpy = b.start.y - a.start.y
+  const t = (qpx * b.dy - qpy * b.dx) / det
+  return new AcGePoint2d(a.start.x + t * a.dx, a.start.y + t * a.dy)
+}

--- a/packages/geometry-engine/src/index.ts
+++ b/packages/geometry-engine/src/index.ts
@@ -95,5 +95,7 @@ export {
   smootherstep,
   smoothstep,
   transformOcsPointToWcs,
-  transformWcsPointToOcs
+  transformWcsPointToOcs,
+  offsetPointByDirectionInXY,
+  offsetVertexPath
 } from './util'

--- a/packages/geometry-engine/src/util/AcGeCurveOffsetUtil.ts
+++ b/packages/geometry-engine/src/util/AcGeCurveOffsetUtil.ts
@@ -1,0 +1,51 @@
+import { AcGePolyline2d } from '../geometry/AcGePolyline2d'
+import {
+  offsetAcGePolyline2d,
+  preparePolylineForOffset
+} from '../geometry/AcGePolyline2dOffset'
+import { AcGePoint3d, AcGePoint3dLike, AcGeVector3dLike } from '../math'
+import { AcGePoint2d } from '../math/AcGePoint2d'
+
+/**
+ * Offsets a point perpendicular to the XY projection of a direction vector.
+ *
+ * @param point - Base point to translate
+ * @param direction - Direction whose XY component defines the offset normal
+ * @param offsetDist - Signed offset distance in drawing units
+ * @returns Translated point, or `null` when the XY direction is degenerate
+ */
+export function offsetPointByDirectionInXY(
+  point: AcGePoint3dLike,
+  direction: AcGeVector3dLike,
+  offsetDist: number
+): AcGePoint3d | null {
+  const len = Math.hypot(direction.x, direction.y)
+  if (len <= 1e-9) return null
+  const nx = (-direction.y / len) * offsetDist
+  const ny = (direction.x / len) * offsetDist
+  return new AcGePoint3d(point.x + nx, point.y + ny, point.z)
+}
+
+/**
+ * Offsets a planar vertex path in the XY plane.
+ *
+ * @param points - Sampled or vertex-derived 2D path
+ * @param closed - Whether the path is treated as a closed polygon
+ * @param offsetDist - Signed offset distance in drawing units
+ * @returns The first offset polyline, or `null` when offsetting fails
+ */
+export function offsetVertexPath(
+  points: AcGePoint2d[],
+  closed: boolean,
+  offsetDist: number
+): AcGePolyline2d | null {
+  if (points.length < 2) return null
+  const polyline = preparePolylineForOffset(
+    new AcGePolyline2d(
+      points.map(point => ({ x: point.x, y: point.y })),
+      closed
+    )
+  )
+  const results = offsetAcGePolyline2d(polyline, offsetDist)
+  return results[0] ?? null
+}

--- a/packages/geometry-engine/src/util/index.ts
+++ b/packages/geometry-engine/src/util/index.ts
@@ -57,3 +57,7 @@ export {
   transformWcsPointToOcs
 } from './AcGeOcsUtil'
 export { AcGeTol, DEFAULT_TOL } from './AcGeTol'
+export {
+  offsetPointByDirectionInXY,
+  offsetVertexPath
+} from './AcGeCurveOffsetUtil'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@mlightcad/common':
         specifier: workspace:*
         version: link:../common
+      clipper2-ts:
+        specifier: 2.0.1-15
+        version: 2.0.1-15
 
   packages/graphic-interface:
     dependencies:
@@ -2204,6 +2207,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  clipper2-ts@2.0.1-15:
+    resolution: {integrity: sha512-roegGp2c3DIyBvTDZM6IwFxe1xRIkg4vvftmf4S6U9FYcRyzfiXVKZxtVL3F4JjqArXq78Cf4L1FzLWXOlE3cQ==}
+    engines: {node: '>=14.0.0'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -7150,6 +7157,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  clipper2-ts@2.0.1-15: {}
 
   cliui@8.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

This PR adds curve offsetting aligned with AutoCAD ObjectARX `AcDbCurve::getOffsetCurves`, plus supporting geometry in `@mlightcad/geometry-engine`.

- **`AcDbCurve`** — New abstract `getOffsetCurves(offsetDist)` and `getOffsetSideAtPoint(point)` APIs (signed distance, `1` / `-1` side).
- **Primitive curves** — Exact offsets for `AcDbLine`, `AcDbArc`, `AcDbCircle`, and `AcDbEllipse` via new `offset()` methods on `AcGeLine3d`, `AcGeCircArc3d`, and `AcGeEllipseArc3d`.
- **Polylines** — `AcGePolyline2d.offset()` / `offsetAcGePolyline2d()`:
  - Closed, straight-only paths: **Clipper2** (`clipper2-ts`) polygon inflate.
  - Open paths and paths with **bulge arcs**: custom segment offset with line/arc junction solving.
- **Curve entities** — `getOffsetCurves` implemented on polylines, 2D/3D polylines, splines, leaders, traces, rays, xlines, and mesh types that expose a planar boundary.
- **Helpers** — `AcGeCurveOffsetUtil`, `AcDbPolyline.from2dPoints` / `fromGePolyline`, and `offsetVertexPathAsPolyline` for sampled XY paths.

## Behavior notes

| Entity / case | Approach |
|---------------|----------|
| `AcDbPolyline` | Direct `AcGePolyline2d` offset (lines + bulge arcs). |
| `AcDbSpline`, `AcDbLeader`, `AcDb2dPolyline` | Sample to XY polyline → offset → returns **`AcDbPolyline`**. |
| `AcDb3dPolyline` | Offset XY projection; **Z** restored by segment interpolation. |
| `AcDbRay` / `AcDbXline` | Parallel offset in XY; fails if direction is degenerate in XY. |
| `AcDbEllipse` | Uniform radius delta on major/minor axes (concentric ellipse). |
| Failure | Returns `[]` from `getOffsetCurves` (no thrown errors). |

## Dependencies & testing

- Adds **`clipper2-ts`** to `geometry-engine`.
- Jest **`setupClipper2Mock`** (global `setupFiles`) identity-mocks Clipper2 for deterministic unit tests.
- Unit tests extended for affected `AcDb*` entities and `AcGePolyline2d` (open/closed, bulge, mixed line–arc).

## Test plan

- [ ] `pnpm test` (or project test target) — all packages green.
- [ ] Offset a rectangle `AcDbPolyline` (closed, no bulge) inward/outward.
- [ ] Offset an LWPOLYLINE with bulge arcs; compare junction behavior to AutoCAD where possible.
- [ ] Offset `AcDbLine` / `AcDbArc` / `AcDbCircle` / `AcDbEllipse` and verify side via `getOffsetSideAtPoint`.
- [ ] Offset `AcDbSpline` / `AcDbLeader` — confirm result is `AcDbPolyline` approximation.
- [ ] Offset `AcDb3dPolyline` with varying Z — check elevation interpolation.
- [ ] Offset `AcDbRay` with near-vertical direction — expect empty result when XY direction is degenerate.