### PR TITLE
fix(data-model): resolve text styles during progressive conversion and fix TRACE boundary order

### DIFF
--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -230,17 +230,17 @@ describe('AcDbMText', () => {
     expect(renderer.mtext).toHaveBeenCalledTimes(3)
   })
 
-  it('throws when subWorldDraw cannot resolve any text style', () => {
+  it('recreates a default text style when the table was cleared', () => {
     const db = createWorkingDb()
     const mtext = new AcDbMText()
     mtext.styleName = '__missing_style__'
     db.textstyle = '__missing_textstyle__'
     db.tables.textStyleTable.removeAll()
 
-    const renderer = { mtext: jest.fn() }
-    expect(() => mtext.subWorldDraw(renderer as never)).toThrow(
-      'No valid text style found in text style table.'
-    )
+    const renderer = { mtext: jest.fn(() => ({})) }
+    expect(() => mtext.subWorldDraw(renderer as never)).not.toThrow()
+    expect(renderer.mtext).toHaveBeenCalled()
+    expect(db.tables.textStyleTable.getAt('Standard')).toBeDefined()
   })
 
   it('writes MTEXT DXF fields with encoded content and optional background fields', () => {

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -354,11 +354,13 @@ describe('AcDbTable', () => {
     ).not.toThrow()
 
     const styleTable = third.database.tables.textStyleTable
-    const getAtSpy = jest.spyOn(styleTable, 'getAt').mockReturnValue(undefined)
+    const resolveAtSpy = jest
+      .spyOn(styleTable, 'resolveAt')
+      .mockReturnValue(undefined)
     expect(() =>
       third.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
     ).toThrow('No valid text style found in text style table.')
-    getAtSpy.mockRestore()
+    resolveAtSpy.mockRestore()
   })
 
   it('covers remaining text alignment branches in subWorldDraw', () => {

--- a/packages/data-model/__tests__/AcDbText.spec.ts
+++ b/packages/data-model/__tests__/AcDbText.spec.ts
@@ -210,19 +210,19 @@ describe('AcDbText', () => {
     expect(delay).toBe(true)
   })
 
-  it('throws when subWorldDraw cannot resolve a text style', () => {
+  it('creates a default text style when subWorldDraw runs against an empty table', () => {
     const text = new AcDbText()
     text.database = new AcDbDatabase()
+    text.textString = 'fallback'
     const renderer = {
-      mtext: jest.fn()
+      mtext: jest.fn(() => ({}))
     } as unknown as {
       mtext: jest.Mock
     }
 
-    expect(() => text.subWorldDraw(renderer as never)).toThrow(
-      'No valid text style found in text style table.'
-    )
-    expect(renderer.mtext).not.toHaveBeenCalled()
+    expect(() => text.subWorldDraw(renderer as never)).not.toThrow()
+    expect(renderer.mtext).toHaveBeenCalled()
+    expect(text.database.tables.textStyleTable.getAt('Standard')).toBeDefined()
   })
 
   it('writes expected DXF fields for text entity', () => {

--- a/packages/data-model/__tests__/AcDbTextStyleResolve.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextStyleResolve.spec.ts
@@ -1,0 +1,161 @@
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+import { AcDbText } from '../src/entity/AcDbText'
+import type { AcGiTextStyle } from '@mlightcad/graphic-interface'
+
+function encodeUtf8(text: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(text)
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer
+}
+
+function makeTextStyle(name: string, font = 'Arial'): AcGiTextStyle {
+  return {
+    name,
+    standardFlag: 0,
+    fixedTextHeight: 0,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: 0.2,
+    font,
+    bigFont: '',
+    extendedFont: font
+  }
+}
+
+const MINIMAL_DXF_NO_STYLE_TABLE = `0
+SECTION
+2
+HEADER
+9
+$ACADVER
+1
+AC1015
+9
+$TEXTSTYLE
+7
+STANDARD
+0
+ENDSEC
+0
+SECTION
+2
+TABLES
+0
+TABLE
+2
+LAYER
+70
+1
+0
+LAYER
+2
+0
+70
+0
+62
+7
+6
+CONTINUOUS
+0
+ENDTAB
+0
+TABLE
+2
+LTYPE
+70
+1
+0
+LTYPE
+2
+CONTINUOUS
+70
+0
+3
+Solid
+72
+65
+73
+0
+40
+0
+0
+ENDTAB
+0
+ENDSEC
+0
+SECTION
+2
+ENTITIES
+0
+TEXT
+8
+0
+10
+0
+20
+0
+30
+0
+40
+2.5
+1
+Hello
+7
+STANDARD
+0
+ENDSEC
+0
+EOF
+`
+
+describe('text style resolution', () => {
+  it('loads TEXT referencing STANDARD when STYLE table is missing', async () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    await db.read(encodeUtf8(MINIMAL_DXF_NO_STYLE_TABLE), {
+      readOnly: true,
+      minimumChunkSize: 1
+    })
+
+    const texts = [
+      ...db.tables.blockTable.modelSpace.newIterator()
+    ] as AcDbText[]
+    expect(texts).toHaveLength(1)
+    expect(texts[0].styleName).toBe('STANDARD')
+
+    const renderer = { mtext: jest.fn(() => ({})) }
+    expect(() => texts[0].subWorldDraw(renderer as never)).not.toThrow()
+    expect(renderer.mtext).toHaveBeenCalled()
+  })
+
+  it('resolves text styles before database defaults run at end of read', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const text = new AcDbText()
+    text.textString = 'Hello'
+    text.styleName = 'STANDARD'
+    db.tables.blockTable.modelSpace.appendEntity(text)
+
+    const renderer = { mtext: jest.fn(() => ({})) }
+    expect(() => text.subWorldDraw(renderer as never)).not.toThrow()
+    expect(renderer.mtext).toHaveBeenCalled()
+    expect(db.tables.textStyleTable.getAt('Standard')).toBeDefined()
+  })
+
+  it('matches text styles case-insensitively', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    db.tables.textStyleTable.add(
+      new AcDbTextStyleTableRecord(makeTextStyle('STANDARD', 'Arial'))
+    )
+
+    const resolved = db.tables.textStyleTable.resolveAt('standard')
+    expect(resolved?.name).toBe('STANDARD')
+  })
+})

--- a/packages/data-model/__tests__/AcDbTextStyleTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextStyleTable.spec.ts
@@ -1,6 +1,7 @@
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbTextStyleTable } from '../src/database/AcDbTextStyleTable'
 import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
 import type { AcGiTextStyle } from '@mlightcad/graphic-interface'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
@@ -46,5 +47,15 @@ describe('AcDbTextStyleTable', () => {
     const db = new AcDbDatabase()
     const table = db.tables.textStyleTable
     expect(table.fonts).toEqual([])
+  })
+
+  it('resolveAt creates and returns the default style when the table is empty', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    const table = db.tables.textStyleTable
+
+    const resolved = table.resolveAt('STANDARD')
+    expect(resolved?.name).toBe('Standard')
+    expect(table.getAt('Standard')).toBeDefined()
   })
 })

--- a/packages/data-model/__tests__/AcDbTrace.spec.ts
+++ b/packages/data-model/__tests__/AcDbTrace.spec.ts
@@ -1,4 +1,8 @@
-import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import {
+  AcGeArea2d,
+  AcGeMatrix3d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
@@ -88,6 +92,36 @@ describe('AcDbTrace', () => {
       otherSnaps
     )
     expect(otherSnaps).toHaveLength(0)
+  })
+
+  it('orders DXF solid corners as a perimeter loop when drawing', () => {
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, { x: 0, y: 0, z: 0 })
+    trace.setPointAt(1, { x: 10, y: 0, z: 0 })
+    trace.setPointAt(2, { x: 0, y: 5, z: 0 })
+    trace.setPointAt(3, { x: 10, y: 5, z: 0 })
+
+    let capturedArea: AcGeArea2d | undefined
+    const renderer = {
+      subEntityTraits: { fillType: undefined as unknown },
+      area: jest.fn((area: AcGeArea2d) => {
+        capturedArea = area
+        return { id: 'trace-area' }
+      })
+    }
+
+    trace.subWorldDraw(renderer as never)
+
+    expect(renderer.area).toHaveBeenCalledTimes(1)
+    const boundary = capturedArea!.getPoints(4)[0]
+    expect(boundary).toHaveLength(5)
+    expect(boundary.map(point => [point.x, point.y])).toEqual([
+      [0, 0],
+      [10, 0],
+      [10, 5],
+      [0, 5],
+      [0, 0]
+    ])
   })
 
   it('transforms itself and draws as filled area', () => {

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -853,6 +853,7 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         })
       }
     }
