### PR TITLE
refactor(geometry-engine): centralize offset tolerance checks with AcGeTol

### DIFF
--- a/packages/geometry-engine/__tests__/AcGeTol.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeTol.spec.ts
@@ -10,6 +10,10 @@ describe('AcGeTol', () => {
     expect(AcGeTol.great(1, 2)).toBe(false)
     expect(AcGeTol.less(1, 2)).toBe(true)
     expect(AcGeTol.less(2, 1)).toBe(false)
+    expect(AcGeTol.isPositive(1e-5)).toBe(true)
+    expect(AcGeTol.isPositive(1e-7)).toBe(false)
+    expect(AcGeTol.isNonPositive(1e-7)).toBe(true)
+    expect(AcGeTol.isNonPositive(1e-5)).toBe(false)
   })
 
   it('clones tolerance values', () => {

--- a/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
@@ -7,12 +7,11 @@ import {
 } from 'clipper2-ts'
 
 import { AcGePoint2d } from '../math/AcGePoint2d'
-import { AcGeMathUtil, TAU } from '../util'
+import { AcGeMathUtil, AcGeTol, TAU } from '../util'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGePolyline2d } from './AcGePolyline2d'
 
 const POLYLINE_OFFSET_CLIPPER_SCALE = 1e6
-const PATH_EPSILON = 1e-9
 
 type PolylineOffsetSegment = {
   start: AcGePoint2d
@@ -138,7 +137,7 @@ function collectPlanarSegments(polyline: AcGePolyline2d): PlanarSegment[] {
   for (let i = 0; i < segmentCount; i++) {
     const start = polyline.vertices[i]
     const end = polyline.vertices[(i + 1) % count]
-    if (Math.abs(start.bulge ?? 0) > PATH_EPSILON) {
+    if (AcGeTol.isPositive(Math.abs(start.bulge ?? 0))) {
       segments.push({
         kind: 'arc',
         arc: new AcGeCircArc2d(start, end, start.bulge!)
@@ -191,7 +190,7 @@ function offsetCircArc2d(
 ): AcGeCircArc2d | null {
   const radiusDelta = getArcRadiusDelta(arc, start, end, offsetDist)
   const radius = arc.radius + radiusDelta
-  if (radius <= PATH_EPSILON) return null
+  if (AcGeTol.isNonPositive(radius)) return null
   return new AcGeCircArc2d(
     arc.center,
     radius,
@@ -218,7 +217,7 @@ function getArcRadiusDelta(
   const dx = end.x - start.x
   const dy = end.y - start.y
   const len = Math.hypot(dx, dy)
-  if (len <= PATH_EPSILON) {
+  if (AcGeTol.isNonPositive(len)) {
     return arc.clockwise ? -offsetDist : offsetDist
   }
 
@@ -239,7 +238,7 @@ function offsetLineSegment(
   const dx = end.x - start.x
   const dy = end.y - start.y
   const len = Math.hypot(dx, dy)
-  if (len <= PATH_EPSILON) return null
+  if (AcGeTol.isNonPositive(len)) return null
 
   const nx = (-dy / len) * offsetDist
   const ny = (dx / len) * offsetDist
@@ -370,14 +369,14 @@ function sweepAlongArc(
 ): number {
   if (arc.clockwise) {
     let sweep = fromInternal - toInternal
-    if (sweep <= PATH_EPSILON) {
+    if (AcGeTol.isNonPositive(sweep)) {
       sweep += TAU
     }
     return sweep
   }
 
   let sweep = toInternal - fromInternal
-  if (sweep <= PATH_EPSILON) {
+  if (AcGeTol.isNonPositive(sweep)) {
     sweep += TAU
   }
   return sweep
@@ -450,7 +449,7 @@ function intersectLineWithCircle(
   near: AcGePoint2d
 ): AcGePoint2d {
   const dirLen = Math.hypot(line.dx, line.dy)
-  if (dirLen <= PATH_EPSILON) {
+  if (AcGeTol.isNonPositive(dirLen)) {
     return near.clone()
   }
 
@@ -479,7 +478,7 @@ function isPointOnArc(arc: AcGeCircArc2d, point: AcGePoint2d): boolean {
   const radiusDelta = Math.abs(
     Math.hypot(point.x - arc.center.x, point.y - arc.center.y) - arc.radius
   )
-  if (radiusDelta > 1e-6) {
+  if (AcGeTol.isPositive(radiusDelta)) {
     return false
   }
 
@@ -507,7 +506,7 @@ function intersectCircles(
   const dx = b.center.x - a.center.x
   const dy = b.center.y - a.center.y
   const dist = Math.hypot(dx, dy)
-  if (dist <= PATH_EPSILON || dist > a.radius + b.radius) {
+  if (AcGeTol.isNonPositive(dist) || dist > a.radius + b.radius) {
     return near.clone()
   }
 
@@ -555,7 +554,7 @@ function hasArcSegments(polyline: AcGePolyline2d): boolean {
   const segmentCount = polyline.closed ? count : count - 1
   for (let i = 0; i < segmentCount; i++) {
     const vertex = polyline.vertices[i]
-    if (Math.abs(vertex.bulge ?? 0) > PATH_EPSILON) {
+    if (AcGeTol.isPositive(Math.abs(vertex.bulge ?? 0))) {
       return true
     }
   }
@@ -585,7 +584,7 @@ function normalizePathPoints(
 
   const first = deduped[0]
   const last = deduped[deduped.length - 1]
-  if (Math.hypot(first.x - last.x, first.y - last.y) <= PATH_EPSILON) {
+  if (AcGeTol.isNonPositive(Math.hypot(first.x - last.x, first.y - last.y))) {
     deduped.pop()
   }
   return deduped
@@ -597,7 +596,7 @@ function dedupeConsecutivePoints(points: AcGePoint2d[]): AcGePoint2d[] {
     const last = result[result.length - 1]
     if (
       !last ||
-      Math.hypot(last.x - point.x, last.y - point.y) > PATH_EPSILON
+      AcGeTol.isPositive(Math.hypot(last.x - point.x, last.y - point.y))
     ) {
       result.push(new AcGePoint2d(point.x, point.y))
     }
@@ -621,7 +620,7 @@ function createOpenPolylineOffset(
     const dx = end.x - start.x
     const dy = end.y - start.y
     const len = Math.hypot(dx, dy)
-    if (len <= PATH_EPSILON) continue
+    if (AcGeTol.isNonPositive(len)) continue
 
     const nx = (-dy / len) * offsetDist
     const ny = (dx / len) * offsetDist
@@ -656,7 +655,7 @@ function intersectPolylineOffsetSegments(
   b: PolylineOffsetSegment
 ): AcGePoint2d {
   const det = a.dx * b.dy - a.dy * b.dx
-  if (Math.abs(det) <= PATH_EPSILON) {
+  if (AcGeTol.equalToZero(det)) {
     return new AcGePoint2d((a.end.x + b.start.x) / 2, (a.end.y + b.start.y) / 2)
   }
 

--- a/packages/geometry-engine/src/util/AcGeCurveOffsetUtil.ts
+++ b/packages/geometry-engine/src/util/AcGeCurveOffsetUtil.ts
@@ -5,6 +5,7 @@ import {
 } from '../geometry/AcGePolyline2dOffset'
 import { AcGePoint3d, AcGePoint3dLike, AcGeVector3dLike } from '../math'
 import { AcGePoint2d } from '../math/AcGePoint2d'
+import { AcGeTol } from './AcGeTol'
 
 /**
  * Offsets a point perpendicular to the XY projection of a direction vector.
@@ -20,7 +21,7 @@ export function offsetPointByDirectionInXY(
   offsetDist: number
 ): AcGePoint3d | null {
   const len = Math.hypot(direction.x, direction.y)
-  if (len <= 1e-9) return null
+  if (AcGeTol.isNonPositive(len)) return null
   const nx = (-direction.y / len) * offsetDist
   const ny = (direction.x / len) * offsetDist
   return new AcGePoint3d(point.x + nx, point.y + ny, point.z)

--- a/packages/geometry-engine/src/util/AcGeTol.ts
+++ b/packages/geometry-engine/src/util/AcGeTol.ts
@@ -133,6 +133,20 @@ export class AcGeTol {
   static less(value1: number, value2: number, tol: number = FLOAT_TOL) {
     return value1 - value2 < tol
   }
+
+  /**
+   * Return true if the value is greater than the specified tolerance.
+   */
+  static isPositive(value: number, tol: number = FLOAT_TOL): boolean {
+    return value > tol
+  }
+
+  /**
+   * Return true if the value is less than or equal to the specified tolerance.
+   */
+  static isNonPositive(value: number, tol: number = FLOAT_TOL): boolean {
+    return value <= tol
+  }
 }
 
 export const DEFAULT_TOL = new AcGeTol()


### PR DESCRIPTION
## Summary

- Add `AcGeTol.isPositive()` and `AcGeTol.isNonPositive()` helpers for consistent floating-point sign and magnitude checks against `FLOAT_TOL`.
- Replace scattered hardcoded epsilon values (`PATH_EPSILON = 1e-9`, inline `1e-6` / `1e-9` comparisons) in polyline offset and curve offset utilities with the shared `AcGeTol` API.
- Add unit tests covering the new tolerance helpers.

## Motivation

Polyline and curve offset logic relied on local magic constants for degenerate-segment detection, zero-length checks, and point-on-arc validation. That made tolerance behavior inconsistent across modules and harder to maintain. This change routes those comparisons through `AcGeTol`, aligning offset code with the rest of the geometry engine.

## Changes

| File | Change |
|------|--------|
| `AcGeTol.ts` | Add `isPositive()` and `isNonPositive()` static methods |
| `AcGePolyline2dOffset.ts` | Remove `PATH_EPSILON`; use `AcGeTol` for bulge, radius, length, sweep, deduplication, and intersection checks |
| `AcGeCurveOffsetUtil.ts` | Use `AcGeTol.isNonPositive()` for zero-length direction vectors |
| `AcGeTol.spec.ts` | Test new helpers at and around the default tolerance boundary |
