### PR TITLE
refactor(geometry-engine): replace Clipper2 with native polyline offset and improve arc joins

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,6 @@ const config: Config = {
   verbose: true,
   preset: "ts-jest",
   testEnvironment: "node",
-  setupFiles: ["<rootDir>/packages/geometry-engine/__tests__/setupClipper2Mock.ts"],
   moduleNameMapper: {
     "^@mlightcad/common$": "<rootDir>/packages/common/src/index.ts",
     "^@mlightcad/geometry-engine$": "<rootDir>/packages/geometry-engine/src/index.ts",
@@ -14,10 +13,7 @@ const config: Config = {
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",
   },
-  testPathIgnorePatterns: [
-    "packages/dxf-json/",
-    "setupClipper2Mock",
-  ]
+  testPathIgnorePatterns: ["packages/dxf-json/"]
 }
 
 export default config

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -376,7 +376,7 @@ describe('AcDbPolyline', () => {
     expect(getDxfGroupValues(dxf, 70)).toContain('0')
   })
 
-  it('offsets a closed square outward', () => {
+  it('offsets a closed square', () => {
     const poly = new AcDbPolyline()
     poly.addVertexAt(0, new AcGePoint2d(0, 0))
     poly.addVertexAt(1, new AcGePoint2d(10, 0))
@@ -384,7 +384,18 @@ describe('AcDbPolyline', () => {
     poly.addVertexAt(3, new AcGePoint2d(0, 10))
     poly.closed = true
     const [result] = poly.getOffsetCurves(1) as AcDbPolyline[]
-    expect(result.numberOfVertices).toBeGreaterThanOrEqual(4)
+    expect(result.numberOfVertices).toBe(4)
+    const xs: number[] = []
+    const ys: number[] = []
+    for (let i = 0; i < result.numberOfVertices; i++) {
+      const point = result.getPoint2dAt(i)
+      xs.push(point.x)
+      ys.push(point.y)
+    }
+    expect(Math.min(...xs)).toBeCloseTo(1)
+    expect(Math.max(...xs)).toBeCloseTo(9)
+    expect(Math.min(...ys)).toBeCloseTo(1)
+    expect(Math.max(...ys)).toBeCloseTo(9)
   })
 
   it('offsets an open polyline with 2 vertices', () => {

--- a/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
@@ -86,6 +86,27 @@ describe('Test AcGePolyline2d', () => {
     expect(polyline.vertices[0].x).toBe(0)
   })
 
+  it('offsets a closed square with miter joins', () => {
+    const polyline = new AcGePolyline2d(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 }
+      ],
+      true
+    )
+    const [result] = polyline.offset(1)
+    expect(result.closed).toBe(true)
+    expect(result.numberOfVertices).toBe(4)
+    const xs = result.vertices.map(vertex => vertex.x)
+    const ys = result.vertices.map(vertex => vertex.y)
+    expect(Math.min(...xs)).toBeCloseTo(1)
+    expect(Math.max(...xs)).toBeCloseTo(9)
+    expect(Math.min(...ys)).toBeCloseTo(1)
+    expect(Math.max(...ys)).toBeCloseTo(9)
+  })
+
   it('offsets an open semicircle bulge segment outward', () => {
     const polyline = new AcGePolyline2d()
     polyline.addVertexAt(0, { x: 0, y: 0, bulge: 1 })
@@ -93,6 +114,78 @@ describe('Test AcGePolyline2d', () => {
     const [result] = polyline.offset(1)
     const minY = Math.min(...result.vertices.map(vertex => vertex.y))
     expect(minY).toBeCloseTo(-6, 0)
+  })
+
+  it('offsets arc-arc cusp with a round join instead of a straight bridge', () => {
+    const polyline = new AcGePolyline2d()
+    polyline.addVertexAt(0, { x: 0, y: 0, bulge: 0.55 })
+    polyline.addVertexAt(1, { x: 100, y: 50, bulge: -0.55 })
+    polyline.addVertexAt(2, { x: 100, y: 100 })
+
+    const [result] = polyline.offset(2)
+    const cusp = polyline.vertices[1]
+    const arcA = new AcGeCircArc2d(
+      polyline.vertices[0],
+      cusp,
+      polyline.vertices[0].bulge ?? 0.55
+    )
+    const arcB = new AcGeCircArc2d(
+      cusp,
+      polyline.vertices[2],
+      polyline.vertices[1].bulge ?? -0.55
+    )
+    const offsetA = new AcGeCircArc2d(
+      arcA.center,
+      arcA.radius + 2,
+      arcA.startAngle,
+      arcA.endAngle,
+      arcA.clockwise
+    )
+    const offsetB = new AcGeCircArc2d(
+      arcB.center,
+      arcB.radius - 2,
+      arcB.startAngle,
+      arcB.endAngle,
+      arcB.clockwise
+    )
+
+    const bridge = result.vertices.find((vertex, index) => {
+      if (index === 0) return false
+      const prev = result.vertices[index - 1]
+      const onA =
+        Math.abs(
+          Math.hypot(prev.x - offsetA.center.x, prev.y - offsetA.center.y) -
+            offsetA.radius
+        ) < 0.5
+      const onB =
+        Math.abs(
+          Math.hypot(vertex.x - offsetB.center.x, vertex.y - offsetB.center.y) -
+            offsetB.radius
+        ) < 0.5
+      const dist = Math.hypot(vertex.x - prev.x, vertex.y - prev.y)
+      return onA && onB && dist > 0.05 && dist < 8
+    })
+    expect(bridge).toBeUndefined()
+  })
+
+  it('offsets tangent line-arc polyline without a loop at the vertex', () => {
+    const polyline = new AcGePolyline2d()
+    polyline.addVertexAt(0, { x: 0, y: 0 })
+    polyline.addVertexAt(1, { x: 100, y: 0, bulge: 0.45 })
+    polyline.addVertexAt(2, { x: 160, y: 40 })
+
+    const [result] = polyline.offset(2)
+    const junctionVertex = polyline.vertices[1]
+    const joinRadius = 2
+    const joinCirclePoints = result.vertices.filter(
+      vertex =>
+        Math.abs(
+          Math.hypot(vertex.x - junctionVertex.x, vertex.y - junctionVertex.y) -
+            joinRadius
+        ) < 0.25
+    )
+    expect(joinCirclePoints.length).toBeLessThan(12)
+    expect(result.vertices.length).toBeLessThan(80)
   })
 
   it('offsets a mixed line-arc polyline to the same side of the path', () => {

--- a/packages/geometry-engine/__tests__/setupClipper2Mock.ts
+++ b/packages/geometry-engine/__tests__/setupClipper2Mock.ts
@@ -1,9 +1,0 @@
-jest.mock(
-  'clipper2-ts',
-  () => ({
-    EndType: { Polygon: 0, Butt: 1 },
-    JoinType: { Miter: 0 },
-    inflatePaths: (paths: unknown) => paths
-  }),
-  { virtual: true }
-)

--- a/packages/geometry-engine/package.json
+++ b/packages/geometry-engine/package.json
@@ -40,8 +40,5 @@
   },
   "peerDependencies": {
     "@mlightcad/common": "workspace:*"
-  },
-  "dependencies": {
-    "clipper2-ts": "2.0.1-15"
   }
 }

--- a/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
@@ -1,18 +1,12 @@
-import {
-  EndType,
-  inflatePaths,
-  JoinType,
-  type Path64,
-  type Paths64
-} from 'clipper2-ts'
-
 import { AcGePoint2d } from '../math/AcGePoint2d'
 import { AcGeMathUtil, AcGeTol, TAU } from '../util'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGePolyline2d } from './AcGePolyline2d'
 
-const POLYLINE_OFFSET_CLIPPER_SCALE = 1e6
+/** Epsilon for circle–circle intersection and tangency tests during arc joins. */
+const ROUND_JOIN_POINT_EPSILON = 1e-6
 
+/** Parallel offset of a straight polyline edge, retaining the original edge direction. */
 type PolylineOffsetSegment = {
   start: AcGePoint2d
   end: AcGePoint2d
@@ -20,10 +14,12 @@ type PolylineOffsetSegment = {
   dy: number
 }
 
+/** A single edge of a polyline in the XY plane, either a line chord or a bulge arc. */
 type PlanarSegment =
   | { kind: 'line'; start: AcGePoint2d; end: AcGePoint2d }
   | { kind: 'arc'; arc: AcGeCircArc2d }
 
+/** Offset geometry for one planar segment, preserving segment kind. */
 type OffsetSegment =
   | {
       kind: 'line'
@@ -34,15 +30,29 @@ type OffsetSegment =
     }
   | { kind: 'arc'; arc: AcGeCircArc2d }
 
+/** Connection data at a vertex between two consecutive offset segments. */
+type SegmentJoinInfo = {
+  /** Point where the previous offset segment meets the join */
+  point: AcGePoint2d
+  /** Round-join samples between mixed line/arc offsets (excludes endpoints) */
+  filletPoints?: AcGePoint2d[]
+  /** Where the next offset segment should start when it differs from `point` */
+  nextSegmentStart?: AcGePoint2d
+}
+
 /**
  * Creates offset curves for a 2D polyline in the XY plane.
  *
- * Arc segments (non-zero bulge) are offset concentrically; straight segments use
- * parallel offsets. Mixed paths are joined at segment boundaries.
+ * Routing depends on polyline content:
+ * - Polylines with bulge (arc) segments use analytic line/arc offset and custom joins.
+ * - Vertex-only polylines (open or closed) use parallel edge offset with miter intersections.
  *
- * @param polyline - Source polyline geometry
- * @param offsetDist - Signed offset distance in drawing units
- * @returns Offset polylines; empty when offsetting fails
+ * Sign convention: positive `offsetDist` offsets to the left of the travel direction
+ * along each segment (consistent with AutoCAD-style polyline offset).
+ *
+ * @param polyline - Source polyline; may be open or closed, with or without bulge arcs
+ * @param offsetDist - Signed offset distance in drawing units (left = positive)
+ * @returns One or more offset polylines; empty array when offsetting fails or input is degenerate
  */
 export function offsetAcGePolyline2d(
   polyline: AcGePolyline2d,
@@ -57,41 +67,19 @@ export function offsetAcGePolyline2d(
   const n = source.numberOfVertices
   if (n < 2) return []
 
-  if (!source.closed) {
-    const result = createOpenPolylineOffset(source, offsetDist)
-    return result ? [result] : []
-  }
-
-  const path: Path64 = []
-  for (let i = 0; i < n; i++) {
-    const pt = source.getPointAt(i)
-    path.push({
-      x: Math.round(pt.x * POLYLINE_OFFSET_CLIPPER_SCALE),
-      y: Math.round(pt.y * POLYLINE_OFFSET_CLIPPER_SCALE)
-    })
-  }
-  const sourcePaths: Paths64 = [path]
-  const paths = inflatePaths(
-    sourcePaths,
-    offsetDist * POLYLINE_OFFSET_CLIPPER_SCALE,
-    JoinType.Miter,
-    EndType.Polygon
-  )
-  if (!paths || paths.length === 0) return []
-
-  const result = new AcGePolyline2d()
-  paths[0].forEach((pt: { x: number; y: number }, i: number) => {
-    result.addVertexAt(i, {
-      x: pt.x / POLYLINE_OFFSET_CLIPPER_SCALE,
-      y: pt.y / POLYLINE_OFFSET_CLIPPER_SCALE
-    })
-  })
-  result.closed = source.closed
-  return [result]
+  const result = createVertexOnlyPolylineOffset(source, offsetDist)
+  return result ? [result] : []
 }
 
 /**
- * Normalizes a vertex-only polyline path by removing duplicate closure points.
+ * Normalizes a vertex-only polyline before offset or other geometric processing.
+ *
+ * Removes consecutive duplicate vertices and, for closed paths, drops a closing
+ * vertex that coincides with the first vertex so downstream algorithms see a
+ * minimal vertex ring.
+ *
+ * @param polyline - Input polyline (typically straight segments only)
+ * @returns The same instance if already normalized, otherwise a new polyline with cleaned vertices
  */
 export function preparePolylineForOffset(
   polyline: AcGePolyline2d
@@ -99,6 +87,17 @@ export function preparePolylineForOffset(
   return normalizeVertexPolyline(polyline)
 }
 
+/**
+ * Offsets a polyline that contains one or more bulge-defined arc segments.
+ *
+ * Each segment is offset individually (parallel line or concentric arc), then
+ * segment ends are joined at original vertices with miter, tangent, or round
+ * fallbacks as appropriate.
+ *
+ * @param polyline - Source polyline with at least one non-zero bulge
+ * @param offsetDist - Signed offset distance in drawing units
+ * @returns A single closed or open offset polyline, or `null` if any segment offset or join fails
+ */
 function offsetPolylineWithArcSegments(
   polyline: AcGePolyline2d,
   offsetDist: number
@@ -117,7 +116,8 @@ function offsetPolylineWithArcSegments(
   const points = buildJoinedOffsetPath(
     offsetSegments,
     joinVertices,
-    polyline.closed
+    polyline.closed,
+    offsetDist
   )
   if (points.length < 2) return null
 
@@ -129,6 +129,15 @@ function offsetPolylineWithArcSegments(
   return result
 }
 
+/**
+ * Decomposes a polyline into ordered planar segments in traversal order.
+ *
+ * Each edge from vertex `i` to `(i + 1) % n` becomes either a line chord (zero bulge)
+ * or a circular arc constructed from start vertex, end vertex, and bulge.
+ *
+ * @param polyline - Source polyline
+ * @returns Array of line and arc segments; empty when the polyline has fewer than two vertices (open) or one vertex (closed)
+ */
 function collectPlanarSegments(polyline: AcGePolyline2d): PlanarSegment[] {
   const segments: PlanarSegment[] = []
   const count = polyline.numberOfVertices
@@ -154,6 +163,14 @@ function collectPlanarSegments(polyline: AcGePolyline2d): PlanarSegment[] {
   return segments
 }
 
+/**
+ * Collects the 2D positions of all polyline vertices in index order.
+ *
+ * Used as join anchors when connecting offset segments at original corners.
+ *
+ * @param polyline - Source polyline
+ * @returns Clone-free point list matching `polyline.numberOfVertices` entries
+ */
 function collectJoinVertices(polyline: AcGePolyline2d): AcGePoint2d[] {
   const vertices: AcGePoint2d[] = []
   for (let i = 0; i < polyline.numberOfVertices; i++) {
@@ -162,6 +179,13 @@ function collectJoinVertices(polyline: AcGePolyline2d): AcGePoint2d[] {
   return vertices
 }
 
+/**
+ * Offsets a single planar segment by the signed distance.
+ *
+ * @param segment - Line chord or bulge arc segment
+ * @param offsetDist - Signed offset distance (left of travel = positive)
+ * @returns Offset line (with direction vector) or offset arc, or `null` if degenerate
+ */
 function offsetPlanarSegment(
   segment: PlanarSegment,
   offsetDist: number
@@ -182,6 +206,17 @@ function offsetPlanarSegment(
   return { kind: 'arc', arc: offsetArc }
 }
 
+/**
+ * Builds a concentric circular arc at the requested offset from a source arc.
+ *
+ * Radius change follows the same left-hand rule as line offset via {@link getArcRadiusDelta}.
+ *
+ * @param arc - Source circular arc
+ * @param start - Start point of the arc segment (chord start)
+ * @param end - End point of the arc segment (chord end)
+ * @param offsetDist - Signed offset distance
+ * @returns New arc sharing center and angles, or `null` if the offset radius is non-positive
+ */
 function offsetCircArc2d(
   arc: AcGeCircArc2d,
   start: AcGePoint2d,
@@ -201,12 +236,20 @@ function offsetCircArc2d(
 }
 
 /**
+ * Computes the signed radius change for a concentric arc offset.
+ *
  * Applies the same left-hand offset rule used for line segments: positive
  * `offsetDist` shifts the arc to the left of its travel direction.
  *
  * Concentric offset direction depends on which side of the chord the center
  * lies: when the center is on the left, shrink the radius; when on the right,
- * expand it.
+ * expand it. Degenerate zero-length chords fall back to clockwise flag only.
+ *
+ * @param arc - Source circular arc
+ * @param start - Chord start point
+ * @param end - Chord end point
+ * @param offsetDist - Signed offset distance
+ * @returns Signed delta to add to `arc.radius` (not the new radius itself)
  */
 function getArcRadiusDelta(
   arc: AcGeCircArc2d,
@@ -230,6 +273,17 @@ function getArcRadiusDelta(
   return centerOnLeft ? -offsetDist : offsetDist
 }
 
+/**
+ * Offsets a finite line segment parallel to itself.
+ *
+ * The offset direction is the left normal scaled by `offsetDist`. The returned
+ * `dx`/`dy` match the original edge direction for use in later miter joins.
+ *
+ * @param start - Segment start
+ * @param end - Segment end
+ * @param offsetDist - Signed offset distance
+ * @returns Offset endpoints plus original direction components, or `null` if the segment length is zero
+ */
 function offsetLineSegment(
   start: AcGePoint2d,
   end: AcGePoint2d,
@@ -250,75 +304,129 @@ function offsetLineSegment(
   }
 }
 
+/**
+ * Assembles a continuous polyline path from offset segments and per-vertex join data.
+ *
+ * Walks segments in order, emitting join points, optional round fillet samples,
+ * and interior samples along offset arcs between join limits.
+ *
+ * @param offsetSegments - Per-edge offset geometry in path order
+ * @param joinVertices - Original polyline vertices used as join anchors
+ * @param closed - Whether the path wraps from last segment back to first
+ * @param offsetDist - Signed offset distance (used for round-join radius)
+ * @returns Ordered vertex chain with consecutive duplicates removed
+ */
 function buildJoinedOffsetPath(
   offsetSegments: OffsetSegment[],
   joinVertices: AcGePoint2d[],
-  closed: boolean
+  closed: boolean,
+  offsetDist: number
 ): AcGePoint2d[] {
   const count = offsetSegments.length
   if (count === 0) return []
 
-  const junctions = computeJunctionPoints(offsetSegments, joinVertices, closed)
-  const points: AcGePoint2d[] = [junctions[0].clone()]
+  const joins = computeSegmentJoins(
+    offsetSegments,
+    joinVertices,
+    closed,
+    offsetDist
+  )
+  const points: AcGePoint2d[] = [joins[0].nextSegmentStart?.clone() ?? joins[0].point.clone()]
 
   for (let i = 0; i < count; i++) {
     const segment = offsetSegments[i]
-    const endJunction =
+    const joinAtEnd =
       i === count - 1 && !closed
-        ? getOffsetSegmentEnd(segment)
-        : junctions[(i + 1) % count]
+        ? {
+            point: getOffsetSegmentEnd(segment)
+          }
+        : joins[(i + 1) % count]
+
+    if (i > 0 && joins[i].filletPoints) {
+      joins[i].filletPoints!.forEach(point => points.push(point.clone()))
+    }
 
     if (segment.kind === 'arc') {
+      const arcStart = joins[i].nextSegmentStart ?? joins[i].point
+      const arcEnd = joinAtEnd.point
       const arcSamples = sampleArcBetweenPoints(
         segment.arc,
-        junctions[i],
-        endJunction,
+        arcStart,
+        arcEnd,
         Math.max(16, 32)
       )
       for (let j = 1; j < arcSamples.length; j++) {
         points.push(arcSamples[j])
       }
     } else {
-      points.push(endJunction.clone())
+      points.push(joinAtEnd.point.clone())
     }
   }
 
   return dedupeConsecutivePoints(points)
 }
 
-function computeJunctionPoints(
+/**
+ * Computes join information at every vertex between consecutive offset segments.
+ *
+ * For closed polylines, index `0` joins the last and first offset segments at
+ * `joinVertices[0]`. For open polylines, the start uses the first segment's
+ * offset start without a prior join.
+ *
+ * @param offsetSegments - Offset segments in path order
+ * @param joinVertices - Original corner vertices
+ * @param closed - Whether the polyline is closed
+ * @param offsetDist - Signed offset distance for round joins
+ * @returns One {@link SegmentJoinInfo} per segment, aligned with segment indices
+ */
+function computeSegmentJoins(
   offsetSegments: OffsetSegment[],
   joinVertices: AcGePoint2d[],
-  closed: boolean
-): AcGePoint2d[] {
+  closed: boolean,
+  offsetDist: number
+): SegmentJoinInfo[] {
   const count = offsetSegments.length
-  const junctions: AcGePoint2d[] = []
+  const joins: SegmentJoinInfo[] = []
 
   for (let i = 0; i < count; i++) {
     if (i === 0) {
-      junctions.push(
+      joins.push(
         closed
           ? joinOffsetSegments(
               offsetSegments[count - 1],
               offsetSegments[0],
-              joinVertices[0]
+              joinVertices[0],
+              offsetDist
             )
-          : getOffsetSegmentStart(offsetSegments[0])
+          : { point: getOffsetSegmentStart(offsetSegments[0]) }
       )
     } else {
-      junctions.push(
+      joins.push(
         joinOffsetSegments(
           offsetSegments[i - 1],
           offsetSegments[i],
-          joinVertices[i]
+          joinVertices[i],
+          offsetDist
         )
       )
     }
   }
 
-  return junctions
+  return joins
 }
 
+/**
+ * Samples points along a circular arc between two arbitrary points on the arc.
+ *
+ * Projects `start` and `end` onto the arc, measures sweep in internal angle
+ * space, and interpolates at uniform parameter steps. Endpoints are included.
+ *
+ * @param arc - Circular arc to sample
+ * @param start - Approximate start of the sampled span (need not lie exactly on the arc)
+ * @param end - Approximate end of the sampled span
+ * @param numPoints - Number of interior divisions (total samples = `numPoints + 1`)
+ * @returns Polyline of sampled points from start to end along the arc
+ */
 function sampleArcBetweenPoints(
   arc: AcGeCircArc2d,
   start: AcGePoint2d,
@@ -345,10 +453,27 @@ function sampleArcBetweenPoints(
   return points
 }
 
+/**
+ * Returns the mathematical polar angle from the arc center to a point.
+ *
+ * @param arc - Circular arc providing the center
+ * @param point - Point in the arc plane
+ * @returns Angle in radians in `[-π, π]`, consistent with `Math.atan2`
+ */
 function internalAngleAtPoint(arc: AcGeCircArc2d, point: AcGePoint2d): number {
   return Math.atan2(point.y - arc.center.y, point.x - arc.center.x)
 }
 
+/**
+ * Converts an internal (mathematical) angle to the public angle used by {@link AcGeCircArc2d}.
+ *
+ * Counterclockwise arcs use normalized mathematical angles; clockwise arcs apply
+ * the arc's mirrored angle convention.
+ *
+ * @param arc - Circular arc defining clockwise vs counterclockwise storage
+ * @param internalAngle - Angle in internal/mathematical space
+ * @returns Angle suitable for `arc.getPointAtAngle`
+ */
 function publicAngleFromInternal(
   arc: AcGeCircArc2d,
   internalAngle: number
@@ -357,11 +482,25 @@ function publicAngleFromInternal(
   return arc.clockwise ? mirrorAngle(normalized) : normalized
 }
 
+/**
+ * Mirrors a mathematical angle into the clockwise arc angle convention.
+ *
+ * @param angle - Angle in radians (mathematical convention)
+ * @returns Mirrored angle in radians for clockwise arc parameterization
+ */
 function mirrorAngle(angle: number): number {
   const degrees = (angle * 180) / Math.PI
   return ((360 - degrees) % 360) * (Math.PI / 180)
 }
 
+/**
+ * Computes the positive sweep from one internal angle to another along the arc.
+ *
+ * @param arc - Circular arc (direction from `clockwise`)
+ * @param fromInternal - Start internal angle
+ * @param toInternal - End internal angle
+ * @returns Positive sweep magnitude in radians along the arc direction
+ */
 function sweepAlongArc(
   arc: AcGeCircArc2d,
   fromInternal: number,
@@ -382,67 +521,309 @@ function sweepAlongArc(
   return sweep
 }
 
+/**
+ * Returns the start point of an offset segment in path order.
+ *
+ * @param segment - Line or arc offset segment
+ * @returns Cloned start point of the offset geometry
+ */
 function getOffsetSegmentStart(segment: OffsetSegment): AcGePoint2d {
   return segment.kind === 'line'
     ? segment.start.clone()
     : segment.arc.startPoint.clone()
 }
 
+/**
+ * Returns the end point of an offset segment in path order.
+ *
+ * @param segment - Line or arc offset segment
+ * @returns Cloned end point of the offset geometry
+ */
 function getOffsetSegmentEnd(segment: OffsetSegment): AcGePoint2d {
   return segment.kind === 'line'
     ? segment.end.clone()
     : segment.arc.endPoint.clone()
 }
 
+/**
+ * Resolves the connection between two consecutive offset segments at a corner vertex.
+ *
+ * Dispatches to line–line miter, line–arc, arc–line, or arc–arc join logic.
+ * Falls back to the original vertex when segment kinds are unexpected.
+ *
+ * @param previous - Offset segment entering the vertex
+ * @param next - Offset segment leaving the vertex
+ * @param vertex - Original polyline corner
+ * @param offsetDist - Signed offset distance (magnitude used for round joins)
+ * @returns Join point and optional fillet bridging to the next segment
+ */
 function joinOffsetSegments(
   previous: OffsetSegment,
   next: OffsetSegment,
-  _near: AcGePoint2d
-): AcGePoint2d {
+  vertex: AcGePoint2d,
+  offsetDist: number
+): SegmentJoinInfo {
   if (previous.kind === 'line' && next.kind === 'line') {
-    return intersectPolylineOffsetSegments(
-      {
-        start: previous.start,
-        end: previous.end,
-        dx: previous.dx,
-        dy: previous.dy
-      },
-      {
-        start: next.start,
-        end: next.end,
-        dx: next.dx,
-        dy: next.dy
-      }
-    )
+    return {
+      point: intersectPolylineOffsetSegments(
+        {
+          start: previous.start,
+          end: previous.end,
+          dx: previous.dx,
+          dy: previous.dy
+        },
+        {
+          start: next.start,
+          end: next.end,
+          dx: next.dx,
+          dy: next.dy
+        }
+      )
+    }
   }
 
   if (previous.kind === 'line' && next.kind === 'arc') {
-    return intersectLineWithCircle(
+    return joinLineWithArcOffset(
       previous,
       next.arc,
-      midpoint(previous.end, next.arc.startPoint)
+      vertex,
+      offsetDist,
+      true
     )
   }
 
   if (previous.kind === 'arc' && next.kind === 'line') {
-    return intersectLineWithCircle(
+    return joinLineWithArcOffset(
       next,
       previous.arc,
-      midpoint(previous.arc.endPoint, next.start)
+      vertex,
+      offsetDist,
+      false
     )
   }
 
   if (previous.kind === 'arc' && next.kind === 'arc') {
-    return intersectCircles(
+    return joinArcWithArcOffset(
       previous.arc,
       next.arc,
-      midpoint(previous.arc.endPoint, next.arc.startPoint)
+      vertex,
+      offsetDist
     )
   }
 
-  return _near.clone()
+  return { point: vertex.clone() }
 }
 
+/**
+ * Joins two offset circular arcs meeting at a common vertex.
+ *
+ * Prefers a point on both offset arcs near the gap midpoint (circle–circle
+ * intersection). If none exists, inserts a round join sampled around the vertex.
+ *
+ * @param previous - Offset arc ending at the vertex
+ * @param next - Offset arc starting at the vertex
+ * @param vertex - Original corner vertex
+ * @param offsetDist - Signed offset distance (absolute value = fillet radius)
+ * @returns Miter point on both arcs, or round join with separate segment endpoints
+ */
+function joinArcWithArcOffset(
+  previous: AcGeCircArc2d,
+  next: AcGeCircArc2d,
+  vertex: AcGePoint2d,
+  offsetDist: number
+): SegmentJoinInfo {
+  const near = midpoint(previous.endPoint, next.startPoint)
+  const candidates = intersectOffsetCircles(previous, next)
+  const onBoth = candidates.filter(
+    candidate =>
+      isPointOnArc(previous, candidate) && isPointOnArc(next, candidate)
+  )
+
+  if (onBoth.length > 0) {
+    return { point: pickClosestPoint(onBoth, near) }
+  }
+
+  const from = previous.endPoint.clone()
+  const to = next.startPoint.clone()
+  const filletPoints = sampleVertexRoundJoin(
+    vertex,
+    Math.abs(offsetDist),
+    from,
+    to
+  )
+
+  return {
+    point: from,
+    filletPoints,
+    nextSegmentStart: to
+  }
+}
+
+/**
+ * Joins an offset line segment with an offset arc at a shared vertex.
+ *
+ * @param line - Offset line segment (includes direction `dx`/`dy`)
+ * @param arc - Offset circular arc on the other side of the vertex
+ * @param vertex - Original corner vertex
+ * @param offsetDist - Signed offset distance
+ * @param lineBeforeArc - `true` if `line` is the incoming segment and `arc` is outgoing
+ * @returns Intersection on both primitives, or round join with optional `nextSegmentStart`
+ */
+function joinLineWithArcOffset(
+  line: {
+    start: AcGePoint2d
+    end: AcGePoint2d
+    dx: number
+    dy: number
+  },
+  arc: AcGeCircArc2d,
+  vertex: AcGePoint2d,
+  offsetDist: number,
+  lineBeforeArc: boolean
+): SegmentJoinInfo {
+  const near = midpoint(
+    lineBeforeArc ? line.end : line.start,
+    lineBeforeArc ? arc.startPoint : arc.endPoint
+  )
+  const intersection = intersectLineWithCircle(line, arc, near)
+
+  if (
+    isPointOnOffsetLine(line, intersection) &&
+    isPointOnArc(arc, intersection)
+  ) {
+    return { point: intersection }
+  }
+
+  const lineSide = getLineOffsetPointAtVertex(line, vertex, offsetDist)
+  const arcSide = lineBeforeArc ? arc.startPoint.clone() : arc.endPoint.clone()
+  const filletPoints = sampleVertexRoundJoin(
+    vertex,
+    Math.abs(offsetDist),
+    lineBeforeArc ? lineSide : arcSide,
+    lineBeforeArc ? arcSide : lineSide
+  )
+
+  if (lineBeforeArc) {
+    return {
+      point: lineSide,
+      filletPoints,
+      nextSegmentStart: arcSide
+    }
+  }
+
+  return {
+    point: arcSide,
+    filletPoints,
+    nextSegmentStart: lineSide
+  }
+}
+
+/**
+ * Computes the offset line point closest to a vertex along the left normal.
+ *
+ * @param line - Offset line with original edge direction `dx`/`dy`
+ * @param vertex - Corner on the source polyline
+ * @param offsetDist - Signed offset distance
+ * @returns Point on the infinite offset line through the vertex
+ */
+function getLineOffsetPointAtVertex(
+  line: { dx: number; dy: number },
+  vertex: AcGePoint2d,
+  offsetDist: number
+): AcGePoint2d {
+  const len = Math.hypot(line.dx, line.dy)
+  const nx = (-line.dy / len) * offsetDist
+  const ny = (line.dx / len) * offsetDist
+  return new AcGePoint2d(vertex.x + nx, vertex.y + ny)
+}
+
+/**
+ * Tests whether a point lies on the infinite line supporting an offset segment.
+ *
+ * @param line - Offset line with start and direction
+ * @param point - Candidate point
+ * @returns `true` if perpendicular distance to the line is within tolerance
+ */
+function isPointOnOffsetLine(
+  line: { start: AcGePoint2d; dx: number; dy: number },
+  point: AcGePoint2d
+): boolean {
+  const len = Math.hypot(line.dx, line.dy)
+  if (AcGeTol.isNonPositive(len)) return false
+  const ux = line.dx / len
+  const uy = line.dy / len
+  const px = point.x - line.start.x
+  const py = point.y - line.start.y
+  const perp = Math.abs(px * uy - py * ux)
+  return AcGeTol.equalToZero(perp)
+}
+
+/**
+ * Samples interior points of a circular round join at a vertex.
+ *
+ * Arc spans the shorter rotation from `from` to `to` about `vertex` at `radius`.
+ * Endpoints are excluded from the returned list.
+ *
+ * @param vertex - Center of the round join
+ * @param radius - Fillet radius (positive)
+ * @param from - Start direction point on the fillet circle
+ * @param to - End direction point on the fillet circle
+ * @returns Interior fillet samples; empty when start and end directions coincide
+ */
+function sampleVertexRoundJoin(
+  vertex: AcGePoint2d,
+  radius: number,
+  from: AcGePoint2d,
+  to: AcGePoint2d
+): AcGePoint2d[] {
+  const a1 = Math.atan2(from.y - vertex.y, from.x - vertex.x)
+  const a2 = Math.atan2(to.y - vertex.y, to.x - vertex.x)
+  const sweep = shortestAngleSweep(a1, a2)
+  if (AcGeTol.equalToZero(Math.abs(sweep))) {
+    return []
+  }
+
+  const points: AcGePoint2d[] = []
+  const steps = Math.max(2, Math.ceil((Math.abs(sweep) / Math.PI) * 16))
+  for (let i = 1; i < steps; i++) {
+    const t = i / steps
+    const angle = a1 + sweep * t
+    points.push(
+      new AcGePoint2d(
+        vertex.x + radius * Math.cos(angle),
+        vertex.y + radius * Math.sin(angle)
+      )
+    )
+  }
+  return points
+}
+
+/**
+ * Returns the shortest signed angular sweep from one direction to another.
+ *
+ * @param from - Start angle in radians
+ * @param to - End angle in radians
+ * @returns Signed sweep in `(-π, π]`
+ */
+function shortestAngleSweep(from: number, to: number): number {
+  let sweep = to - from
+  while (sweep > Math.PI) {
+    sweep -= TAU
+  }
+  while (sweep <= -Math.PI) {
+    sweep += TAU
+  }
+  return sweep
+}
+
+/**
+ * Intersects an infinite offset line with a circle (offset arc boundary).
+ *
+ * @param line - Offset line segment defining origin and direction
+ * @param arc - Circular arc whose radius and center define the circle
+ * @param near - Preference point when choosing among multiple intersections
+ * @returns Closest valid intersection to `near`, or `near` when no real roots exist
+ */
 function intersectLineWithCircle(
   line: { start: AcGePoint2d; end: AcGePoint2d; dx: number; dy: number },
   arc: AcGeCircArc2d,
@@ -474,6 +855,13 @@ function intersectLineWithCircle(
   return pickClosestPoint(onArc.length > 0 ? onArc : candidates, near)
 }
 
+/**
+ * Tests whether a point lies on a circular arc segment (not merely on the full circle).
+ *
+ * @param arc - Circular arc with defined start/end and clockwise flag
+ * @param point - Candidate point
+ * @returns `true` if distance to center matches radius and angle is within the arc span
+ */
 function isPointOnArc(arc: AcGeCircArc2d, point: AcGePoint2d): boolean {
   const radiusDelta = Math.abs(
     Math.hypot(point.x - arc.center.x, point.y - arc.center.y) - arc.radius
@@ -498,37 +886,63 @@ function isPointOnArc(arc: AcGeCircArc2d, point: AcGePoint2d): boolean {
   )
 }
 
-function intersectCircles(
+/**
+ * Intersects two circles defined by offset arc centers and radii.
+ *
+ * @param a - First offset arc (circle at `a.center` with radius `a.radius`)
+ * @param b - Second offset arc
+ * @returns Zero, one (tangent), or two intersection points; empty when circles are separated or nested beyond tolerance
+ */
+function intersectOffsetCircles(
   a: AcGeCircArc2d,
-  b: AcGeCircArc2d,
-  near: AcGePoint2d
-): AcGePoint2d {
+  b: AcGeCircArc2d
+): AcGePoint2d[] {
   const dx = b.center.x - a.center.x
   const dy = b.center.y - a.center.y
   const dist = Math.hypot(dx, dy)
-  if (AcGeTol.isNonPositive(dist) || dist > a.radius + b.radius) {
-    return near.clone()
+  if (AcGeTol.isNonPositive(dist)) {
+    return []
+  }
+
+  const radiusSum = a.radius + b.radius
+  const radiusDiff = Math.abs(a.radius - b.radius)
+  if (dist > radiusSum + ROUND_JOIN_POINT_EPSILON) {
+    return []
+  }
+  if (dist < radiusDiff - ROUND_JOIN_POINT_EPSILON) {
+    return []
   }
 
   const aTerm =
     (a.radius * a.radius - b.radius * b.radius + dist * dist) / (2 * dist)
   const hSquared = a.radius * a.radius - aTerm * aTerm
-  if (hSquared < 0) {
-    return near.clone()
+  if (hSquared < -ROUND_JOIN_POINT_EPSILON) {
+    return []
+  }
+
+  const mx = a.center.x + (aTerm * dx) / dist
+  const my = a.center.y + (aTerm * dy) / dist
+  if (hSquared <= ROUND_JOIN_POINT_EPSILON) {
+    return [new AcGePoint2d(mx, my)]
   }
 
   const h = Math.sqrt(hSquared)
-  const mx = a.center.x + (aTerm * dx) / dist
-  const my = a.center.y + (aTerm * dy) / dist
   const rx = (-dy * h) / dist
   const ry = (dx * h) / dist
 
-  return pickClosestPoint(
-    [new AcGePoint2d(mx + rx, my + ry), new AcGePoint2d(mx - rx, my - ry)],
-    near
-  )
+  return [
+    new AcGePoint2d(mx + rx, my + ry),
+    new AcGePoint2d(mx - rx, my - ry)
+  ]
 }
 
+/**
+ * Selects the candidate point closest to a reference location.
+ *
+ * @param points - Non-empty list of candidates
+ * @param near - Reference point for distance comparison
+ * @returns Clone of the closest candidate
+ */
 function pickClosestPoint(
   points: AcGePoint2d[],
   near: AcGePoint2d
@@ -545,10 +959,23 @@ function pickClosestPoint(
   return best.clone()
 }
 
+/**
+ * Computes the component-wise midpoint between two points.
+ *
+ * @param a - First point
+ * @param b - Second point
+ * @returns New point at `(a + b) / 2`
+ */
 function midpoint(a: AcGePoint2d, b: AcGePoint2d): AcGePoint2d {
   return new AcGePoint2d((a.x + b.x) / 2, (a.y + b.y) / 2)
 }
 
+/**
+ * Determines whether a polyline contains any bulge-defined arc segments.
+ *
+ * @param polyline - Polyline to inspect
+ * @returns `true` if any edge has a non-zero bulge within tolerance
+ */
 function hasArcSegments(polyline: AcGePolyline2d): boolean {
   const count = polyline.numberOfVertices
   const segmentCount = polyline.closed ? count : count - 1
@@ -561,6 +988,12 @@ function hasArcSegments(polyline: AcGePolyline2d): boolean {
   return false
 }
 
+/**
+ * Returns a vertex-only polyline with normalized path points.
+ *
+ * @param polyline - Input polyline
+ * @returns `polyline` unchanged when already normalized, else a new instance
+ */
 function normalizeVertexPolyline(polyline: AcGePolyline2d): AcGePolyline2d {
   const points = normalizePathPoints(
     polyline.vertices.map(vertex => new AcGePoint2d(vertex.x, vertex.y)),
@@ -575,6 +1008,13 @@ function normalizeVertexPolyline(polyline: AcGePolyline2d): AcGePolyline2d {
   )
 }
 
+/**
+ * Deduplicates consecutive vertices and removes redundant closure for closed paths.
+ *
+ * @param points - Vertex chain in order
+ * @param closed - Whether the path is closed
+ * @returns Cleaned vertex list
+ */
 function normalizePathPoints(
   points: AcGePoint2d[],
   closed: boolean
@@ -590,6 +1030,12 @@ function normalizePathPoints(
   return deduped
 }
 
+/**
+ * Removes consecutive vertices that coincide within geometric tolerance.
+ *
+ * @param points - Input vertex chain (may contain duplicates)
+ * @returns New array with only distinct consecutive points
+ */
 function dedupeConsecutivePoints(points: AcGePoint2d[]): AcGePoint2d[] {
   const result: AcGePoint2d[] = []
   points.forEach(point => {
@@ -604,7 +1050,18 @@ function dedupeConsecutivePoints(points: AcGePoint2d[]): AcGePoint2d[] {
   return result
 }
 
-function createOpenPolylineOffset(
+/**
+ * Offsets a vertex-only polyline (open or closed) composed of straight segments.
+ *
+ * Each edge is offset parallel to itself; consecutive offset lines are joined with
+ * miter intersections. Open paths keep raw offset starts/ends; closed paths join
+ * cyclically at every corner.
+ *
+ * @param polyline - Vertex-only polyline with at least two vertices
+ * @param offsetDist - Signed offset distance
+ * @returns Offset polyline, or `null` if no valid edges remain after skipping zero-length segments
+ */
+function createVertexOnlyPolylineOffset(
   polyline: AcGePolyline2d,
   offsetDist: number
 ): AcGePolyline2d | null {
@@ -613,10 +1070,61 @@ function createOpenPolylineOffset(
     sourcePoints.push(polyline.getPointAt(i))
   }
 
+  const offsetSegments = buildPolylineOffsetSegments(
+    sourcePoints,
+    polyline.closed,
+    offsetDist
+  )
+  if (offsetSegments.length === 0) return null
+
+  const resultPoints: AcGePoint2d[] = []
+  if (polyline.closed) {
+    if (offsetSegments.length < 2) return null
+    const count = offsetSegments.length
+    for (let i = 0; i < count; i++) {
+      const prev = offsetSegments[(i - 1 + count) % count]
+      const curr = offsetSegments[i]
+      resultPoints.push(intersectPolylineOffsetSegments(prev, curr))
+    }
+  } else {
+    resultPoints.push(offsetSegments[0].start)
+    for (let i = 1; i < offsetSegments.length; i++) {
+      resultPoints.push(
+        intersectPolylineOffsetSegments(
+          offsetSegments[i - 1],
+          offsetSegments[i]
+        )
+      )
+    }
+    resultPoints.push(offsetSegments[offsetSegments.length - 1].end)
+  }
+
+  const result = new AcGePolyline2d()
+  resultPoints.forEach((point, index) => {
+    result.addVertexAt(index, { x: point.x, y: point.y })
+  })
+  result.closed = polyline.closed
+  return result
+}
+
+/**
+ * Builds parallel offset segments for each non-degenerate edge of a vertex path.
+ *
+ * @param sourcePoints - Vertices in path order
+ * @param closed - Whether edges wrap from the last vertex back to the first
+ * @param offsetDist - Signed offset distance (left of travel = positive)
+ * @returns One offset segment per valid edge, in path order
+ */
+function buildPolylineOffsetSegments(
+  sourcePoints: AcGePoint2d[],
+  closed: boolean,
+  offsetDist: number
+): PolylineOffsetSegment[] {
   const offsetSegments: PolylineOffsetSegment[] = []
-  for (let i = 0; i < sourcePoints.length - 1; i++) {
+  const edgeCount = closed ? sourcePoints.length : sourcePoints.length - 1
+  for (let i = 0; i < edgeCount; i++) {
     const start = sourcePoints[i]
-    const end = sourcePoints[i + 1]
+    const end = sourcePoints[closed ? (i + 1) % sourcePoints.length : i + 1]
     const dx = end.x - start.x
     const dy = end.y - start.y
     const len = Math.hypot(dx, dy)
@@ -631,25 +1139,19 @@ function createOpenPolylineOffset(
       dy
     })
   }
-
-  if (offsetSegments.length === 0) return null
-
-  const resultPoints: AcGePoint2d[] = [offsetSegments[0].start]
-  for (let i = 1; i < offsetSegments.length; i++) {
-    resultPoints.push(
-      intersectPolylineOffsetSegments(offsetSegments[i - 1], offsetSegments[i])
-    )
-  }
-  resultPoints.push(offsetSegments[offsetSegments.length - 1].end)
-
-  const result = new AcGePolyline2d()
-  resultPoints.forEach((point, index) => {
-    result.addVertexAt(index, { x: point.x, y: point.y })
-  })
-  result.closed = false
-  return result
+  return offsetSegments
 }
 
+/**
+ * Computes the intersection of two infinite offset lines from consecutive polyline edges.
+ *
+ * Each segment supplies a point on the line (`start`) and direction (`dx`, `dy`).
+ * Parallel edges return the midpoint of the gap between segment ends as a fallback.
+ *
+ * @param a - First offset edge
+ * @param b - Second offset edge
+ * @returns Intersection point (miter) of the two supporting lines
+ */
 function intersectPolylineOffsetSegments(
   a: PolylineOffsetSegment,
   b: PolylineOffsetSegment

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       '@mlightcad/common':
         specifier: workspace:*
         version: link:../common
-      clipper2-ts:
-        specifier: 2.0.1-15
-        version: 2.0.1-15
 
   packages/graphic-interface:
     dependencies:
@@ -2207,10 +2204,6 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
-
-  clipper2-ts@2.0.1-15:
-    resolution: {integrity: sha512-roegGp2c3DIyBvTDZM6IwFxe1xRIkg4vvftmf4S6U9FYcRyzfiXVKZxtVL3F4JjqArXq78Cf4L1FzLWXOlE3cQ==}
-    engines: {node: '>=14.0.0'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -7157,8 +7150,6 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
-
-  clipper2-ts@2.0.1-15: {}
 
   cliui@8.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

This PR removes the `clipper2-ts` dependency from `geometry-engine` and replaces closed polyline offsetting with a native miter-join implementation. It also improves join handling at mixed line/arc and arc/arc vertices by adding round-join fallbacks where analytic intersections fail.

- **Remove Clipper2** — Drop `clipper2-ts` from `geometry-engine` dependencies, remove the Jest mock (`setupClipper2Mock.ts`), and clean up related Jest config.
- **Native vertex-only offset** — Route all straight-segment polylines (open and closed) through `createVertexOnlyPolylineOffset`, which parallel-offsets each edge and joins consecutive segments with miter intersections.
- **Improved arc joins** — Introduce `SegmentJoinInfo` to support round fillets at line–arc and arc–arc junctions when circle/line intersections are invalid or missing, avoiding straight bridge segments at cusps.
- **Documentation** — Add JSDoc across the offset module describing routing, sign convention, and join strategies.

## Motivation

The previous implementation used Clipper2 only for closed, vertex-only polylines while open paths used a custom offset path. This split added an external dependency and produced inconsistent join behavior. A single native implementation simplifies the dependency graph and gives more control over join quality at arc transitions.

## Changes

| Area | Change |
|------|--------|
| `AcGePolyline2dOffset.ts` | Unified entry routing; closed miter offset; round joins for line–arc and arc–arc |
| `geometry-engine/package.json` | Remove `clipper2-ts` |
| `jest.config.ts` | Remove Clipper2 mock setup |
| Tests | Add cases for closed square miter join, arc–arc cusp round join, and tangent line–arc offset; tighten `AcDbPolyline` closed-square assertions |