+    db.ensureTextStyleDefaults()
   }
 
   /**

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -1632,6 +1632,51 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
+   * Ensures the default text style exists in the text style table.
+   *
+   * This is invoked while converting STYLE records and again after a drawing
+   * is fully opened so TEXT/MTEXT entities can resolve a style during
+   * progressive rendering.
+   */
+  ensureTextStyleDefaults() {
+    if (this.hasDefaultTextStyle()) {
+      return
+    }
+
+    this.tables.textStyleTable.add(
+      new AcDbTextStyleTableRecord({
+        name: DEFAULT_TEXT_STYLE,
+        standardFlag: 0,
+        fixedTextHeight: 0,
+        widthFactor: 1,
+        obliqueAngle: 0,
+        textGenerationFlag: 0,
+        lastHeight: 0.2,
+        font: 'SimKai',
+        bigFont: '',
+        extendedFont: 'SimKai'
+      })
+    )
+  }
+
+  private hasDefaultTextStyle() {
+    const defaultNames = [DEFAULT_TEXT_STYLE, 'STANDARD']
+    for (const name of defaultNames) {
+      if (this.tables.textStyleTable.has(name)) {
+        return true
+      }
+    }
+
+    for (const record of this.tables.textStyleTable.newIterator()) {
+      if (record.name.toUpperCase() === DEFAULT_TEXT_STYLE.toUpperCase()) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
    * Ensures required default database data exists.
    *
    * This is used after opening a file (or before exporting) to fill in any
@@ -1686,22 +1731,7 @@ export class AcDbDatabase extends AcDbObject {
       )
     }
 
-    if (!this.tables.textStyleTable.has(DEFAULT_TEXT_STYLE)) {
-      this.tables.textStyleTable.add(
-        new AcDbTextStyleTableRecord({
-          name: DEFAULT_TEXT_STYLE,
-          standardFlag: 0,
-          fixedTextHeight: 0,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 0.2,
-          font: 'SimKai',
-          bigFont: '',
-          extendedFont: 'SimKai'
-        })
-      )
-    }
+    this.ensureTextStyleDefaults()
 
     if (!this.tables.dimStyleTable.has(DEFAULT_TEXT_STYLE)) {
       this.tables.dimStyleTable.add(

--- a/packages/data-model/src/database/AcDbTextStyleTable.ts
+++ b/packages/data-model/src/database/AcDbTextStyleTable.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TEXT_STYLE } from '../misc'
 import { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSymbolTable } from './AcDbSymbolTable'
 import { AcDbTextStyleTableRecord } from './AcDbTextStyleTableRecord'
@@ -47,6 +48,52 @@ export class AcDbTextStyleTable extends AcDbSymbolTable<AcDbTextStyleTableRecord
    * // Output: ['arial', 'times', 'calibri', ...]
    * ```
    */
+  /**
+   * Resolves a text style table record using AutoCAD-style fallbacks.
+   *
+   * Lookup order:
+   * 1. Exact style name on the entity
+   * 2. Current `$TEXTSTYLE` system variable
+   * 3. Default style names (`Standard`, `STANDARD`)
+   * 4. Case-insensitive match for each candidate above
+   * 5. First available style in the table
+   *
+   * Ensures a default text style exists before resolving so entities can be
+   * rendered while a drawing is still being converted.
+   */
+  resolveAt(name?: string): AcDbTextStyleTableRecord | undefined {
+    this.database.ensureTextStyleDefaults()
+
+    const candidates: string[] = []
+    const addCandidate = (value?: string) => {
+      const trimmed = value?.trim()
+      if (trimmed && !candidates.includes(trimmed)) {
+        candidates.push(trimmed)
+      }
+    }
+
+    addCandidate(name)
+    addCandidate(this.database.textstyle)
+    addCandidate(DEFAULT_TEXT_STYLE)
+    addCandidate('STANDARD')
+
+    for (const candidate of candidates) {
+      const exact = this.getAt(candidate)
+      if (exact) {
+        return exact
+      }
+
+      const normalizedCandidate = candidate.toUpperCase()
+      for (const record of this.newIterator()) {
+        if (record.name.toUpperCase() === normalizedCandidate) {
+          return record
+        }
+      }
+    }
+
+    return this.newIterator().next().value ?? undefined
+  }
+
   get fonts() {
     const fonts = new Set<string>()
     const setFontName = (fontFileName: string) => {

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -24,8 +24,7 @@ import { AcDbDxfFiler } from '../base'
 import {
   AcDbRenderingCache,
   decodeMLeaderStyleRawColor,
-  DEFAULT_MLEADER_STYLE,
-  DEFAULT_TEXT_STYLE
+  DEFAULT_MLEADER_STYLE
 } from '../misc'
 import { AcDbMLeaderStyle } from '../object'
 import { AcDbEntity } from './AcDbEntity'
@@ -2357,12 +2356,9 @@ export class AcDbMLeader extends AcDbEntity {
    * @returns A valid text style object.
    */
   private getTextStyle(): AcGiTextStyle {
-    const textStyleTable = this.database.tables.textStyleTable
-    const textStyleName = this.getResolvedTextStyleName()
-    const style =
-      (textStyleName ? textStyleTable.getAt(textStyleName) : undefined) ??
-      textStyleTable.getAt(this.database.textstyle) ??
-      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
+    const style = this.database.tables.textStyleTable.resolveAt(
+      this.getResolvedTextStyleName()
+    )
 
     if (!style) {
       throw new Error('No valid text style found in text style table.')

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -14,7 +14,7 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode, DEFAULT_TEXT_STYLE } from '../misc'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 
@@ -619,11 +619,7 @@ export class AcDbMText extends AcDbEntity {
   }
 
   private getTextStyle(): AcGiTextStyle {
-    const textStyleTable = this.database.tables.textStyleTable
-    const style =
-      textStyleTable.getAt(this.styleName) ??
-      textStyleTable.getAt(this.database.textstyle) ??
-      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
+    const style = this.database.tables.textStyleTable.resolveAt(this.styleName)
 
     if (!style) {
       throw new Error('No valid text style found in text style table.')

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -15,7 +15,6 @@ import {
 
 import { AcDbDxfFiler } from '../base'
 import type { AcDbBlockTableRecord } from '../database'
-import { DEFAULT_TEXT_STYLE } from '../misc'
 import { AcDbBlockReference } from './AcDbBlockReference'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 
@@ -700,11 +699,7 @@ export class AcDbTable extends AcDbBlockReference {
    * @private
    */
   private getTextStyle(cell: AcDbTableCell): AcGiTextStyle {
-    const textStyleTable = this.database.tables.textStyleTable
-    const style =
-      (cell.textStyle ? textStyleTable.getAt(cell.textStyle) : undefined) ??
-      textStyleTable.getAt(this.database.textstyle) ??
-      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
+    const style = this.database.tables.textStyleTable.resolveAt(cell.textStyle)
     if (!style) {
       throw new Error('No valid text style found in text style table.')
     }

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -15,7 +15,7 @@ import {
 } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode, DEFAULT_TEXT_STYLE } from '../misc'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 
@@ -701,11 +701,7 @@ export class AcDbText extends AcDbEntity {
    * ```
    */
   protected getTextStyle(): AcGiTextStyle {
-    const textStyleTable = this.database.tables.textStyleTable
-    const style =
-      textStyleTable.getAt(this.styleName) ??
-      textStyleTable.getAt(this.database.textstyle) ??
-      textStyleTable.getAt(DEFAULT_TEXT_STYLE)
+    const style = this.database.tables.textStyleTable.resolveAt(this.styleName)
     if (!style) {
       throw new Error('No valid text style found in text style table.')
     }

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -284,7 +284,10 @@ export class AcDbTrace extends AcDbCurve {
    * @returns The rendered trace entity, or undefined if drawing failed
    */
   subWorldDraw(renderer: AcGiRenderer) {
-    const polyline = new AcGePolyline2d(this._vertices, true)
+    const polyline = new AcGePolyline2d(
+      AcDbTrace.boundaryPointsFromVertices(this._vertices),
+      true
+    )
     const area = new AcGeArea2d()
     area.add(polyline)
 
@@ -355,6 +358,27 @@ export class AcDbTrace extends AcDbCurve {
    * @returns XY boundary vertices
    */
   private collectBoundary2d(): AcGePoint2d[] {
-    return this._vertices.map(vertex => new AcGePoint2d(vertex.x, vertex.y))
+    return AcDbTrace.boundaryPointsFromVertices(this._vertices)
+  }
+
+  /**
+   * Builds the closed 2D boundary for TRACE/SOLID entities.
+   *
+   * DXF stores corners 10–13 as two opposite edges (1–2 and 3–4), not as a
+   * sequential perimeter. The filled outline follows 1 → 2 → 4 → 3.
+   */
+  static boundaryPointsFromVertices(
+    vertices: ReadonlyArray<AcGePoint3dLike>
+  ): AcGePoint2d[] {
+    const v0 = vertices[0]
+    const v1 = vertices[1]
+    const v2 = vertices[2]
+    const v3 = vertices[3]
+    return [
+      new AcGePoint2d(v0.x, v0.y),
+      new AcGePoint2d(v1.x, v1.y),
+      new AcGePoint2d(v3.x, v3.y),
+      new AcGePoint2d(v2.x, v2.y)
+    ]
   }
 }

--- a/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
+++ b/packages/libdxfrw-converter/src/AcDbLibdxfrwConverter.ts
@@ -147,6 +147,7 @@ export class AcDbLibdxfrwConverter extends AcDbDatabaseConverter<DRW_Database> {
         db.tables.textStyleTable.add(record)
       }
     }
+    db.ensureTextStyleDefaults()
   }
 
   protected processDimStyles(model: DRW_Database, db: AcDbDatabase) {

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -206,6 +206,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       this.processCommonTableEntryAttrs(item, record)
       db.tables.textStyleTable.add(record)
     })
+    db.ensureTextStyleDefaults()
   }
 
   protected processDimStyles(model: DwgDatabase, db: AcDbDatabase) {


### PR DESCRIPTION
## Summary

This PR improves text rendering reliability during progressive DXF/DWG conversion and fixes incorrect fill geometry for TRACE/SOLID entities.

- **Centralized text style resolution** — Adds `AcDbTextStyleTable.resolveAt()` with AutoCAD-style fallback lookup (entity style → `$TEXTSTYLE` → `Standard`/`STANDARD` → case-insensitive match → first available style).
- **Default style bootstrap** — Extracts `AcDbDatabase.ensureTextStyleDefaults()` so a `Standard` text style is created when missing, and invokes it after STYLE table conversion in the DXF, libdxfrw, and libredwg converters.
- **Entity updates** — `AcDbText`, `AcDbMText`, `AcDbTable`, and `AcDbMLeader` now use `resolveAt()` instead of duplicating lookup logic, allowing TEXT/MTEXT entities to render while a drawing is still being opened.
- **TRACE/SOLID fix** — Corrects boundary vertex ordering for filled TRACE/SOLID entities. DXF stores corners as two opposite edges (1–2 and 3–4); the closed perimeter should follow **1 → 2 → 4 → 3**, not 1 → 2 → 3 → 4.

## Motivation

When drawings are loaded incrementally, TEXT/MTEXT entities can be parsed before the STYLE table is fully populated. Previously, style lookup could fail and throw during `subWorldDraw`. Ensuring defaults and resolving styles with fallbacks matches AutoCAD behavior and enables progressive rendering.

Separately, TRACE/SOLID fills were drawn with a bow-tie polygon because corner vertices were connected sequentially instead of following the DXF perimeter convention.

## Changes

| Area | Change |
|------|--------|
| `AcDbTextStyleTable` | New `resolveAt()` method with fallback chain |
| `AcDbDatabase` | New `ensureTextStyleDefaults()`; reused in `ensureDefaults()` |
| Converters | Call `ensureTextStyleDefaults()` after processing text styles |
| Text entities | Replace inline style lookup with `resolveAt()` |
| `AcDbTrace` | New `boundaryPointsFromVertices()`; use correct perimeter order for fill and boundary collection |

## Test plan

- [x] `AcDbTextStyleResolve.spec.ts` — TEXT with missing STYLE table, early render before defaults, case-insensitive resolution
- [x] `AcDbTextStyleTable.spec.ts` — `resolveAt()` creates default style on empty table
- [x] `AcDbText.spec.ts` / `AcDbMText.spec.ts` — rendering succeeds and creates `Standard` when table is empty
- [x] `AcDbTable.spec.ts` — updated to mock `resolveAt` instead of `getAt`
- [x] `AcDbTrace.spec.ts` — verifies DXF solid corners form a correct rectangular perimeter loop
- [ ] Load a DXF/DWG with TEXT/MTEXT and confirm text renders during progressive open
- [ ] Verify TRACE/SOLID filled regions no longer appear as bow-tie shapes