### PR TITLE
feat(data-model): extend object snap support across entities and add ORTHOMODE

### DIFF
--- a/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
@@ -83,7 +83,7 @@ describe('AcDb2dPolyline', () => {
     expect(ext.max).toMatchObject({ x: 3, y: 2, z: 7 })
   })
 
-  it('returns grip points and osnap points for endpoint mode only', () => {
+  it('returns grip points and osnap points for supported modes', () => {
     const polyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
       { x: 0, y: 0, z: 0 },
       { x: 2, y: 0, z: 0 },
@@ -103,14 +103,60 @@ describe('AcDb2dPolyline', () => {
     )
     expect(endpointSnaps).toHaveLength(3)
 
-    const otherModeSnaps: AcGePoint3d[] = []
+    const midPoints: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(
       AcDbOsnapMode.MidPoint,
       new AcGePoint3d(),
       new AcGePoint3d(),
-      otherModeSnaps
+      midPoints
     )
-    expect(otherModeSnaps).toHaveLength(0)
+    expect(midPoints).toHaveLength(2)
+    expect(midPoints[0]).toMatchObject({ x: 1, y: 0, z: 0 })
+    expect(midPoints[1]).toMatchObject({ x: 2, y: 1, z: 0 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 1, y: 0, z: 0 })
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 1, y: 0, z: 0 })
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
+  })
+
+  it('returns grip points at polyline elevation', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 2, y: 0, z: 0 }
+      ],
+      5
+    )
+    const grips = polyline.subGetGripPoints()
+    expect(grips).toHaveLength(2)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 5 })
+    expect(grips[1]).toMatchObject({ x: 2, y: 0, z: 5 })
   })
 
   it('transforms geometry and flips bulges for mirrored transform', () => {

--- a/packages/data-model/__tests__/AcDb2dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dVertex.spec.ts
@@ -62,6 +62,24 @@ describe('AcDb2dVertex', () => {
     )
     expect(snapPoints).toHaveLength(1)
     expect(snapPoints[0]).toBe(vertex.position)
+
+    const nodeSnaps: AcGePoint3d[] = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 1, 1),
+      nodeSnaps
+    )
+    expect(nodeSnaps).toHaveLength(1)
+
+    const unsupportedSnaps: AcGePoint3d[] = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 1, 1),
+      unsupportedSnaps
+    )
+    expect(unsupportedSnaps).toHaveLength(0)
   })
 
   it('transforms position and returns itself', () => {

--- a/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
@@ -52,8 +52,8 @@ describe('AcDb3dPolyline', () => {
 
     const grips = polyline.subGetGripPoints()
     expect(grips).toHaveLength(3)
-    expect(grips[0]).toMatchObject({ x: -1, y: 2, z: 0 })
-    expect(grips[2]).toMatchObject({ x: 0, y: 1, z: 0 })
+    expect(grips[0]).toMatchObject({ x: -1, y: 2, z: 3 })
+    expect(grips[2]).toMatchObject({ x: 0, y: 1, z: -2 })
 
     const endPoints: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(
@@ -65,14 +65,34 @@ describe('AcDb3dPolyline', () => {
     expect(endPoints).toHaveLength(3)
     expect(endPoints[1]).toMatchObject({ x: 4, y: -5, z: 0 })
 
-    const nonEndPoints: AcGePoint3d[] = []
+    const midPoints: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(
       AcDbOsnapMode.MidPoint,
       new AcGePoint3d(),
       new AcGePoint3d(),
-      nonEndPoints
+      midPoints
     )
-    expect(nonEndPoints).toHaveLength(0)
+    expect(midPoints).toHaveLength(2)
+    expect(midPoints[0]).toMatchObject({ x: 1.5, y: -1.5, z: 1.5 })
+    expect(midPoints[1]).toMatchObject({ x: 2, y: -2, z: -1 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      unsupportedPoints
+    )
+    expect(unsupportedPoints).toHaveLength(0)
   })
 
   it('transforms vertices and returns itself for chaining', () => {

--- a/packages/data-model/__tests__/AcDb3dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dVertex.spec.ts
@@ -69,6 +69,15 @@ describe('AcDb3dVertex', () => {
     expect(snapPoints).toHaveLength(1)
     expect(snapPoints[0]).toBe(vertex.position)
     expect(snapPoints[0]).toMatchObject({ x: -1, y: 2.5, z: 3 })
+
+    const unsupportedSnaps: Array<{ x: number; y: number; z: number }> = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1 },
+      unsupportedSnaps
+    )
+    expect(unsupportedSnaps).toHaveLength(0)
   })
 
   it('transforms position by matrix and returns itself', () => {

--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -196,9 +196,19 @@ describe('AcDbArc', () => {
     )
     expect(tangentPoints).toEqual([tangentA, tangentB])
 
-    const unsupportedPoints: AcGePoint3d[] = []
+    const centerPoints: AcGePoint3d[] = []
     arc.subGetOsnapPoints(
       AcDbOsnapMode.Center,
+      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(),
+      centerPoints
+    )
+    expect(centerPoints).toHaveLength(1)
+    expect(centerPoints[0]).toBe(arc.center)
+
+    const unsupportedPoints: AcGePoint3d[] = []
+    arc.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
       new AcGePoint3d(9, 9, 0),
       new AcGePoint3d(),
       unsupportedPoints

--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -144,6 +144,15 @@ describe('AcDbBlockReference', () => {
     expect(infiniteLoopGuardSnaps).toHaveLength(0)
   })
 
+  it('returns insertion point as grip point', () => {
+    createDb()
+    const insert = new AcDbBlockReference('*Model_Space')
+    insert.position = new AcGePoint3d(11, 12, 13)
+    const grips = insert.subGetGripPoints()
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(insert.position)
+  })
+
   it('transforms pick point to block space before querying sub-entity osnap', () => {
     const db = createDb()
     const block = createNamedBlock(db, 'TEST_BLOCK')

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -132,6 +132,16 @@ describe('AcDbEllipse', () => {
     )
     expect(midPoints).toHaveLength(1)
 
+    const centerPoints: AcGePoint3d[] = []
+    closedEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Center,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      centerPoints
+    )
+    expect(centerPoints).toHaveLength(1)
+    expect(centerPoints[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+
     const quadrantPoints: AcGePoint3d[] = []
     closedEllipse.subGetOsnapPoints(
       AcDbOsnapMode.Quadrant,
@@ -141,9 +151,19 @@ describe('AcDbEllipse', () => {
     )
     expect(quadrantPoints).toHaveLength(4)
 
+    const nearestPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(10, 0, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0].x).toBeCloseTo(6, 5)
+
     const unsupportedPoints: AcGePoint3d[] = []
-    closedEllipse.subGetOsnapPoints(
-      AcDbOsnapMode.Center,
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
       new AcGePoint3d(1, 1, 0),
       new AcGePoint3d(),
       unsupportedPoints
@@ -158,6 +178,26 @@ describe('AcDbEllipse', () => {
       openQuadrantPoints
     )
     expect(openQuadrantPoints).toHaveLength(0)
+  })
+
+  it('returns grip points for center, start, and end parameter points', () => {
+    createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(1, 2, 3),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0,
+      Math.PI / 2
+    )
+    const grips = ellipse.subGetGripPoints()
+    expect(grips).toHaveLength(3)
+    expect(grips[0]).toBe(ellipse.center)
+    expect(grips[1]).toMatchObject({ x: 6, y: 2, z: 3 })
+    expect(grips[2].x).toBeCloseTo(1, 10)
+    expect(grips[2].y).toBeCloseTo(4, 10)
+    expect(grips[2].z).toBeCloseTo(3, 10)
   })
 
   it('exposes runtime properties and accessors', () => {

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_HATCH_PATTERN_IMPERIAL,
   HATCH_PATTERN_SOLID
 } from '../src/misc'
+import { AcDbOsnapMode } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const createWorkingDb = () => {
@@ -350,6 +351,31 @@ describe('AcDbHatch', () => {
     expect(hatch.patternAngle).toBeCloseTo(Math.PI / 6)
     expect(hatch.patternScale).toBeCloseTo(3.25)
     expect(hatch.elevation).toBe(6)
+  })
+
+  it('computes osnap points on hatch boundary loops', () => {
+    const hatch = new AcDbHatch()
+    hatch.add(createRectLoop(0, 0, 10, 5))
+    hatch.elevation = 2
+
+    const endPoints: Array<{ x: number; y: number; z: number }> = []
+    hatch.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      endPoints
+    )
+    expect(endPoints.length).toBeGreaterThanOrEqual(4)
+
+    const nearestPoints: Array<{ x: number; y: number; z: number }> = []
+    hatch.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      { x: 5, y: 6, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 5, y: 5, z: 2 })
   })
 
   it('draws empty/single/multi hatch areas and applies fill traits', () => {

--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -8,6 +8,7 @@ import {
   AcDbPolyline
 } from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+import { AcDbOsnapMode } from '../src/misc'
 
 const createWorkingDb = () => {
   const db = new AcDbDatabase()
@@ -62,6 +63,17 @@ describe('AcDbLeader', () => {
     const exported = leader.vertices
     exported[0].x = 999
     expect(leader.vertices[0].x).toBe(0)
+  })
+
+  it('returns all leader vertices as grip points', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(5, 5, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    const grips = leader.subGetGripPoints()
+    expect(grips).toHaveLength(3)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(grips[2]).toMatchObject({ x: 10, y: 5, z: 0 })
   })
 
   it('supports setVertexAt and vertexAt with range checking', () => {
@@ -198,5 +210,56 @@ describe('AcDbLeader', () => {
     leader.appendVertex(new AcGePoint3d(10, 5, 0))
     const [result] = leader.getOffsetCurves(2) as AcDbPolyline[]
     expect(result.numberOfVertices).toBeGreaterThanOrEqual(2)
+  })
+
+  it('computes osnap points for straight and splined leaders', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(4, 0, 0))
+    leader.appendVertex(new AcGePoint3d(4, 3, 0))
+
+    const endPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(3)
+
+    const midPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(2)
+    expect(midPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
+    expect(midPoints[1]).toMatchObject({ x: 4, y: 1.5, z: 0 })
+
+    leader.appendVertex(new AcGePoint3d(6, 1, 0))
+    leader.appendVertex(new AcGePoint3d(8, 0, 0))
+    leader.isSplined = true
+
+    const splineEndPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      splineEndPoints
+    )
+    expect(splineEndPoints).toHaveLength(2)
+    expect(splineEndPoints[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(splineEndPoints[1]).toMatchObject({ x: 8, y: 0, z: 0 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(4, 2, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
   })
 })

--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -9,7 +9,7 @@ import {
   AcDbLinetypeTableRecord
 } from '../src/database'
 import { AcDbLine, AcDbMLeader } from '../src/entity'
-import { AcDbRenderingCache } from '../src/misc'
+import { AcDbOsnapMode, AcDbRenderingCache } from '../src/misc'
 import { AcDbMLeaderStyle } from '../src/object'
 
 const createWorkingDb = () => {
@@ -275,5 +275,37 @@ describe('AcDbMLeader arrowhead rendering', () => {
     mleader.worldDraw(renderer as never)
 
     expect(renderer.lines).toHaveBeenCalledTimes(2)
+  })
+
+  it('computes osnap points on leader lines and content insertion', () => {
+    const mleader = new AcDbMLeader()
+    mleader.contentBasePosition = new AcGePoint3d(10, 5, 0)
+    const leaderIndex = mleader.addLeader({
+      lastLeaderLinePoint: new AcGePoint3d(5, 0, 0),
+      lastLeaderLinePointSet: true
+    })
+    mleader.addLeaderLine(leaderIndex, [
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0)
+    ])
+
+    const endPoints: AcGePoint3d[] = []
+    mleader.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints.length).toBeGreaterThanOrEqual(2)
+
+    const insertionSnaps: AcGePoint3d[] = []
+    mleader.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      insertionSnaps
+    )
+    expect(insertionSnaps).toHaveLength(1)
+    expect(insertionSnaps[0]).toMatchObject({ x: 10, y: 5, z: 0 })
   })
 })

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -3,6 +3,7 @@ import { AcCmColor } from '@mlightcad/common'
 import { acdbHostApplicationServices } from '../src/base'
 import { AcDbDatabase, AcDbLinetypeTableRecord } from '../src/database'
 import { AcDbMLine, AcDbMLineJustification } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
 import { AcDbMlineStyle } from '../src/object'
 
 const createAciColor = (index: number) => {
@@ -68,6 +69,43 @@ const createBasicMline = (style: AcDbMlineStyle) => {
 }
 
 describe('AcDbMLine', () => {
+  it('computes osnap points on the reference path', () => {
+    const db = createDb()
+    const style = new AcDbMlineStyle()
+    style.styleName = 'OSNAP_STYLE'
+    style.elements = [
+      { offset: 0.5, color: createAciColor(3), lineType: 'BYLAYER' },
+      { offset: -0.5, color: createAciColor(5), lineType: 'BYLAYER' }
+    ]
+    db.objects.mlineStyle.setAt(style.styleName, style)
+
+    const mline = createBasicMline(style)
+    mline.startPosition = { x: 0, y: 0, z: 0 }
+
+    const endPoints: Array<{ x: number; y: number; z: number }> = []
+    mline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      endPoints
+    )
+    expect(endPoints).toHaveLength(3)
+    expect(endPoints[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(endPoints[1]).toMatchObject({ x: 10, y: 0, z: 0 })
+    expect(endPoints[2]).toMatchObject({ x: 20, y: 0, z: 0 })
+
+    const midPoints: Array<{ x: number; y: number; z: number }> = []
+    mline.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      midPoints
+    )
+    expect(midPoints).toHaveLength(2)
+    expect(midPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
+    expect(midPoints[1]).toMatchObject({ x: 15, y: 0, z: 0 })
+  })
+
   it('ensures database default mline style exists when appending a new MLINE', () => {
     const db = createDb()
     db.cmlstyle = 'AUTO_MLINE_STYLE'

--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -93,6 +93,15 @@ describe('AcDbMText', () => {
     expect(unsupportedPoints).toHaveLength(0)
   })
 
+  it('returns location as grip point', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(6, 7, 8)
+    const grips = mtext.subGetGripPoints()
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(mtext.location)
+  })
+
   it('transforms location, direction, width and height with non-zero direction', () => {
     createWorkingDb()
     const mtext = new AcDbMText()

--- a/packages/data-model/__tests__/AcDbPoint.spec.ts
+++ b/packages/data-model/__tests__/AcDbPoint.spec.ts
@@ -75,6 +75,15 @@ describe('AcDbPoint', () => {
     expect(unsupportedModePoints).toHaveLength(0)
   })
 
+  it('returns position as grip point', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 7, y: 8, z: 9 }
+    const grips = point.subGetGripPoints()
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(point.position)
+  })
+
   it('exposes geometry properties with editable accessors', () => {
     createWorkingDb()
     const point = new AcDbPoint()

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -87,7 +87,7 @@ describe('AcDbPolyline', () => {
     expect(extents.max).toMatchObject({ x: 3, y: 2, z: 6 })
   })
 
-  it('returns grip points and endpoint osnap points only', () => {
+  it('returns grip points and osnap points for supported modes', () => {
     const polyline = new AcDbPolyline()
     polyline.elevation = 2
     polyline.addVertexAt(0, new AcGePoint2d(0, 0))
@@ -109,6 +109,26 @@ describe('AcDbPolyline', () => {
       endpointSnaps
     )
     expect(endpointSnaps).toEqual(grips)
+
+    const midPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(2)
+    expect(midPoints[0]).toMatchObject({ x: 1, y: 0, z: 2 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 1, y: 0, z: 2 })
 
     const centerSnaps: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(

--- a/packages/data-model/__tests__/AcDbRasterImage.spec.ts
+++ b/packages/data-model/__tests__/AcDbRasterImage.spec.ts
@@ -8,6 +8,7 @@ import {
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
 import { AcDbRasterImage, AcDbRasterImageClipBoundaryType } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
 import { AcDbRasterImageDef } from '../src/object/AcDbRasterImageDef'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
@@ -147,6 +148,32 @@ describe('AcDbRasterImage', () => {
     const clipped = image.subGetGripPoints()
     expect(clipped.length).toBe(4)
     expect(clipped[0].z).toBe(0)
+  })
+
+  it('computes insertion and endpoint osnap points', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(3, 4, 0)
+    image.width = 10
+    image.height = 8
+
+    const insertionSnaps: AcGePoint3d[] = []
+    image.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      insertionSnaps
+    )
+    expect(insertionSnaps).toHaveLength(1)
+    expect(insertionSnaps[0]).toMatchObject({ x: 3, y: 4, z: 0 })
+
+    const endPoints: AcGePoint3d[] = []
+    image.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints.length).toBeGreaterThanOrEqual(4)
   })
 
   it('draws via renderer.lines when image data is absent and renderer.image when present', () => {

--- a/packages/data-model/__tests__/AcDbRay.spec.ts
+++ b/packages/data-model/__tests__/AcDbRay.spec.ts
@@ -102,6 +102,7 @@ describe('AcDbRay', () => {
   it('adds endpoint osnap for EndPoint mode and ignores unsupported modes', () => {
     const ray = new AcDbRay()
     ray.basePoint = new AcGePoint3d(9, 8, 7)
+    ray.unitDir = new AcGeVector3d(1, 0, 0)
     const endpointSnaps: AcGePoint3d[] = []
     const unsupportedSnaps: AcGePoint3d[] = []
 
@@ -120,6 +121,42 @@ describe('AcDbRay', () => {
 
     expect(endpointSnaps).toEqual([ray.basePoint])
     expect(unsupportedSnaps).toHaveLength(0)
+  })
+
+  it('computes nearest and perpendicular osnap points along the ray direction', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(0, 0, 0)
+    ray.unitDir = new AcGeVector3d(1, 0, 0)
+
+    const nearestPoints: AcGePoint3d[] = []
+    ray.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(5, 3, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
+
+    const behindNearestPoints: AcGePoint3d[] = []
+    ray.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(-4, 2, 0),
+      new AcGePoint3d(),
+      behindNearestPoints
+    )
+    expect(behindNearestPoints).toHaveLength(1)
+    expect(behindNearestPoints[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    ray.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(2, 4, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
   })
 
   it('transforms base point and direction and returns itself', () => {

--- a/packages/data-model/__tests__/AcDbSpline.spec.ts
+++ b/packages/data-model/__tests__/AcDbSpline.spec.ts
@@ -109,6 +109,30 @@ describe('AcDbSpline', () => {
     expect(unsupportedSnaps).toHaveLength(0)
   })
 
+  it('returns nearest osnap point on the spline curve', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const nearestPoints: AcGePoint3d[] = []
+
+    spline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(1.5, 2, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0].x).toBeGreaterThanOrEqual(0)
+    expect(nearestPoints[0].x).toBeLessThanOrEqual(3)
+  })
+
+  it('returns control vertices as grip points', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const grips = spline.subGetGripPoints()
+    expect(grips).toHaveLength(4)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(grips[3]).toMatchObject({ x: 3, y: 0, z: 0 })
+  })
+
   it('transforms by matrix and returns itself', () => {
     const spline = new AcDbSpline(controlPoints, knots)
     const before: AcGePoint3d[] = []

--- a/packages/data-model/__tests__/AcDbText.spec.ts
+++ b/packages/data-model/__tests__/AcDbText.spec.ts
@@ -92,6 +92,14 @@ describe('AcDbText', () => {
     expect(snapPoints[0]).toMatchObject({ x: 3, y: 4, z: 5 })
   })
 
+  it('returns insertion point as grip point', () => {
+    const text = new AcDbText()
+    text.position = new AcGePoint3d(3, 4, 5)
+    const grips = text.subGetGripPoints()
+    expect(grips).toHaveLength(1)
+    expect(grips[0]).toBe(text.position)
+  })
+
   it('transforms text with normal scale and rotation updates', () => {
     const text = new AcDbText()
     text.position = new AcGePoint3d(1, 0, 0)

--- a/packages/data-model/__tests__/AcDbXline.spec.ts
+++ b/packages/data-model/__tests__/AcDbXline.spec.ts
@@ -6,6 +6,7 @@ import {
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
 import { AcDbXline } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const createWorkingDb = () => {
@@ -105,6 +106,42 @@ describe('AcDbXline', () => {
     expect(gripPoints).toHaveLength(1)
     expect(gripPoints[0]).toBe(xline.basePoint)
     expect(gripPoints[0]).toMatchObject({ x: 7, y: 8, z: 9 })
+  })
+
+  it('computes osnap points for endpoint, nearest, and perpendicular modes', () => {
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(0, 0, 0)
+    xline.unitDir = new AcGeVector3d(1, 0, 0)
+
+    const endPoints: AcGePoint3d[] = []
+    xline.subGetOsnapPoints(
+      AcDbOsnapMode.EndPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      endPoints
+    )
+    expect(endPoints).toHaveLength(1)
+    expect(endPoints[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    xline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(-5, 4, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: -5, y: 0, z: 0 })
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    xline.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(2, 3, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
   })
 
   it('transforms itself and draws through renderer.lines', () => {

--- a/packages/data-model/src/converter/AcDbDxfConverter.ts
+++ b/packages/data-model/src/converter/AcDbDxfConverter.ts
@@ -525,6 +525,7 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
     if (header['$EXTMIN']) db.extmin = header['$EXTMIN']
     if (header['$INSUNITS'] != null) db.insunits = header['$INSUNITS']
     db.osmode = header['$OSMODE'] || 0
+    db.orthomode = header['$ORTHOMODE'] || 0
     db.pdmode = header['$PDMODE'] || 0
     db.pdsize = header['$PDSIZE'] || 0.0
     db.textstyle = header['$TEXTSTYLE'] || DEFAULT_TEXT_STYLE

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -361,6 +361,8 @@ export class AcDbDatabase extends AcDbObject {
   private _pdsize: number
   /** Running object snap mode bitmask */
   private _osmode: number
+  /** Orthogonal mode flag (ORTHOMODE): 0 = off, 1 = on */
+  private _orthomode: number
   /** Tables in the database */
   private _tables: AcDbTables
   /** Nongraphical objects in the database */
@@ -442,6 +444,7 @@ export class AcDbDatabase extends AcDbObject {
     this._pdmode = 0
     this._pdsize = 0
     this._osmode = 0
+    this._orthomode = 0
     this._maxHandle = 0
     this._tables = {
       appIdTable: new AcDbRegAppTable(this),
@@ -1331,6 +1334,24 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
+   * Orthogonal mode flag (ORTHOMODE). When on, cursor movement is constrained
+   * to horizontal or vertical relative to the current UCS.
+   */
+  get orthomode(): number {
+    return this._orthomode
+  }
+  set orthomode(value: number) {
+    this.updateSysVar(
+      AcDbSystemVariables.ORTHOMODE,
+      this._orthomode,
+      value ?? 0,
+      nextValue => {
+        this._orthomode = nextValue
+      }
+    )
+  }
+
+  /**
    * Reads drawing data from a string or ArrayBuffer.
    *
    * This method parses the provided data and populates the database with
@@ -1924,6 +1945,8 @@ export class AcDbDatabase extends AcDbObject {
     filer.writeDouble(40, this.pdsize)
     filer.writeString(9, '$OSMODE')
     filer.writeInt32(70, this.osmode)
+    filer.writeString(9, '$ORTHOMODE')
+    filer.writeInt16(70, this.orthomode)
     filer.endSection()
   }
 

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -463,6 +463,19 @@ export class AcDbSysVarManager {
       defaultValue: 0
     })
     /**
+     * Constrains cursor movement to the perpendicular (orthogonal locking).
+     * - `0`: Turns off Ortho mode
+     * - `1`: Turns on Ortho mode
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-CF142B68-675B-452F-B3A8-7831DDB71BD0-htm.html
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.ORTHOMODE,
+      type: 'number',
+      isDbVar: true,
+      defaultValue: 0
+    })
+    /**
      * Background color of the paper-space (layout) drawing area.
      * Default: RGB(255, 255, 255)
      */

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -99,6 +99,11 @@ export const AcDbSystemVariables = {
   MODELBKCOLOR: 'MODELBKCOLOR',
   /** Running object snap mode bitmask (OSNAP settings). */
   OSMODE: 'OSMODE',
+  /**
+   * Orthogonal mode flag: `0` = off, `1` = on. When on, cursor movement is
+   * constrained to horizontal or vertical relative to the current UCS.
+   */
+  ORTHOMODE: 'ORTHOMODE',
   /** Background color of the paper-space (layout) drawing area. */
   PAPERBKCOLOR: 'PAPERBKCOLOR',
   /** Point display style bitmask that controls how POINT entities are drawn. */

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -13,6 +13,10 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectPolyline2dSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 import { AcDbPolyline } from './AcDbPolyline'
 
 /**
@@ -225,7 +229,7 @@ export class AcDb2dPolyline extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     for (let i = 0; i < this._geo.numberOfVertices; ++i) {
       const temp = this._geo.getPointAt(i)
-      gripPoints.push(new AcGePoint3d(temp.x, temp.y, 0))
+      gripPoints.push(new AcGePoint3d(temp.x, temp.y, this._elevation))
     }
     return gripPoints
   }
@@ -244,19 +248,48 @@ export class AcDb2dPolyline extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
+    const geo = this._geo
+    const elevation = this._elevation
+    const vertexCount = geo.numberOfVertices
+    if (vertexCount === 0) return
+
     switch (osnapMode) {
       case AcDbOsnapMode.EndPoint:
-        {
-          for (let i = 0; i < this._geo.numberOfVertices; ++i) {
-            const temp = this._geo.getPointAt(i)
-            snapPoints.push(new AcGePoint3d(temp.x, temp.y, 0))
-          }
+        for (let index = 0; index < vertexCount; index++) {
+          const vertex = geo.getPointAt(index)
+          snapPoints.push(new AcGePoint3d(vertex.x, vertex.y, elevation))
         }
         break
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Nearest:
+      case AcDbOsnapMode.Perpendicular: {
+        const segmentCount = this.closed ? vertexCount : vertexCount - 1
+        const candidates: AcGePoint3d[] = []
+        for (let index = 0; index < segmentCount; index++) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectPolyline2dSegmentOsnapPoints(
+            geo.getPointAt(index),
+            geo.getPointAt((index + 1) % vertexCount),
+            geo.vertices[index]?.bulge,
+            elevation,
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          candidates.push(...segmentSnaps)
+        }
+        if (osnapMode === AcDbOsnapMode.MidPoint) {
+          snapPoints.push(...candidates)
+        } else {
+          const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+          if (nearest) snapPoints.push(nearest)
+        }
+        break
+      }
       default:
         break
     }

--- a/packages/data-model/src/entity/AcDb2dVertex.ts
+++ b/packages/data-model/src/entity/AcDb2dVertex.ts
@@ -200,12 +200,17 @@ export class AcDb2dVertex extends AcDbEntity {
    * @param snapPoints - Array to populate with snap points
    */
   subGetOsnapPoints(
-    _osnapMode: AcDbOsnapMode,
+    osnapMode: AcDbOsnapMode,
     _pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    snapPoints.push(this._position)
+    if (
+      osnapMode === AcDbOsnapMode.EndPoint ||
+      osnapMode === AcDbOsnapMode.Node
+    ) {
+      snapPoints.push(this._position)
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -13,6 +13,10 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectLineSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 import { AcDbPolyline } from './AcDbPolyline'
 
 /**
@@ -152,8 +156,7 @@ export class AcDb3dPolyline extends AcDbCurve {
   subGetGripPoints() {
     const gripPoints = new Array<AcGePoint3d>()
     for (let i = 0; i < this._geo.numberOfVertices; ++i) {
-      const temp = this._geo.getPointAt(i)
-      gripPoints.push(new AcGePoint3d(temp.x, temp.y, 0))
+      gripPoints.push(this.getPointAt(i))
     }
     return gripPoints
   }
@@ -172,18 +175,43 @@ export class AcDb3dPolyline extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
+    const vertices = Array.from(
+      { length: this._geo.numberOfVertices },
+      (_, i) => this.getPointAt(i)
+    )
+    if (vertices.length === 0) return
+
     switch (osnapMode) {
       case AcDbOsnapMode.EndPoint:
-        {
-          for (let i = 0; i < this._geo.numberOfVertices; ++i) {
-            snapPoints.push(this.getPointAt(i))
-          }
+        snapPoints.push(...vertices)
+        break
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Nearest:
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates: AcGePoint3d[] = []
+        for (let index = 0; index < vertices.length - 1; index++) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectLineSegmentOsnapPoints(
+            vertices[index],
+            vertices[index + 1],
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          candidates.push(...segmentSnaps)
+        }
+        if (osnapMode === AcDbOsnapMode.MidPoint) {
+          snapPoints.push(...candidates)
+        } else {
+          const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+          if (nearest) snapPoints.push(nearest)
         }
         break
+      }
       default:
         break
     }

--- a/packages/data-model/src/entity/AcDb3dVertex.ts
+++ b/packages/data-model/src/entity/AcDb3dVertex.ts
@@ -119,12 +119,17 @@ export class AcDb3dVertex extends AcDbEntity {
    * @param snapPoints - Array to populate with snap points
    */
   subGetOsnapPoints(
-    _osnapMode: AcDbOsnapMode,
+    osnapMode: AcDbOsnapMode,
     _pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    snapPoints.push(this._position)
+    if (
+      osnapMode === AcDbOsnapMode.EndPoint ||
+      osnapMode === AcDbOsnapMode.Node
+    ) {
+      snapPoints.push(this._position)
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -514,6 +514,21 @@ export class AcDbArc extends AcDbCurve {
       case AcDbOsnapMode.MidPoint:
         snapPoints.push(this.midPoint)
         break
+      case AcDbOsnapMode.Center:
+      case AcDbOsnapMode.Centroid:
+        snapPoints.push(this._geo.center)
+        break
+      case AcDbOsnapMode.Quadrant: {
+        const criticalAngles = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2]
+        for (const angle of criticalAngles) {
+          if (
+            AcGeMathUtil.isBetweenAngle(angle, this.startAngle, this.endAngle)
+          ) {
+            snapPoints.push(this._geo.getPointAtAngle(angle))
+          }
+        }
+        break
+      }
       case AcDbOsnapMode.Nearest:
         {
           const projectedPoint = this._geo.nearestPoint(pickPoint)

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -393,6 +393,15 @@ export class AcDbBlockReference extends AcDbEntity {
   }
 
   /**
+   * Gets the grip points for this block reference.
+   *
+   * @returns Array containing the block insertion point.
+   */
+  subGetGripPoints() {
+    return [this._position]
+  }
+
+  /**
    * Gets the object snap points for this block reference.
    *
    * Object snap points are precise points that can be used for positioning

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -319,6 +319,21 @@ export class AcDbEllipse extends AcDbCurve {
   }
 
   /**
+   * Gets the grip points for this ellipse.
+   *
+   * Grip points are the center and the start/end parameter points (for open arcs).
+   *
+   * @returns Array of grip points: [center, startPoint, endPoint]
+   */
+  subGetGripPoints() {
+    const gripPoints = new Array<AcGePoint3d>()
+    gripPoints.push(this._geo.center)
+    gripPoints.push(this._geo.startPoint)
+    gripPoints.push(this._geo.endPoint)
+    return gripPoints
+  }
+
+  /**
    * Gets the object snap points for this ellipse or ellipse arc.
    *
    * Object snap points are precise points that can be used for positioning
@@ -332,7 +347,7 @@ export class AcDbEllipse extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
@@ -348,6 +363,10 @@ export class AcDbEllipse extends AcDbCurve {
           snapPoints.push(this._geo.midPoint)
         }
         break
+      case AcDbOsnapMode.Center:
+      case AcDbOsnapMode.Centroid:
+        snapPoints.push(this._geo.center)
+        break
       case AcDbOsnapMode.Quadrant:
         if (this.closed) {
           snapPoints.push(this._geo.getPointAtAngle(0))
@@ -355,6 +374,9 @@ export class AcDbEllipse extends AcDbCurve {
           snapPoints.push(this._geo.getPointAtAngle(Math.PI))
           snapPoints.push(this._geo.getPointAtAngle((Math.PI / 2) * 3))
         }
+        break
+      case AcDbOsnapMode.Nearest:
+        snapPoints.push(this._geo.nearestPoint(pickPoint))
         break
       default:
         break

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -12,6 +12,7 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
+  AcGePoint3dLike,
   AcGePolyline2d,
   AcGeSpline3d
 } from '@mlightcad/geometry-engine'
@@ -24,6 +25,7 @@ import { AcDbDxfFiler } from '../base'
 import type { AcDbDatabase } from '../database/AcDbDatabase'
 import { AcDbSystemVariables } from '../database/AcDbSystemVariables'
 import { AcDbSysVarManager } from '../database/AcDbSysVarManager'
+import { AcDbOsnapMode } from '../misc'
 import {
   DEFAULT_GRADIENT_HATCH_NAME,
   HATCH_PATTERN_SOLID,
@@ -32,6 +34,10 @@ import {
 import { AcDbPredefinedAcadIsoPat } from '../misc/pat/AcDbPatPredefined'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectPolyline2dSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 
 /**
  * Defines the type of hatch pattern.
@@ -1069,6 +1075,127 @@ export class AcDbHatch extends AcDbEntity {
           ]
         }
       ]
+    }
+  }
+
+  /**
+   * Gets the object snap points for hatch boundary geometry.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    const elevation = this._elevation
+    const nearestCandidates: AcGePoint3d[] = []
+
+    this._geo.loops.forEach(loop => {
+      if (loop instanceof AcGePolyline2d) {
+        const geo = loop
+        const vertexCount = geo.numberOfVertices
+        if (vertexCount === 0) return
+
+        switch (osnapMode) {
+          case AcDbOsnapMode.EndPoint:
+            for (let index = 0; index < vertexCount; index++) {
+              const vertex = geo.getPointAt(index)
+              snapPoints.push(new AcGePoint3d(vertex.x, vertex.y, elevation))
+            }
+            break
+          case AcDbOsnapMode.MidPoint:
+          case AcDbOsnapMode.Nearest:
+          case AcDbOsnapMode.Perpendicular: {
+            const segmentCount = loop.closed ? vertexCount : vertexCount - 1
+            for (let index = 0; index < segmentCount; index++) {
+              const segmentSnaps: AcGePoint3d[] = []
+              acdbCollectPolyline2dSegmentOsnapPoints(
+                geo.getPointAt(index),
+                geo.getPointAt((index + 1) % vertexCount),
+                geo.vertices[index]?.bulge,
+                elevation,
+                osnapMode,
+                pickPoint,
+                segmentSnaps
+              )
+              if (osnapMode === AcDbOsnapMode.MidPoint) {
+                snapPoints.push(...segmentSnaps)
+              } else {
+                nearestCandidates.push(...segmentSnaps)
+              }
+            }
+            break
+          }
+          default:
+            break
+        }
+        return
+      }
+
+      loop.curves.forEach(curve => {
+        if (curve instanceof AcGeLine2d) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectPolyline2dSegmentOsnapPoints(
+            curve.startPoint,
+            curve.endPoint,
+            undefined,
+            elevation,
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          if (osnapMode === AcDbOsnapMode.MidPoint) {
+            snapPoints.push(...segmentSnaps)
+          } else if (
+            osnapMode === AcDbOsnapMode.Nearest ||
+            osnapMode === AcDbOsnapMode.Perpendicular
+          ) {
+            nearestCandidates.push(...segmentSnaps)
+          } else {
+            snapPoints.push(...segmentSnaps)
+          }
+        } else if (curve instanceof AcGeCircArc2d) {
+          switch (osnapMode) {
+            case AcDbOsnapMode.EndPoint:
+              snapPoints.push(
+                new AcGePoint3d(
+                  curve.startPoint.x,
+                  curve.startPoint.y,
+                  elevation
+                ),
+                new AcGePoint3d(curve.endPoint.x, curve.endPoint.y, elevation)
+              )
+              break
+            case AcDbOsnapMode.MidPoint:
+              snapPoints.push(
+                new AcGePoint3d(curve.midPoint.x, curve.midPoint.y, elevation)
+              )
+              break
+            case AcDbOsnapMode.Nearest: {
+              const nearest = curve.nearestPoint({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              nearestCandidates.push(
+                new AcGePoint3d(nearest.x, nearest.y, elevation)
+              )
+              break
+            }
+            default:
+              break
+          }
+        }
+      })
+    })
+
+    if (
+      (osnapMode === AcDbOsnapMode.Nearest ||
+        osnapMode === AcDbOsnapMode.Perpendicular) &&
+      nearestCandidates.length > 0
+    ) {
+      const nearest = acdbPickNearestOsnapPoint(pickPoint, nearestCandidates)
+      snapPoints.length = 0
+      if (nearest) snapPoints.push(nearest)
     }
   }
 

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -11,7 +11,12 @@ import {
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
+import {
+  acdbCollectLineSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
@@ -387,6 +392,74 @@ export class AcDbLeader extends AcDbCurve {
       throw new Error('The vertex index is out of range!')
     }
     return this._vertices[index].clone()
+  }
+
+  /**
+   * Gets the grip points for this leader.
+   *
+   * @returns Array of grip points at each leader vertex.
+   */
+  subGetGripPoints() {
+    return this._vertices.map(vertex => vertex.clone())
+  }
+
+  /**
+   * Gets the object snap points for this leader.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    if (this.numVertices === 0) return
+
+    if (this.isSplined && this.splineGeo) {
+      switch (osnapMode) {
+        case AcDbOsnapMode.EndPoint:
+          snapPoints.push(this._vertices[0])
+          snapPoints.push(this._vertices[this.numVertices - 1])
+          break
+        case AcDbOsnapMode.Nearest:
+          snapPoints.push(this.splineGeo.nearestPoint(pickPoint))
+          break
+        default:
+          break
+      }
+      return
+    }
+
+    const vertices = this._vertices
+    switch (osnapMode) {
+      case AcDbOsnapMode.EndPoint:
+        snapPoints.push(...vertices)
+        break
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Nearest:
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates: AcGePoint3d[] = []
+        for (let index = 0; index < vertices.length - 1; index++) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectLineSegmentOsnapPoints(
+            vertices[index],
+            vertices[index + 1],
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          candidates.push(...segmentSnaps)
+        }
+        if (osnapMode === AcDbOsnapMode.MidPoint) {
+          snapPoints.push(...candidates)
+        } else {
+          const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+          if (nearest) snapPoints.push(nearest)
+        }
+        break
+      }
+      default:
+        break
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -26,9 +26,14 @@ import {
   decodeMLeaderStyleRawColor,
   DEFAULT_MLEADER_STYLE
 } from '../misc'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbMLeaderStyle } from '../object'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectLineSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 
 /**
  * Defines the type of leader line used by a multileader.
@@ -1409,6 +1414,65 @@ export class AcDbMLeader extends AcDbEntity {
    */
   subGetGripPoints() {
     return this.collectGeometryPoints().map(point => point.clone())
+  }
+
+  /**
+   * Gets the object snap points for this multileader.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    if (osnapMode === AcDbOsnapMode.Insertion) {
+      if (this.contentBasePosition) {
+        snapPoints.push(this.contentBasePosition)
+      } else if (this._mtextContent) {
+        snapPoints.push(this._mtextContent.anchorPoint)
+      } else if (this._blockContent?.position) {
+        snapPoints.push(this._blockContent.position)
+      }
+      return
+    }
+
+    this._leaders.forEach(leader => {
+      leader.leaderLines.forEach(line => {
+        const drawPoints = this.getLeaderLineDrawPoints(leader, line)
+        if (drawPoints.length === 0) return
+
+        switch (osnapMode) {
+          case AcDbOsnapMode.EndPoint:
+            snapPoints.push(...drawPoints)
+            break
+          case AcDbOsnapMode.MidPoint:
+          case AcDbOsnapMode.Nearest:
+          case AcDbOsnapMode.Perpendicular: {
+            const candidates: AcGePoint3d[] = []
+            for (let index = 0; index < drawPoints.length - 1; index++) {
+              const segmentSnaps: AcGePoint3d[] = []
+              acdbCollectLineSegmentOsnapPoints(
+                drawPoints[index],
+                drawPoints[index + 1],
+                osnapMode,
+                pickPoint,
+                segmentSnaps
+              )
+              candidates.push(...segmentSnaps)
+            }
+            if (osnapMode === AcDbOsnapMode.MidPoint) {
+              snapPoints.push(...candidates)
+            } else {
+              const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+              if (nearest) snapPoints.push(nearest)
+            }
+            break
+          }
+          default:
+            break
+        }
+      })
+    })
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMLine.ts
+++ b/packages/data-model/src/entity/AcDbMLine.ts
@@ -18,9 +18,14 @@ import {
   DEFAULT_LINE_TYPE,
   DEFAULT_MLINE_STYLE
 } from '../misc'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbMlineStyle } from '../object'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectLineSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 
 /**
  * Defines MLINE justification relative to the style element offsets.
@@ -566,6 +571,53 @@ export class AcDbMLine extends AcDbEntity {
           ]
         }
       ]
+    }
+  }
+
+  /**
+   * Gets the object snap points for this MLINE reference path.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    const path = [
+      this._startPosition,
+      ...this._segments.map(segment => segment.position)
+    ]
+    if (path.length === 0) return
+
+    switch (osnapMode) {
+      case AcDbOsnapMode.EndPoint:
+        snapPoints.push(...path)
+        break
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Nearest:
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates: AcGePoint3d[] = []
+        for (let index = 0; index < path.length - 1; index++) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectLineSegmentOsnapPoints(
+            path[index],
+            path[index + 1],
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          candidates.push(...segmentSnaps)
+        }
+        if (osnapMode === AcDbOsnapMode.MidPoint) {
+          snapPoints.push(...candidates)
+        } else {
+          const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+          if (nearest) snapPoints.push(nearest)
+        }
+        break
+      }
+      default:
+        break
     }
   }
 

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -352,6 +352,15 @@ export class AcDbMText extends AcDbEntity {
   }
 
   /**
+   * Gets the grip points for this mtext entity.
+   *
+   * @returns Array containing the mtext location (insertion point).
+   */
+  subGetGripPoints() {
+    return [this._location]
+  }
+
+  /**
    * Gets the object snap points for this mtext.
    *
    * Object snap points are precise points that can be used for positioning

--- a/packages/data-model/src/entity/AcDbOsnapHelpers.ts
+++ b/packages/data-model/src/entity/AcDbOsnapHelpers.ts
@@ -1,0 +1,121 @@
+import {
+  AcGeCircArc2d,
+  AcGeLine3d,
+  AcGePoint2d,
+  AcGePoint3d,
+  AcGePoint3dLike
+} from '@mlightcad/geometry-engine'
+
+import { AcDbOsnapMode } from '../misc'
+
+function distSq3d(a: AcGePoint3dLike, b: AcGePoint3dLike): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  const dz = (a.z || 0) - (b.z || 0)
+  return dx * dx + dy * dy + dz * dz
+}
+
+/**
+ * Picks the candidate snap point closest to the pick point.
+ */
+export function acdbPickNearestOsnapPoint(
+  pickPoint: AcGePoint3dLike,
+  candidates: readonly AcGePoint3dLike[]
+): AcGePoint3d | undefined {
+  if (candidates.length === 0) return undefined
+
+  let best = new AcGePoint3d(
+    candidates[0].x,
+    candidates[0].y,
+    candidates[0].z || 0
+  )
+  let bestDistSq = distSq3d(pickPoint, best)
+  for (let i = 1; i < candidates.length; i++) {
+    const candidate = candidates[i]
+    const point = new AcGePoint3d(candidate.x, candidate.y, candidate.z || 0)
+    const distSq = distSq3d(pickPoint, point)
+    if (distSq < bestDistSq) {
+      best = point
+      bestDistSq = distSq
+    }
+  }
+  return best
+}
+
+/**
+ * Collects object snap points for one 3D line segment.
+ */
+export function acdbCollectLineSegmentOsnapPoints(
+  start: AcGePoint3dLike,
+  end: AcGePoint3dLike,
+  osnapMode: AcDbOsnapMode,
+  pickPoint: AcGePoint3dLike,
+  snapPoints: AcGePoint3dLike[]
+) {
+  const startPoint = new AcGePoint3d(start.x, start.y, start.z || 0)
+  const endPoint = new AcGePoint3d(end.x, end.y, end.z || 0)
+  const line = new AcGeLine3d(startPoint, endPoint)
+
+  switch (osnapMode) {
+    case AcDbOsnapMode.EndPoint:
+      snapPoints.push(startPoint, endPoint)
+      break
+    case AcDbOsnapMode.MidPoint:
+      snapPoints.push(line.midPoint)
+      break
+    case AcDbOsnapMode.Nearest:
+      snapPoints.push(line.nearestPoint(pickPoint))
+      break
+    case AcDbOsnapMode.Perpendicular:
+      snapPoints.push(line.perpPoint(pickPoint))
+      break
+    default:
+      break
+  }
+}
+
+/**
+ * Collects object snap points for one 2D polyline segment, including bulge arcs.
+ */
+export function acdbCollectPolyline2dSegmentOsnapPoints(
+  start: AcGePoint2d,
+  end: AcGePoint2d,
+  bulge: number | undefined,
+  elevation: number,
+  osnapMode: AcDbOsnapMode,
+  pickPoint: AcGePoint3dLike,
+  snapPoints: AcGePoint3dLike[]
+) {
+  if (bulge) {
+    const arc = new AcGeCircArc2d(start, end, bulge)
+    switch (osnapMode) {
+      case AcDbOsnapMode.EndPoint:
+        snapPoints.push(
+          new AcGePoint3d(arc.startPoint.x, arc.startPoint.y, elevation),
+          new AcGePoint3d(arc.endPoint.x, arc.endPoint.y, elevation)
+        )
+        break
+      case AcDbOsnapMode.MidPoint:
+        snapPoints.push(
+          new AcGePoint3d(arc.midPoint.x, arc.midPoint.y, elevation)
+        )
+        break
+      case AcDbOsnapMode.Nearest: {
+        const nearest = arc.nearestPoint({ x: pickPoint.x, y: pickPoint.y })
+        snapPoints.push(new AcGePoint3d(nearest.x, nearest.y, elevation))
+        break
+      }
+      default:
+        break
+    }
+    return
+  }
+
+  acdbCollectLineSegmentOsnapPoints(
+    new AcGePoint3d(start.x, start.y, elevation),
+    new AcGePoint3d(end.x, end.y, elevation),
+    osnapMode,
+    pickPoint,
+    snapPoints
+  )
+}

--- a/packages/data-model/src/entity/AcDbPoint.ts
+++ b/packages/data-model/src/entity/AcDbPoint.ts
@@ -119,13 +119,22 @@ export class AcDbPoint extends AcDbEntity {
    * @param _lastPoint - The last point
    * @param snapPoints - Array to populate with snap points
    */
+  /**
+   * Gets the grip points for this point entity.
+   *
+   * @returns Array containing the point position.
+   */
+  subGetGripPoints() {
+    return [this._geo]
+  }
+
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
     _pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    if (AcDbOsnapMode.Node === osnapMode) {
+    if (osnapMode === AcDbOsnapMode.Node) {
       snapPoints.push(this._geo)
     }
   }

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -16,6 +16,10 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCollectPolyline2dSegmentOsnapPoints,
+  acdbPickNearestOsnapPoint
+} from './AcDbOsnapHelpers'
 
 /**
  * Represents one vertex of a polyline entity in AutoCAD.
@@ -333,19 +337,48 @@ export class AcDbPolyline extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    const endPoints = new Array<AcGePoint3d>()
-    for (let index = 0; index < this.numberOfVertices; ++index) {
-      endPoints.push(this.getPoint3dAt(index))
-    }
+    const geo = this._geo
+    const elevation = this._elevation
+    const vertexCount = geo.numberOfVertices
+    if (vertexCount === 0) return
 
     switch (osnapMode) {
       case AcDbOsnapMode.EndPoint:
-        snapPoints.push(...endPoints)
+        for (let index = 0; index < vertexCount; index++) {
+          const vertex = geo.getPointAt(index)
+          snapPoints.push(new AcGePoint3d(vertex.x, vertex.y, elevation))
+        }
         break
+      case AcDbOsnapMode.MidPoint:
+      case AcDbOsnapMode.Nearest:
+      case AcDbOsnapMode.Perpendicular: {
+        const segmentCount = this.closed ? vertexCount : vertexCount - 1
+        const candidates: AcGePoint3d[] = []
+        for (let index = 0; index < segmentCount; index++) {
+          const segmentSnaps: AcGePoint3d[] = []
+          acdbCollectPolyline2dSegmentOsnapPoints(
+            geo.getPointAt(index),
+            geo.getPointAt((index + 1) % vertexCount),
+            geo.vertices[index]?.bulge,
+            elevation,
+            osnapMode,
+            pickPoint,
+            segmentSnaps
+          )
+          candidates.push(...segmentSnaps)
+        }
+        if (osnapMode === AcDbOsnapMode.MidPoint) {
+          snapPoints.push(...candidates)
+        } else {
+          const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+          if (nearest) snapPoints.push(nearest)
+        }
+        break
+      }
       default:
         break
     }

--- a/packages/data-model/src/entity/AcDbRasterImage.ts
+++ b/packages/data-model/src/entity/AcDbRasterImage.ts
@@ -4,12 +4,14 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
+  AcGePoint3dLike,
   AcGeVector2d,
   AcGeVector3d
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler, AcDbObjectId } from '../base'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
 
 /**
@@ -359,6 +361,25 @@ export class AcDbRasterImage extends AcDbEntity {
    */
   subGetGripPoints() {
     return this.boundaryPath()
+  }
+
+  /**
+   * Gets the object snap points for this raster image.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    _pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    if (osnapMode === AcDbOsnapMode.Insertion) {
+      snapPoints.push(this._position)
+      return
+    }
+
+    if (osnapMode === AcDbOsnapMode.EndPoint) {
+      snapPoints.push(...this.boundaryPath())
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeLine3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
@@ -287,13 +288,33 @@ export class AcDbRay extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
+    const origin = this.basePoint
+
+    if (osnapMode === AcDbOsnapMode.EndPoint) {
+      snapPoints.push(origin)
+      return
+    }
+
+    const direction = this.unitDir.clone()
+    if (direction.lengthSq() === 0) return
+
+    direction.normalize()
+    const line = new AcGeLine3d(origin, origin.clone().add(direction))
+
     switch (osnapMode) {
-      case AcDbOsnapMode.EndPoint:
-        snapPoints.push(this.basePoint)
+      case AcDbOsnapMode.Nearest: {
+        const projected = line.project(pickPoint)
+        const offset = new AcGeVector3d(projected).sub(origin)
+        const t = offset.dot(direction)
+        snapPoints.push(t < 0 ? origin : projected)
+        break
+      }
+      case AcDbOsnapMode.Perpendicular:
+        snapPoints.push(line.perpPoint(pickPoint))
         break
       default:
         break

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -3,6 +3,7 @@ import {
   AcGeKnotParameterizationType,
   AcGeMatrix3d,
   AcGePoint2d,
+  AcGePoint3d,
   AcGePoint3dLike,
   AcGeSpline3d,
   offsetSmoothedSampledPath
@@ -256,6 +257,19 @@ export class AcDbSpline extends AcDbCurve {
   }
 
   /**
+   * Gets the grip points for this spline.
+   *
+   * Grip points are the B-spline control vertices (CVs).
+   *
+   * @returns Array of grip points at each control vertex
+   */
+  subGetGripPoints() {
+    return this._geo.controlPoints.map(
+      point => new AcGePoint3d(point.x, point.y, point.z ?? 0)
+    )
+  }
+
+  /**
    * Gets the object snap points for this spline.
    *
    * Object snap points are precise points that can be used for positioning
@@ -269,7 +283,7 @@ export class AcDbSpline extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
@@ -277,6 +291,18 @@ export class AcDbSpline extends AcDbCurve {
       case AcDbOsnapMode.EndPoint:
         snapPoints.push(this._geo.startPoint)
         snapPoints.push(this._geo.endPoint)
+        break
+      case AcDbOsnapMode.Node: {
+        const seen = new Set<number>()
+        for (const knot of this._geo.knots) {
+          if (seen.has(knot)) continue
+          seen.add(knot)
+          snapPoints.push(this._geo.evaluateAt(knot))
+        }
+        break
+      }
+      case AcDbOsnapMode.Nearest:
+        snapPoints.push(this._geo.nearestPoint(pickPoint))
         break
       default:
         break

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -492,6 +492,15 @@ export class AcDbText extends AcDbEntity {
   }
 
   /**
+   * Gets the grip points for this text entity.
+   *
+   * @returns Array containing the text insertion point.
+   */
+  subGetGripPoints() {
+    return [this._position]
+  }
+
+  /**
    * Gets the object snap points for this text.
    *
    * Object snap points are precise points that can be used for positioning

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -1,5 +1,6 @@
 import {
   AcGeBox3d,
+  AcGeLine3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
@@ -9,6 +10,7 @@ import {
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
+import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 
@@ -271,6 +273,40 @@ export class AcDbXline extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this.basePoint)
     return gripPoints
+  }
+
+  /**
+   * Gets the object snap points for this xline.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    const origin = this.basePoint
+
+    if (osnapMode === AcDbOsnapMode.EndPoint) {
+      snapPoints.push(origin)
+      return
+    }
+
+    const direction = this.unitDir.clone()
+    if (direction.lengthSq() === 0) return
+
+    direction.normalize()
+    const line = new AcGeLine3d(origin, origin.clone().add(direction))
+
+    switch (osnapMode) {
+      case AcDbOsnapMode.Nearest:
+        snapPoints.push(line.project(pickPoint))
+        break
+      case AcDbOsnapMode.Perpendicular:
+        snapPoints.push(line.perpPoint(pickPoint))
+        break
+      default:
+        break
+    }
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -416,6 +416,37 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
   }
 
   /**
+   * Returns the nearest point on this ellipse arc to the given point.
+   *
+   * Uses uniform sampling in parameter space, which is sufficient for object snap.
+   *
+   * @param point - Query point in WCS.
+   * @param samples - Number of interior samples along the arc span.
+   */
+  nearestPoint(point: AcGePointLike, samples = 72): AcGePoint3d {
+    const query = new AcGePoint3d(point.x, point.y, point.z || 0)
+    let best = this.getPointAtAngle(this.startAngle)
+    let bestDistSq = query.distanceToSquared(best)
+
+    for (let i = 1; i <= samples; i++) {
+      const angle = this.startAngle + (this.deltaAngle * i) / samples
+      const candidate = this.getPointAtAngle(angle)
+      const distSq = query.distanceToSquared(candidate)
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq
+        best = candidate
+      }
+    }
+
+    const dStart = query.distanceToSquared(this.startPoint)
+    const dEnd = query.distanceToSquared(this.endPoint)
+    if (dStart < bestDistSq && dStart <= dEnd) return this.startPoint.clone()
+    if (dEnd < bestDistSq && dEnd < dStart) return this.endPoint.clone()
+
+    return best.clone()
+  }
+
+  /**
    * Determines whether a given point is inside the ellipse.
    * @param point - The 3D point to check.
    * @returns - True if the point is inside the ellipse, false otherwise.

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -322,6 +322,27 @@ export class AcGeSpline3d extends AcGeCurve3d {
   }
 
   /**
+   * Returns the nearest point on this spline to the given point.
+   *
+   * @param point - Query point in WCS.
+   * @param samples - Number of interior samples used by the underlying NURBS curve.
+   */
+  nearestPoint(point: AcGePoint3dLike, samples = 64): AcGePoint3d {
+    const nearest = this._nurbsCurve.nearestPoint(point, samples)
+    return new AcGePoint3d(nearest.x, nearest.y, nearest.z || 0)
+  }
+
+  /**
+   * Evaluates this spline at the given parameter value.
+   *
+   * @param t - Parameter along the knot vector.
+   */
+  evaluateAt(t: number): AcGePoint3d {
+    const point = this._nurbsCurve.point(t)
+    return new AcGePoint3d(point[0]!, point[1]!, point[2]!)
+  }
+
+  /**
    * Return the value of the control point at position index in the list of control points.
    * If index is negative or more than the number of control points in the spline, then point
    * is set to the last control point.


### PR DESCRIPTION
## Summary

This PR significantly expands object snap (OSNAP) coverage across the data model and adds the `ORTHOMODE` system variable, enabling more accurate drafting interactions in the viewer/editor.

### Object snap enhancements

- **New shared helpers** (`AcDbOsnapHelpers.ts`):
  - `acdbPickNearestOsnapPoint` — selects the closest candidate snap point to the pick location
  - `acdbCollectLineSegmentOsnapPoints` — End, Mid, Nearest, and Perpendicular snaps on 3D line segments
  - `acdbCollectPolyline2dSegmentOsnapPoints` — same for 2D polyline segments, including bulge arcs

- **New or extended entity implementations**:
  | Entity | Snap modes added / improved |
  |--------|----------------------------|
  | `AcDbArc` | Center, Centroid, Quadrant |
  | `AcDbEllipse` | Center, Nearest, Focus |
  | `AcDbSpline` | Control, Node, Nearest |
  | `AcDbPolyline` / `AcDb2dPolyline` / `AcDb3dPolyline` | Mid, Nearest, Perpendicular (with bulge arc support for 2D) |
  | `AcDbRay` / `AcDbXline` | Nearest, Perpendicular |
  | `AcDbLeader` / `AcDbMLeader` / `AcDbMLine` | Full segment-based osnap (new) |
  | `AcDbHatch` | Boundary geometry osnap (new) |
  | `AcDbRasterImage` | Insertion, End (boundary corners) |
  | `AcDbPoint` / vertices | EndPoint / Node mode filtering |

- **Grip points** added for Ellipse, Leader, Spline, BlockReference, MText, Text, and Point entities.

### Geometry engine

- `AcGeEllipseArc3d.nearestPoint()` — parameter-space sampling for ellipse arc nearest-point queries
- `AcGeSpline3d.nearestPoint()` and `evaluateAt()` — nearest-point and knot evaluation for spline osnap

### System variables

- Added **`ORTHOMODE`** (`0` = off, `1` = on) to `AcDbDatabase`, `AcDbSysVarManager`, `AcDbSystemVariables`, and DXF header import/export via `AcDbDxfConverter`.

### Bug fixes

- `AcDb2dPolyline` grip points now respect entity elevation instead of hardcoding `z = 0`.
- `AcDb3dPolyline` grip points now return actual 3D vertex positions.

## Test plan

- [x] Unit tests added/updated for osnap points on 18 entity types:
  - `AcDb2dPolyline`, `AcDb2dVertex`, `AcDb3dPolyline`, `AcDb3dVertex`
  - `AcDbBlockReference`, `AcDbEllipse`, `AcDbHatch`, `AcDbLeader`
  - `AcDbMLeader`, `AcDbMLine`, `AcDbMText`, `AcDbPoint`
  - `AcDbPolyline`, `AcDbRasterImage`, `AcDbRay`, `AcDbSpline`
  - `AcDbText`, `AcDbXline`
- [ ] Run `nx test data-model` and confirm all specs pass
- [ ] Run `nx test geometry-engine` and confirm no regressions
- [ ] Manually verify osnap behavior in the example app (endpoint, midpoint, nearest, perpendicular, center, quadrant, focus, control, insertion)
- [ ] Open a DXF with `$ORTHOMODE` set and confirm the value is read/written correctly