### PR TITLE
feat(data-model): replace WHITEBKCOLOR with MODELBKCOLOR and PAPERBKCOLOR

### DIFF
--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -439,6 +439,20 @@ export class AcDbSysVarManager {
       })()
     })
     /**
+     * Background color of the model-space drawing area.
+     * Default: RGB(0, 0, 0)
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.MODELBKCOLOR,
+      type: 'color',
+      isDbVar: false,
+      defaultValue: (() => {
+        const c = new AcCmColor(AcCmColorMethod.ByColor)
+        c.setRGB(0, 0, 0)
+        return c
+      })()
+    })
+    /**
      * Running Object Snap (OSNAP) modes stored as a bitcode value.
      * Each snap type corresponds to a bit, and the values are added together.
      */
@@ -447,6 +461,20 @@ export class AcDbSysVarManager {
       type: 'number',
       isDbVar: true,
       defaultValue: 0
+    })
+    /**
+     * Background color of the paper-space (layout) drawing area.
+     * Default: RGB(255, 255, 255)
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.PAPERBKCOLOR,
+      type: 'color',
+      isDbVar: false,
+      defaultValue: (() => {
+        const c = new AcCmColor(AcCmColorMethod.ByColor)
+        c.setRGB(255, 255, 255)
+        return c
+      })()
     })
     /**
      * Represents the half-size of the pickbox in pixels
@@ -486,17 +514,6 @@ export class AcDbSysVarManager {
       type: 'number',
       isDbVar: true,
       defaultValue: 0
-    })
-    this.registerVar({
-      /**
-       * The flag whether the background color is white
-       * - false: black
-       * - true: white
-       */
-      name: AcDbSystemVariables.WHITEBKCOLOR,
-      type: 'boolean',
-      isDbVar: false,
-      defaultValue: false
     })
   }
 

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -95,8 +95,12 @@ export const AcDbSystemVariables = {
   MEASUREMENT: 'MEASUREMENT',
   /** Color used for measurement tool overlays (distance, area, arc). */
   MEASUREMENTCOLOR: 'MEASUREMENTCOLOR',
+  /** Background color of the model-space drawing area. */
+  MODELBKCOLOR: 'MODELBKCOLOR',
   /** Running object snap mode bitmask (OSNAP settings). */
   OSMODE: 'OSMODE',
+  /** Background color of the paper-space (layout) drawing area. */
+  PAPERBKCOLOR: 'PAPERBKCOLOR',
   /** Point display style bitmask that controls how POINT entities are drawn. */
   PDMODE: 'PDMODE',
   /** Point display size, expressed as an absolute value or viewport percentage. */
@@ -111,9 +115,7 @@ export const AcDbSystemVariables = {
    * Controls feet-inch and fractional display delimiters together with **LUNITS**
    * (`0` = report format, `1` = input format).
    */
-  UNITMODE: 'UNITMODE',
-  /** Flag indicating whether the drawing background should be rendered as white. */
-  WHITEBKCOLOR: 'WHITEBKCOLOR'
+  UNITMODE: 'UNITMODE'
 } as const
 
 /**


### PR DESCRIPTION
## Summary

Replace the boolean `WHITEBKCOLOR` system variable with two color-typed variables for independent control of drawing-area backgrounds:

- **`MODELBKCOLOR`** — background color for model space (default: `RGB(0, 0, 0)`)
- **`PAPERBKCOLOR`** — background color for paper space / layouts (default: `RGB(255, 255, 255)`)

Both variables are session-scoped (`isDbVar: false`), use the existing `color` sysvar type, and dispatch `sysVarChanged` events on update — consistent with `MEASUREMENTCOLOR`.

`WHITEBKCOLOR` is removed. It was a boolean toggle (`false` = black, `true` = white) and could not express separate model/paper space colors or arbitrary RGB values.

## Motivation

Viewers and UI integrations need explicit, per-space background colors rather than a single white/black flag. Color-typed sysvars also support the same string formats already used elsewhere (`'red'`, `'RGB:10,20,30'`, etc.).

## Changes

- `AcDbSystemVariables.ts`: add `MODELBKCOLOR` and `PAPERBKCOLOR`; remove `WHITEBKCOLOR`
- `AcDbSysVarManager.ts`: register both new variables with defaults; remove `WHITEBKCOLOR` registration

## Breaking changes

- `WHITEBKCOLOR` is no longer available. Callers should migrate to:
  - `MODELBKCOLOR` for model-space background
  - `PAPERBKCOLOR` for layout/paper-space background

## Test plan

- [x] `pnpm test -- packages/data-model/__tests__/AcDbSysVarManager.spec.ts`
- [ ] Verify viewer/UI reads `MODELBKCOLOR` / `PAPERBKCOLOR` and applies the correct background per space
- [ ] Confirm `setVar` accepts color strings (e.g. `'RGB:33,33,33'`, `'white'`) and fires `sysVarChanged`