### PR TITLE
feat: improve spline offset with curvature-adaptive sampling and loop trimming

### DIFF
--- a/packages/data-model/__tests__/AcDbSpline.spec.ts
+++ b/packages/data-model/__tests__/AcDbSpline.spec.ts
@@ -5,7 +5,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbSpline } from '../src/entity'
+import { AcDbSpline, AcDbPolyline } from '../src/entity'
 import { AcDbOsnapMode } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
@@ -238,5 +238,46 @@ describe('AcDbSpline', () => {
       [0, 0, 0, 0, 1, 1, 1, 1]
     )
     expect(spline.getOffsetCurves(1).length).toBeGreaterThan(0)
+  })
+
+  it('offsets a tight spline without self-intersecting loops', () => {
+    const spline = new AcDbSpline(
+      [
+        new AcGePoint3d(0, 0, 0),
+        new AcGePoint3d(10, 8, 0),
+        new AcGePoint3d(20, -8, 0),
+        new AcGePoint3d(30, 8, 0),
+        new AcGePoint3d(40, 0, 0)
+      ],
+      [0, 0, 0, 0, 0.5, 1, 1, 1, 1]
+    )
+    const [result] = spline.getOffsetCurves(2) as AcDbPolyline[]
+    expect(result).toBeDefined()
+    const points = Array.from({ length: result.numberOfVertices }, (_, i) =>
+      result.getPoint2dAt(i)
+    )
+    const hasCrossing = (() => {
+      for (let i = 0; i < points.length - 1; i++) {
+        const a0 = points[i]
+        const a1 = points[i + 1]
+        for (let j = i + 2; j < points.length - 1; j++) {
+          const b0 = points[j]
+          const b1 = points[j + 1]
+          const dx1 = a1.x - a0.x
+          const dy1 = a1.y - a0.y
+          const dx2 = b1.x - b0.x
+          const dy2 = b1.y - b0.y
+          const det = dx1 * dy2 - dy1 * dx2
+          if (Math.abs(det) <= 1e-9) continue
+          const qpx = b0.x - a0.x
+          const qpy = b0.y - a0.y
+          const t = (qpx * dy2 - qpy * dx2) / det
+          const u = (qpx * dy1 - qpy * dx1) / det
+          if (t >= 0 && t <= 1 && u >= 0 && u <= 1) return true
+        }
+      }
+      return false
+    })()
+    expect(hasCrossing).toBe(false)
   })
 })

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -4,14 +4,15 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3dLike,
-  AcGeSpline3d
+  AcGeSpline3d,
+  offsetSmoothedSampledPath
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
-import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
+import { AcDbPolyline } from './AcDbPolyline'
 
 /**
  * Represents a spline entity in AutoCAD.
@@ -343,7 +344,8 @@ export class AcDbSpline extends AcDbCurve {
   /**
    * {@inheritDoc AcDbCurve.getOffsetCurves}
    *
-   * Approximates the spline with a sampled polyline in XY, then offsets that path.
+   * Approximates the spline with a densely sampled path in XY, offsets each sample
+   * along its local normal, and trims self-intersecting loops at tight bends.
    * The result is an {@link AcDbPolyline}, not a spline entity.
    */
   override getOffsetCurves(offsetDist: number): AcDbCurve[] {
@@ -357,7 +359,7 @@ export class AcDbSpline extends AcDbCurve {
    * Evaluates side relative to the sampled 2D approximation of the spline.
    */
   override getOffsetSideAtPoint(point: AcGePoint3dLike): 1 | -1 {
-    const path = this.collectPath2d()
+    const path = this.collectPath2d(1)
     if (path.length < 2) return 1
     return AcDbPolyline.from2dPoints(path, this.closed).getOffsetSideAtPoint(
       point
@@ -369,21 +371,23 @@ export class AcDbSpline extends AcDbCurve {
    * @returns Offset polyline approximating this spline, or `null` on failure
    */
   private createOffsetCurve(offsetDist: number): AcDbCurve | null {
-    return offsetVertexPathAsPolyline(
-      this.collectPath2d(),
+    const { points, tangents } = this._geo.getOffsetSamplePath2d(offsetDist)
+    const geo = offsetSmoothedSampledPath(
+      points,
       this.closed,
-      offsetDist
+      offsetDist,
+      tangents
     )
+    return geo ? AcDbPolyline.fromGePolyline(geo) : null
   }
 
   /**
-   * Samples {@link AcGeSpline3d} into a fixed-density 2D path for planar offset.
+   * Samples {@link AcGeSpline3d} for side tests (uniform parameter density).
    *
-   * @returns 64 XY points along the spline
+   * @param offsetDist - Used only to choose sample spacing
+   * @returns XY points along the spline
    */
-  private collectPath2d(): AcGePoint2d[] {
-    return this._geo
-      .getPoints(64)
-      .map(point => new AcGePoint2d(point.x, point.y))
+  private collectPath2d(offsetDist: number): AcGePoint2d[] {
+    return this._geo.getOffsetSamplePath2d(offsetDist).points
   }
 }

--- a/packages/geometry-engine/__tests__/AcGeNurbsUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeNurbsUtil.spec.ts
@@ -5,6 +5,8 @@ import {
   generateSqrtChordKnots,
   basisFunction,
   evaluateNurbsPoint,
+  evaluateNurbsDerivatives,
+  signedPlanarCurvature,
   calculateCurveLength,
   interpolateControlPoints,
   interpolateNurbsCurve
@@ -277,6 +279,34 @@ describe('AcGeNurbsUtil', () => {
       expect(negativePoint[0]).toBeCloseTo(positivePoint[0], 10)
       expect(negativePoint[1]).toBeCloseTo(positivePoint[1], 10)
       expect(negativePoint[2]).toBeCloseTo(positivePoint[2], 10)
+    })
+  })
+
+  describe('evaluateNurbsDerivatives', () => {
+    it('returns a constant tangent for a straight degree-1 segment', () => {
+      const degree = 1
+      const knots = [0, 0, 1, 1]
+      const controlPoints = [
+        [0, 0, 0],
+        [4, 0, 0]
+      ]
+      const weights = [1, 1]
+
+      const evaluation = evaluateNurbsDerivatives(
+        0.5,
+        degree,
+        knots,
+        controlPoints,
+        weights
+      )
+
+      expect(evaluation.point[0]).toBeCloseTo(2, 6)
+      expect(evaluation.point[1]).toBeCloseTo(0, 6)
+      expect(evaluation.deriv1[0]).toBeCloseTo(4, 4)
+      expect(evaluation.deriv1[1]).toBeCloseTo(0, 4)
+      expect(
+        signedPlanarCurvature(evaluation.deriv1, evaluation.deriv2)
+      ).toBeCloseTo(0, 4)
     })
   })
 

--- a/packages/geometry-engine/__tests__/AcGeSampledCurveOffsetUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeSampledCurveOffsetUtil.spec.ts
@@ -1,0 +1,76 @@
+import { AcGePoint2d, offsetSmoothedSampledPath } from '../src'
+
+function hasSelfIntersection(points: AcGePoint2d[], closed = false): boolean {
+  const segmentCount = closed ? points.length : points.length - 1
+  for (let i = 0; i < segmentCount; i++) {
+    const a0 = points[i]
+    const a1 = points[(i + 1) % points.length]
+    for (let j = i + 1; j < segmentCount; j++) {
+      if (j === i + 1) continue
+      if (closed && i === 0 && j === segmentCount - 1) continue
+      const b0 = points[j]
+      const b1 = points[(j + 1) % points.length]
+      const dx1 = a1.x - a0.x
+      const dy1 = a1.y - a0.y
+      const dx2 = b1.x - b0.x
+      const dy2 = b1.y - b0.y
+      const det = dx1 * dy2 - dy1 * dx2
+      if (Math.abs(det) <= 1e-9) continue
+      const qpx = b0.x - a0.x
+      const qpy = b0.y - a0.y
+      const t = (qpx * dy2 - qpy * dx2) / det
+      const u = (qpx * dy1 - qpy * dx1) / det
+      if (t >= 0 && t <= 1 && u >= 0 && u <= 1) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+describe('offsetSmoothedSampledPath', () => {
+  it('offsets a gentle open curve without self-intersections', () => {
+    const points = [
+      new AcGePoint2d(0, 0),
+      new AcGePoint2d(1, 1),
+      new AcGePoint2d(2, -1),
+      new AcGePoint2d(3, 0)
+    ]
+    const result = offsetSmoothedSampledPath(points, false, 0.5)
+    expect(result).not.toBeNull()
+    const offsetPoints = Array.from(
+      { length: result!.numberOfVertices },
+      (_, i) => result!.getPointAt(i)
+    )
+    expect(hasSelfIntersection(offsetPoints)).toBe(false)
+  })
+
+  it('trims loops when offset distance exceeds local curvature on a serpentine path', () => {
+    const points: AcGePoint2d[] = []
+    for (let i = 0; i <= 80; i++) {
+      const t = i / 80
+      points.push(
+        new AcGePoint2d(
+          t * 40,
+          4 * Math.sin(t * Math.PI * 2.5) + 2 * Math.sin(t * Math.PI * 5)
+        )
+      )
+    }
+
+    const result = offsetSmoothedSampledPath(points, false, 2)
+    expect(result).not.toBeNull()
+    const offsetPoints = Array.from(
+      { length: result!.numberOfVertices },
+      (_, i) => result!.getPointAt(i)
+    )
+    expect(offsetPoints.length).toBeGreaterThan(2)
+    expect(hasSelfIntersection(offsetPoints)).toBe(false)
+  })
+
+  it('returns null for degenerate input', () => {
+    expect(offsetSmoothedSampledPath([], false, 1)).toBeNull()
+    expect(
+      offsetSmoothedSampledPath([new AcGePoint2d(0, 0)], false, 1)
+    ).toBeNull()
+  })
+})

--- a/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
@@ -787,4 +787,27 @@ describe('AcGeSpline3d', () => {
       expect(cloned.knotParameterization).toBe('Uniform')
     })
   })
+
+  describe('getOffsetSamplePath2d', () => {
+    it('returns more samples in high-curvature regions', () => {
+      const spline = new AcGeSpline3d(
+        [
+          new AcGePoint3d(0, 0, 0),
+          new AcGePoint3d(10, 8, 0),
+          new AcGePoint3d(20, -8, 0),
+          new AcGePoint3d(30, 8, 0),
+          new AcGePoint3d(40, 0, 0)
+        ],
+        [0, 0, 0, 0, 0.5, 1, 1, 1, 1]
+      )
+
+      const path = spline.getOffsetSamplePath2d(2)
+
+      expect(path.points.length).toBeGreaterThan(64)
+      expect(path.tangents).toHaveLength(path.points.length)
+      path.tangents.forEach(tangent => {
+        expect(Math.hypot(tangent.x, tangent.y)).toBeCloseTo(1, 4)
+      })
+    })
+  })
 })

--- a/packages/geometry-engine/src/geometry/AcGeNurbsCurve.ts
+++ b/packages/geometry-engine/src/geometry/AcGeNurbsCurve.ts
@@ -1,15 +1,24 @@
 import { AcGePoint3d, AcGePoint3dLike } from '../math'
 
+/**
+ * Squared distance from a geometry point to a numeric `[x, y, z]` tuple.
+ *
+ * @param a - Query point
+ * @param b - Target coordinates as `[x, y, z]`
+ * @returns Squared Euclidean distance
+ */
 function distSq3d(a: AcGePoint3dLike, b: number[]): number {
   const dx = a.x - b[0]!
   const dy = a.y - b[1]!
   const dz = (a.z ?? 0) - (b[2] ?? 0)
   return dx * dx + dy * dy + dz * dz
 }
+import { AcGePoint2d } from '../math/AcGePoint2d'
 import {
   calculateCurveLength,
-  evaluateNurbsPoint,
-  interpolateNurbsCurve
+  evaluateNurbsDerivatives,
+  interpolateNurbsCurve,
+  signedPlanarCurvature
 } from '../util'
 import { AcGeCatmullRomCurve3d } from './AcGeCatmullRomCurve3d'
 
@@ -27,6 +36,17 @@ export class AcGeNurbsCurve {
   private _controlPoints: AcGePoint3dLike[]
   private _weights: number[]
 
+  /**
+   * Creates a NURBS curve from degree, knots, control points, and optional weights.
+   *
+   * When `weights` is omitted, all control points receive a weight of `1.0`
+   * (non-rational B-spline).
+   *
+   * @param degree - Polynomial degree `p` of the basis functions
+   * @param knots - Non-decreasing knot vector of length `n + p + 1`
+   * @param controlPoints - Control points in curve order
+   * @param weights - Optional rational weights aligned with control points
+   */
   constructor(
     degree: number,
     knots: number[],
@@ -82,18 +102,120 @@ export class AcGeNurbsCurve {
   }
 
   /**
-   * Calculate a point on the curve at parameter u
+   * Calculates a point on the curve at parameter `u`.
+   *
+   * Delegates to {@link evaluate} and returns only the position component.
+   *
+   * @param u - Curve parameter in the valid knot span
+   * @returns Evaluated point as `[x, y, z]`
    */
   point(u: number): number[] {
-    // Convert AcGePoint3dLike[] to number[][] for utility functions
+    return this.evaluate(u).point
+  }
+
+  /**
+   * Evaluates position and parametric derivatives at parameter `u`.
+   *
+   * Returns the rational NURBS point together with first- and second-order
+   * parametric derivatives computed analytically from the basis functions.
+   *
+   * @param u - Curve parameter in the valid knot span
+   * @returns Position `point`, first derivative `deriv1`, and second derivative `deriv2`
+   */
+  evaluate(u: number) {
     const controlPointsArray = this._controlPoints.map(p => [p.x, p.y, p.z])
-    return evaluateNurbsPoint(
+    return evaluateNurbsDerivatives(
       u,
       this._degree,
       this._knots,
       controlPointsArray,
       this._weights
     )
+  }
+
+  /**
+   * Signed curvature in the XY plane at parameter `u`.
+   *
+   * Uses the standard planar formula
+   * `(x'y'' - y'x'') / (x'^2 + y'^2)^(3/2)` applied to the parametric
+   * derivatives from {@link evaluate}.
+   *
+   * @param u - Curve parameter in the valid knot span
+   * @returns Signed curvature; positive indicates counterclockwise bending
+   */
+  signedPlanarCurvatureAt(u: number): number {
+    const evaluation = this.evaluate(u)
+    return signedPlanarCurvature(evaluation.deriv1, evaluation.deriv2)
+  }
+
+  /**
+   * Samples a 2D path with analytic tangents for planar offset.
+   *
+   * Builds an initial uniform parameter list scaled by curve length and offset
+   * distance, then refines intervals where `|offsetDist| * |curvature|` exceeds
+   * `0.85` (potential cusp region). Each final sample includes a unit tangent
+   * derived from the analytic first derivative.
+   *
+   * @param offsetDist - Signed offset distance used to choose sample density
+   * @param maxSamples - Upper bound on the number of returned samples (default 512)
+   * @returns XY samples and matching unit tangents in parameter order
+   */
+  getOffsetSamplePath2d(
+    offsetDist: number,
+    maxSamples = 512
+  ): { points: AcGePoint2d[]; tangents: AcGePoint2d[] } {
+    const absOffset = Math.abs(offsetDist)
+    const { start, end } = this.getParameterRange()
+    const length = this.length()
+    const minSamples = Math.max(
+      64,
+      Math.ceil(length / Math.max(absOffset * 0.2, 1e-6))
+    )
+    let params = uniformNurbsParameters(
+      start,
+      end,
+      Math.min(minSamples, maxSamples)
+    )
+
+    for (let pass = 0; pass < 8 && params.length < maxSamples; pass++) {
+      const insertions: number[] = []
+      for (let i = 0; i < params.length - 1; i++) {
+        const t0 = params[i]
+        const t1 = params[i + 1]
+        const mid = (t0 + t1) / 2
+        const curvature = Math.max(
+          Math.abs(this.signedPlanarCurvatureAt(t0)),
+          Math.abs(this.signedPlanarCurvatureAt(t1)),
+          Math.abs(this.signedPlanarCurvatureAt(mid))
+        )
+        if (absOffset * curvature > 0.85) {
+          insertions.push(mid)
+        }
+      }
+      if (insertions.length === 0) break
+      params = mergeSortedParameters(params, insertions)
+      if (params.length > maxSamples) {
+        params = params.slice(0, maxSamples)
+        break
+      }
+    }
+
+    const points: AcGePoint2d[] = []
+    const tangents: AcGePoint2d[] = []
+    params.forEach(param => {
+      const evaluation = this.evaluate(param)
+      points.push(new AcGePoint2d(evaluation.point[0], evaluation.point[1]))
+      const dx = evaluation.deriv1[0]
+      const dy = evaluation.deriv1[1]
+      const len = Math.hypot(dx, dy)
+      tangents.push(
+        len > 1e-10
+          ? new AcGePoint2d(dx / len, dy / len)
+          : new AcGePoint2d(1, 0)
+      )
+    })
+
+    return { points, tangents }
   }
 
   /**
@@ -258,4 +380,51 @@ export class AcGeNurbsCurve {
     // Create NURBS curve from the interpolated points
     return AcGeNurbsCurve.byPoints(nurbsPoints, degree, parameterization)
   }
+}
+
+/**
+ * Builds a uniform parameter list between two knot-span endpoints.
+ *
+ * The last parameter is pinned exactly to `end` to avoid floating-point drift.
+ *
+ * @param start - First parameter value
+ * @param end - Last parameter value
+ * @param count - Number of parameters to generate (minimum 2)
+ * @returns Sorted parameter values from `start` to `end` inclusive
+ */
+function uniformNurbsParameters(
+  start: number,
+  end: number,
+  count: number
+): number[] {
+  if (count < 2) return [start, end]
+  const params: number[] = []
+  for (let i = 0; i < count; i++) {
+    params.push(
+      i === count - 1 ? end : start + ((end - start) * i) / (count - 1)
+    )
+  }
+  return params
+}
+
+/**
+ * Merges a sorted parameter list with additional insertion values.
+ *
+ * Duplicate values closer than `1e-10` are collapsed so refinement passes do
+ * not create redundant evaluations.
+ *
+ * @param base - Existing sorted parameter values
+ * @param insertions - Additional parameters to insert
+ * @returns Combined sorted parameter list without near-duplicates
+ */
+function mergeSortedParameters(base: number[], insertions: number[]): number[] {
+  const merged = [...base, ...insertions].sort((a, b) => a - b)
+  const result: number[] = []
+  merged.forEach(value => {
+    const last = result[result.length - 1]
+    if (last === undefined || Math.abs(last - value) > 1e-10) {
+      result.push(value)
+    }
+  })
+  return result
 }

--- a/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2dOffset.ts
@@ -331,7 +331,9 @@ function buildJoinedOffsetPath(
     closed,
     offsetDist
   )
-  const points: AcGePoint2d[] = [joins[0].nextSegmentStart?.clone() ?? joins[0].point.clone()]
+  const points: AcGePoint2d[] = [
+    joins[0].nextSegmentStart?.clone() ?? joins[0].point.clone()
+  ]
 
   for (let i = 0; i < count; i++) {
     const segment = offsetSegments[i]
@@ -583,32 +585,15 @@ function joinOffsetSegments(
   }
 
   if (previous.kind === 'line' && next.kind === 'arc') {
-    return joinLineWithArcOffset(
-      previous,
-      next.arc,
-      vertex,
-      offsetDist,
-      true
-    )
+    return joinLineWithArcOffset(previous, next.arc, vertex, offsetDist, true)
   }
 
   if (previous.kind === 'arc' && next.kind === 'line') {
-    return joinLineWithArcOffset(
-      next,
-      previous.arc,
-      vertex,
-      offsetDist,
-      false
-    )
+    return joinLineWithArcOffset(next, previous.arc, vertex, offsetDist, false)
   }
 
   if (previous.kind === 'arc' && next.kind === 'arc') {
-    return joinArcWithArcOffset(
-      previous.arc,
-      next.arc,
-      vertex,
-      offsetDist
-    )
+    return joinArcWithArcOffset(previous.arc, next.arc, vertex, offsetDist)
   }
 
   return { point: vertex.clone() }
@@ -930,10 +915,7 @@ function intersectOffsetCircles(
   const rx = (-dy * h) / dist
   const ry = (dx * h) / dist
 
-  return [
-    new AcGePoint2d(mx + rx, my + ry),
-    new AcGePoint2d(mx - rx, my - ry)
-  ]
+  return [new AcGePoint2d(mx + rx, my + ry), new AcGePoint2d(mx - rx, my - ry)]
 }
 
 /**

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -3,6 +3,7 @@ import { AcCmErrors } from '@mlightcad/common'
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike
@@ -348,6 +349,17 @@ export class AcGeSpline3d extends AcGeCurve3d {
     const length = this._controlPoints.length
     const newIndex = index < 0 || index >= length ? length - 1 : index
     return this._controlPoints[newIndex]
+  }
+
+  /**
+   * Samples the spline for planar offset using analytic NURBS tangents and
+   * curvature-adaptive parameter refinement.
+   */
+  getOffsetSamplePath2d(offsetDist: number): {
+    points: AcGePoint2d[]
+    tangents: AcGePoint2d[]
+  } {
+    return this._nurbsCurve.getOffsetSamplePath2d(offsetDist)
   }
 
   /**

--- a/packages/geometry-engine/src/index.ts
+++ b/packages/geometry-engine/src/index.ts
@@ -65,6 +65,8 @@ export {
   degToRad,
   euclideanModulo,
   evaluateNurbsPoint,
+  evaluateNurbsDerivatives,
+  signedPlanarCurvature,
   floorPowerOfTwo,
   generateAveragedKnots,
   generateChordKnots,
@@ -97,5 +99,6 @@ export {
   transformOcsPointToWcs,
   transformWcsPointToOcs,
   offsetPointByDirectionInXY,
+  offsetSmoothedSampledPath,
   offsetVertexPath
 } from './util'

--- a/packages/geometry-engine/src/util/AcGeNurbsUtil.ts
+++ b/packages/geometry-engine/src/util/AcGeNurbsUtil.ts
@@ -444,6 +444,149 @@ export function evaluateNurbsPoint(
   return point
 }
 
+export type AcGeNurbsEvaluation = {
+  point: number[]
+  deriv1: number[]
+  deriv2: number[]
+}
+
+/**
+ * First derivative of a B-spline basis function N_{i,p}(u).
+ */
+function basisFunctionDeriv1(
+  i: number,
+  k: number,
+  u: number,
+  knots: number[]
+): number {
+  if (k === 0) return 0
+
+  const denomA = knots[i + k] - knots[i]
+  const denomB = knots[i + k + 1] - knots[i + 1]
+  let value = 0
+
+  if (denomA > 1e-10) {
+    value += (k / denomA) * basisFunction(i, k - 1, u, knots)
+  }
+  if (denomB > 1e-10) {
+    value -= (k / denomB) * basisFunction(i + 1, k - 1, u, knots)
+  }
+
+  return value
+}
+
+/**
+ * Second derivative of a B-spline basis function N_{i,p}(u).
+ */
+function basisFunctionDeriv2(
+  i: number,
+  k: number,
+  u: number,
+  knots: number[]
+): number {
+  if (k <= 1) return 0
+
+  const denomA = knots[i + k] - knots[i]
+  const denomB = knots[i + k + 1] - knots[i + 1]
+  let value = 0
+
+  if (denomA > 1e-10) {
+    value += (k / denomA) * basisFunctionDeriv1(i, k - 1, u, knots)
+  }
+  if (denomB > 1e-10) {
+    value -= (k / denomB) * basisFunctionDeriv1(i + 1, k - 1, u, knots)
+  }
+
+  return value
+}
+
+/**
+ * Evaluates a rational NURBS curve and its first two parametric derivatives.
+ */
+export function evaluateNurbsDerivatives(
+  u: number,
+  degree: number,
+  knots: number[],
+  controlPoints: number[][],
+  weights: number[]
+): AcGeNurbsEvaluation {
+  const n = controlPoints.length - 1
+  const p = degree
+  const startParam = knots[p]
+  const endParam = knots[n + 1]
+  u = Math.max(startParam, Math.min(endParam, u))
+
+  const aw = [0, 0, 0]
+  const daw = [0, 0, 0]
+  const d2aw = [0, 0, 0]
+  let w = 0
+  let dw = 0
+  let d2w = 0
+
+  for (let i = 0; i <= n; i++) {
+    const basis = basisFunction(i, p, u, knots)
+    const dbasis = basisFunctionDeriv1(i, p, u, knots)
+    const d2basis = basisFunctionDeriv2(i, p, u, knots)
+    const weight = weights[i]
+    const wBasis = weight * basis
+    const wDBasis = weight * dbasis
+    const wD2Basis = weight * d2basis
+    const cp = controlPoints[i]
+
+    aw[0] += wBasis * cp[0]
+    aw[1] += wBasis * cp[1]
+    aw[2] += wBasis * cp[2]
+    daw[0] += wDBasis * cp[0]
+    daw[1] += wDBasis * cp[1]
+    daw[2] += wDBasis * cp[2]
+    d2aw[0] += wD2Basis * cp[0]
+    d2aw[1] += wD2Basis * cp[1]
+    d2aw[2] += wD2Basis * cp[2]
+    w += wBasis
+    dw += wDBasis
+    d2w += wD2Basis
+  }
+
+  if (Math.abs(w) < 1e-10) {
+    const point = evaluateNurbsPoint(u, degree, knots, controlPoints, weights)
+    return { point, deriv1: [0, 0, 0], deriv2: [0, 0, 0] }
+  }
+
+  const w2 = w * w
+  const point = [aw[0] / w, aw[1] / w, aw[2] / w]
+  const deriv1 = [
+    (daw[0] * w - aw[0] * dw) / w2,
+    (daw[1] * w - aw[1] * dw) / w2,
+    (daw[2] * w - aw[2] * dw) / w2
+  ]
+  const num2x = d2aw[0] * w - aw[0] * d2w
+  const num2y = d2aw[1] * w - aw[1] * d2w
+  const num2z = d2aw[2] * w - aw[2] * d2w
+  const deriv2 = [
+    num2x / w2 - (2 * dw * deriv1[0]) / w,
+    num2y / w2 - (2 * dw * deriv1[1]) / w,
+    num2z / w2 - (2 * dw * deriv1[2]) / w
+  ]
+
+  return { point, deriv1, deriv2 }
+}
+
+/**
+ * Signed planar curvature from parametric derivatives in XY.
+ */
+export function signedPlanarCurvature(
+  deriv1: number[],
+  deriv2: number[]
+): number {
+  const dx = deriv1[0]
+  const dy = deriv1[1]
+  const ddx = deriv2[0]
+  const ddy = deriv2[1]
+  const speed2 = dx * dx + dy * dy
+  if (speed2 < 1e-20) return 0
+  return (dx * ddy - dy * ddx) / Math.pow(speed2, 1.5)
+}
+
 /**
  * Calculate curve length using numerical integration
  */

--- a/packages/geometry-engine/src/util/AcGeSampledCurveOffsetUtil.ts
+++ b/packages/geometry-engine/src/util/AcGeSampledCurveOffsetUtil.ts
@@ -1,0 +1,344 @@
+import { AcGePolyline2d } from '../geometry/AcGePolyline2d'
+import { AcGePoint2d } from '../math/AcGePoint2d'
+import { AcGeTol, DEFAULT_TOL } from './AcGeTol'
+
+/** Intersection of two non-adjacent polyline segments during loop trimming. */
+type SegmentIntersection = {
+  /** Intersection point in WCS (XY). */
+  point: AcGePoint2d
+  /** Index of the first intersecting segment (segment `i` connects `points[i]` to `points[i+1]`). */
+  segmentA: number
+  /** Index of the second intersecting segment. */
+  segmentB: number
+}
+
+/**
+ * Offsets a densely sampled smooth curve path in the XY plane.
+ *
+ * Unlike vertex polyline offset (parallel edges with miter joins), each sample
+ * is shifted along the local left normal. Self-intersecting loops that appear
+ * when the offset distance exceeds the local radius of curvature are trimmed.
+ *
+ * Sign convention: positive `offsetDist` offsets to the left of the travel
+ * direction along the sampled path (consistent with {@link offsetAcGePolyline2d}).
+ *
+ * @param points - Sampled path points in travel order
+ * @param closed - Whether the path is treated as a closed polygon for trimming
+ * @param offsetDist - Signed offset distance in drawing units (left = positive)
+ * @param tangents - Optional unit tangents aligned with `points`; when omitted,
+ * tangents are estimated from neighboring samples via central differences
+ * @returns Offset polyline, or `null` when input is degenerate or offset distance is zero
+ */
+export function offsetSmoothedSampledPath(
+  points: AcGePoint2d[],
+  closed: boolean,
+  offsetDist: number,
+  tangents?: AcGePoint2d[]
+): AcGePolyline2d | null {
+  if (points.length < 2 || AcGeTol.equalToZero(offsetDist)) return null
+
+  const { points: source, tangents: sourceTangents } = dedupeConsecutiveSamples(
+    points,
+    tangents
+  )
+  if (source.length < 2) return null
+
+  const resolvedTangents =
+    sourceTangents ?? computePathSampleTangents(source, closed)
+  const offsetPoints = offsetPointsByNormals(
+    source,
+    resolvedTangents,
+    offsetDist
+  )
+  const trimmed = closed
+    ? trimClosedPolylineSelfIntersections(offsetPoints)
+    : trimOpenPolylineSelfIntersections(offsetPoints)
+
+  if (trimmed.length < 2) return null
+
+  const result = new AcGePolyline2d()
+  trimmed.forEach((point, index) => {
+    result.addVertexAt(index, { x: point.x, y: point.y })
+  })
+  result.closed = closed
+  return result
+}
+
+/**
+ * Computes unit tangents for a sampled path using central differences.
+ *
+ * Open paths use one-sided differences at endpoints and central differences
+ * at interior samples. Closed paths wrap the predecessor of the first point
+ * and the successor of the last.
+ *
+ * @param points - Sampled path vertices in travel order
+ * @param closed - Whether the path wraps from last point back to first
+ * @returns Unit tangent at each sample; degenerate segments fall back to `(1, 0)`
+ */
+function computePathSampleTangents(
+  points: AcGePoint2d[],
+  closed: boolean
+): AcGePoint2d[] {
+  const count = points.length
+  const tangents: AcGePoint2d[] = new Array(count)
+
+  for (let i = 0; i < count; i++) {
+    let dx = 0
+    let dy = 0
+
+    if (closed) {
+      const prev = points[(i - 1 + count) % count]
+      const next = points[(i + 1) % count]
+      dx = next.x - prev.x
+      dy = next.y - prev.y
+    } else if (i === 0) {
+      dx = points[1].x - points[0].x
+      dy = points[1].y - points[0].y
+    } else if (i === count - 1) {
+      dx = points[count - 1].x - points[count - 2].x
+      dy = points[count - 1].y - points[count - 2].y
+    } else {
+      dx = points[i + 1].x - points[i - 1].x
+      dy = points[i + 1].y - points[i - 1].y
+    }
+
+    const len = Math.hypot(dx, dy)
+    if (AcGeTol.isNonPositive(len)) {
+      tangents[i] = new AcGePoint2d(1, 0)
+    } else {
+      tangents[i] = new AcGePoint2d(dx / len, dy / len)
+    }
+  }
+
+  return tangents
+}
+
+/**
+ * Offsets each sample along the left normal of its tangent.
+ *
+ * The left normal of a unit tangent `(tx, ty)` is `(-ty, tx)`, scaled by
+ * `offsetDist` and added to the sample position.
+ *
+ * @param points - Source samples in travel order
+ * @param tangents - Unit tangents aligned index-for-index with `points`
+ * @param offsetDist - Signed offset distance in drawing units
+ * @returns Translated samples forming the raw offset polyline before trimming
+ */
+function offsetPointsByNormals(
+  points: AcGePoint2d[],
+  tangents: AcGePoint2d[],
+  offsetDist: number
+): AcGePoint2d[] {
+  return points.map((point, index) => {
+    const tangent = tangents[index]
+    const nx = -tangent.y * offsetDist
+    const ny = tangent.x * offsetDist
+    return new AcGePoint2d(point.x + nx, point.y + ny)
+  })
+}
+
+/**
+ * Removes self-intersecting loops from an open offset polyline.
+ *
+ * Repeatedly finds the earliest non-adjacent segment crossing and replaces the
+ * enclosed vertex chain with the intersection point until no crossings remain.
+ * This produces cusp-style joins when the offset distance exceeds the local
+ * radius of curvature at concave bends.
+ *
+ * @param points - Raw offset samples connected in order
+ * @returns Trimmed open vertex chain with loops removed
+ */
+function trimOpenPolylineSelfIntersections(
+  points: AcGePoint2d[]
+): AcGePoint2d[] {
+  let current = dedupeConsecutivePoints(points)
+  if (current.length < 3) return current
+
+  while (true) {
+    const hit = findFirstSelfIntersection(current, false)
+    if (!hit) break
+    current = dedupeConsecutivePoints([
+      ...current.slice(0, hit.segmentA + 1),
+      hit.point,
+      ...current.slice(hit.segmentB + 1)
+    ])
+    if (current.length < 2) break
+  }
+
+  return current
+}
+
+/**
+ * Removes self-intersecting loops from a closed offset polyline.
+ *
+ * Uses the same earliest-intersection trimming strategy as
+ * {@link trimOpenPolylineSelfIntersections}, but treats the last-to-first
+ * segment as part of the closed ring.
+ *
+ * @param points - Raw offset samples forming a closed ring
+ * @returns Trimmed closed vertex chain with loops removed
+ */
+function trimClosedPolylineSelfIntersections(
+  points: AcGePoint2d[]
+): AcGePoint2d[] {
+  let current = dedupeConsecutivePoints(points)
+  if (current.length < 4) return current
+
+  while (true) {
+    const hit = findFirstSelfIntersection(current, true)
+    if (!hit) break
+    current = dedupeConsecutivePoints([
+      ...current.slice(0, hit.segmentA + 1),
+      hit.point,
+      ...current.slice(hit.segmentB + 1)
+    ])
+    if (current.length < 3) break
+  }
+
+  return current
+}
+
+/**
+ * Finds the earliest non-adjacent segment intersection in a polyline.
+ *
+ * Segments are tested in lexicographic order `(segmentA, segmentB)` so trimming
+ * removes the innermost loop encountered first along the path.
+ *
+ * @param points - Polyline vertices in order
+ * @param closed - Whether the polyline wraps from last vertex back to first
+ * @returns Intersection data, or `null` when no crossing exists
+ */
+function findFirstSelfIntersection(
+  points: AcGePoint2d[],
+  closed: boolean
+): SegmentIntersection | null {
+  const segmentCount = closed ? points.length : points.length - 1
+  if (segmentCount < 2) return null
+
+  for (let i = 0; i < segmentCount; i++) {
+    const a0 = points[i]
+    const a1 = points[(i + 1) % points.length]
+
+    for (let j = i + 1; j < segmentCount; j++) {
+      if (areAdjacentSegments(i, j, segmentCount, closed)) continue
+
+      const b0 = points[j]
+      const b1 = points[(j + 1) % points.length]
+      const point = intersectBoundedSegments(a0, a1, b0, b1)
+      if (point) {
+        return { point, segmentA: i, segmentB: j }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Tests whether two segment indices share a vertex and should be skipped
+ * during self-intersection search.
+ *
+ * @param i - Index of the first segment
+ * @param j - Index of the second segment
+ * @param segmentCount - Total number of segments in the polyline
+ * @param closed - Whether the polyline is closed
+ * @returns `true` when the segments are identical or share an endpoint
+ */
+function areAdjacentSegments(
+  i: number,
+  j: number,
+  segmentCount: number,
+  closed: boolean
+): boolean {
+  if (j === i) return true
+  if (j === i + 1) return true
+  if (closed && i === 0 && j === segmentCount - 1) return true
+  return false
+}
+
+/**
+ * Computes the intersection point of two bounded line segments, if any.
+ *
+ * Uses parametric line intersection and requires both parameters to lie in
+ * `[0, 1]` within {@link DEFAULT_TOL}. Parallel or collinear segments return
+ * `null`.
+ *
+ * @param a0 - Start of the first segment
+ * @param a1 - End of the first segment
+ * @param b0 - Start of the second segment
+ * @param b1 - End of the second segment
+ * @returns Intersection point, or `null` when segments do not cross
+ */
+function intersectBoundedSegments(
+  a0: AcGePoint2d,
+  a1: AcGePoint2d,
+  b0: AcGePoint2d,
+  b1: AcGePoint2d
+): AcGePoint2d | null {
+  const dx1 = a1.x - a0.x
+  const dy1 = a1.y - a0.y
+  const dx2 = b1.x - b0.x
+  const dy2 = b1.y - b0.y
+  const det = dx1 * dy2 - dy1 * dx2
+  if (AcGeTol.equalToZero(det)) return null
+
+  const qpx = b0.x - a0.x
+  const qpy = b0.y - a0.y
+  const t = (qpx * dy2 - qpy * dx2) / det
+  const u = (qpx * dy1 - qpy * dx1) / det
+
+  const tol = DEFAULT_TOL.equalPointTol
+  if (t < -tol || t > 1 + tol || u < -tol || u > 1 + tol) {
+    return null
+  }
+
+  return new AcGePoint2d(a0.x + t * dx1, a0.y + t * dy1)
+}
+
+/**
+ * Removes consecutive duplicate samples while keeping tangents aligned.
+ *
+ * When `tangents` is provided with the same length as `points`, tangents
+ * corresponding to dropped duplicates are removed as well.
+ *
+ * @param points - Input sample chain, possibly containing consecutive duplicates
+ * @param tangents - Optional unit tangents aligned with `points`
+ * @returns Deduplicated points and, when supplied, matching tangents
+ */
+function dedupeConsecutiveSamples(
+  points: AcGePoint2d[],
+  tangents?: AcGePoint2d[]
+): { points: AcGePoint2d[]; tangents?: AcGePoint2d[] } {
+  const resultPoints: AcGePoint2d[] = []
+  const resultTangents: AcGePoint2d[] = []
+  const keepTangents = tangents != null && tangents.length === points.length
+
+  points.forEach((point, index) => {
+    const last = resultPoints[resultPoints.length - 1]
+    if (
+      !last ||
+      AcGeTol.isPositive(Math.hypot(last.x - point.x, last.y - point.y))
+    ) {
+      resultPoints.push(new AcGePoint2d(point.x, point.y))
+      if (keepTangents) {
+        const tangent = tangents![index]
+        resultTangents.push(new AcGePoint2d(tangent.x, tangent.y))
+      }
+    }
+  })
+
+  return {
+    points: resultPoints,
+    tangents: keepTangents ? resultTangents : undefined
+  }
+}
+
+/**
+ * Removes consecutive duplicate vertices from a point chain.
+ *
+ * @param points - Input vertex chain
+ * @returns New array with only distinct consecutive points
+ */
+function dedupeConsecutivePoints(points: AcGePoint2d[]): AcGePoint2d[] {
+  return dedupeConsecutiveSamples(points).points
+}

--- a/packages/geometry-engine/src/util/index.ts
+++ b/packages/geometry-engine/src/util/index.ts
@@ -43,6 +43,8 @@ export {
   calculateCurveLength,
   computeParameterValues,
   evaluateNurbsPoint,
+  evaluateNurbsDerivatives,
+  signedPlanarCurvature,
   generateAveragedKnots,
   generateChordKnots,
   generateSqrtChordKnots,
@@ -61,3 +63,4 @@ export {
   offsetPointByDirectionInXY,
   offsetVertexPath
 } from './AcGeCurveOffsetUtil'
+export { offsetSmoothedSampledPath } from './AcGeSampledCurveOffsetUtil'


### PR DESCRIPTION
## Summary

Improves planar offset for spline entities by replacing fixed-density polyline sampling with a curvature-aware NURBS pipeline and a dedicated sampled-curve offset utility. The result is more stable offset geometry on tight bends and serpentine paths, with self-intersecting loops trimmed at concave regions.

## Changes

### Data model
- **`AcDbSpline.getOffsetCurves`**: samples the underlying spline adaptively, offsets each point along its local normal, and returns an `AcDbPolyline` approximation instead of reusing generic vertex-path offset.
- **`getOffsetSideAtPoint`**: uses the same adaptive sampling path for consistent side evaluation.

### Geometry engine
- **`AcGeNurbsUtil`**: adds `evaluateNurbsDerivatives` and `signedPlanarCurvature` for analytic NURBS evaluation.
- **`AcGeNurbsCurve` / `AcGeSpline3d`**: adds `getOffsetSamplePath2d`, which refines samples in high-curvature regions where `|offsetDist| × |curvature|` exceeds the cusp threshold, and returns matching unit tangents.
- **`AcGeSampledCurveOffsetUtil`**: new utility that offsets sampled smooth paths by local normals and trims self-intersecting loops for both open and closed polylines.

### Tests
- Coverage for NURBS derivative evaluation, adaptive spline sampling, sampled-path offset (including serpentine loop trimming), and tight spline offset without self-intersections.

## Motivation

The previous spline offset used a fixed 64-point sample and generic polyline offset, which could produce self-intersecting loops on curves with high local curvature or large offset distances. This change aligns spline offset behavior with the recent curve-offset work (#86–#88) while handling smooth-curve-specific edge cases.