### PR TITLE
feat(data-model): complete object snap coverage across all entities

### DIFF
--- a/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
@@ -85,6 +85,18 @@ describe('AcDb3dPolyline', () => {
     )
     expect(nearestPoints).toHaveLength(1)
 
+    const perpendicularPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(1.5, -1.5, 1.5),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0].x).toBeCloseTo(1.5, 5)
+    expect(perpendicularPoints[0].y).toBeCloseTo(-1.5, 5)
+    expect(perpendicularPoints[0].z).toBeCloseTo(1.5, 5)
+
     const unsupportedPoints: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(
       AcDbOsnapMode.Center,

--- a/packages/data-model/__tests__/AcDb3dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dVertex.spec.ts
@@ -70,6 +70,16 @@ describe('AcDb3dVertex', () => {
     expect(snapPoints[0]).toBe(vertex.position)
     expect(snapPoints[0]).toMatchObject({ x: -1, y: 2.5, z: 3 })
 
+    const nodeSnaps: Array<{ x: number; y: number; z: number }> = []
+    vertex.subGetOsnapPoints(
+      AcDbOsnapMode.Node,
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1 },
+      nodeSnaps
+    )
+    expect(nodeSnaps).toHaveLength(1)
+    expect(nodeSnaps[0]).toBe(vertex.position)
+
     const unsupportedSnaps: Array<{ x: number; y: number; z: number }> = []
     vertex.subGetOsnapPoints(
       AcDbOsnapMode.MidPoint,

--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -181,11 +181,12 @@ describe('AcDbArc', () => {
     const perpendicularPoints: AcGePoint3d[] = []
     arc.subGetOsnapPoints(
       AcDbOsnapMode.Perpendicular,
-      new AcGePoint3d(9, 9, 0),
+      new AcGePoint3d(10, 0, 0),
       new AcGePoint3d(),
       perpendicularPoints
     )
-    expect(perpendicularPoints).toHaveLength(0)
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
 
     const tangentPoints: AcGePoint3d[] = []
     arc.subGetOsnapPoints(

--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -182,6 +182,34 @@ describe('AcDbBlockReference', () => {
     expect(nearestSnaps[0].z).toBeCloseTo(0)
   })
 
+  it('collects nearest osnap from block geometry without gsMark', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'TEST_BLOCK')
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+    block.appendEntity(line)
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    blockRef.position = new AcGePoint3d(10, 0, 0)
+    blockRef.rotation = Math.PI / 2
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    const nearestSnaps: AcGePoint3d[] = []
+    blockRef.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(11, 3, 0),
+      new AcGePoint3d(),
+      nearestSnaps
+    )
+
+    expect(nearestSnaps).toHaveLength(1)
+    expect(nearestSnaps[0].x).toBeCloseTo(10)
+    expect(nearestSnaps[0].y).toBeCloseTo(3)
+    expect(nearestSnaps[0].z).toBeCloseTo(0)
+  })
+
   it('resolves osnap points through nested block references', () => {
     const db = createDb()
     const leafBlock = createNamedBlock(db, 'LEAF_BLOCK')

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -140,6 +140,16 @@ describe('AcDbCircle', () => {
     )
     expect(tangentPoints).toEqual([tangentA, tangentB])
 
+    const perpendicularPoints: AcGePoint3d[] = []
+    circle.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(6, 0, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
+
     const unsupportedPoints: AcGePoint3d[] = []
     circle.subGetOsnapPoints(
       AcDbOsnapMode.EndPoint,

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -161,6 +161,26 @@ describe('AcDbEllipse', () => {
     expect(nearestPoints).toHaveLength(1)
     expect(nearestPoints[0].x).toBeCloseTo(6, 5)
 
+    const tangentPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Tangent,
+      new AcGePoint3d(10, 10, 0),
+      new AcGePoint3d(),
+      tangentPoints
+    )
+    expect(tangentPoints.length).toBeGreaterThan(0)
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    openEllipse.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(10, 0, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0].x).toBeCloseTo(6, 5)
+    expect(perpendicularPoints[0].y).toBeCloseTo(0, 5)
+
     const unsupportedPoints: AcGePoint3d[] = []
     openEllipse.subGetOsnapPoints(
       AcDbOsnapMode.Insertion,

--- a/packages/data-model/__tests__/AcDbFace.spec.ts
+++ b/packages/data-model/__tests__/AcDbFace.spec.ts
@@ -115,6 +115,36 @@ describe('AcDbFace', () => {
       unsupportedPoints
     )
     expect(unsupportedPoints).toHaveLength(0)
+
+    const midPoints: AcGePoint3d[] = []
+    face.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(4)
+
+    const nearestPoints: AcGePoint3d[] = []
+    face.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(1, 2.5, 5),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0].x).toBeCloseTo(1)
+    expect(nearestPoints[0].y).toBeCloseTo(2.5)
+    expect(nearestPoints[0].z).toBeCloseTo(5)
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    face.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(0.5, 0.5, -1),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
   })
 
   it('transforms vertices and draws visible edges via line segments', () => {

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -376,6 +376,25 @@ describe('AcDbHatch', () => {
     )
     expect(nearestPoints).toHaveLength(1)
     expect(nearestPoints[0]).toMatchObject({ x: 5, y: 5, z: 2 })
+
+    const midPoints: Array<{ x: number; y: number; z: number }> = []
+    hatch.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      { x: 5, y: 6, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      midPoints
+    )
+    expect(midPoints.length).toBeGreaterThanOrEqual(4)
+
+    const perpendicularPoints: Array<{ x: number; y: number; z: number }> = []
+    hatch.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      { x: 5, y: 6, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 5, y: 5, z: 2 })
   })
 
   it('draws empty/single/multi hatch areas and applies fill traits', () => {

--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -238,6 +238,26 @@ describe('AcDbLeader', () => {
     expect(midPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
     expect(midPoints[1]).toMatchObject({ x: 4, y: 1.5, z: 0 })
 
+    const straightNearestPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(4, 2, 0),
+      new AcGePoint3d(),
+      straightNearestPoints
+    )
+    expect(straightNearestPoints).toHaveLength(1)
+    expect(straightNearestPoints[0]).toMatchObject({ x: 4, y: 2, z: 0 })
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    leader.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(4, 2, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 4, y: 2, z: 0 })
+
     leader.appendVertex(new AcGePoint3d(6, 1, 0))
     leader.appendVertex(new AcGePoint3d(8, 0, 0))
     leader.isSplined = true

--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -307,5 +307,35 @@ describe('AcDbMLeader arrowhead rendering', () => {
     )
     expect(insertionSnaps).toHaveLength(1)
     expect(insertionSnaps[0]).toMatchObject({ x: 10, y: 5, z: 0 })
+
+    const midPoints: AcGePoint3d[] = []
+    mleader.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(2, 1, 0),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(1)
+    expect(midPoints[0]).toMatchObject({ x: 2.5, y: 0, z: 0 })
+
+    const nearestPoints: AcGePoint3d[] = []
+    mleader.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(2, 1, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    mleader.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(2, 1, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
   })
 })

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -104,6 +104,26 @@ describe('AcDbMLine', () => {
     expect(midPoints).toHaveLength(2)
     expect(midPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
     expect(midPoints[1]).toMatchObject({ x: 15, y: 0, z: 0 })
+
+    const nearestPoints: Array<{ x: number; y: number; z: number }> = []
+    mline.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      { x: 5, y: 2, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
+
+    const perpendicularPoints: Array<{ x: number; y: number; z: number }> = []
+    mline.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      { x: 5, y: 2, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 5, y: 0, z: 0 })
   })
 
   it('ensures database default mline style exists when appending a new MLINE', () => {

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -130,6 +130,16 @@ describe('AcDbPolyline', () => {
     expect(nearestPoints).toHaveLength(1)
     expect(nearestPoints[0]).toMatchObject({ x: 1, y: 0, z: 2 })
 
+    const perpendicularPoints: AcGePoint3d[] = []
+    polyline.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(1, 1, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
+    expect(perpendicularPoints[0]).toMatchObject({ x: 1, y: 0, z: 2 })
+
     const centerSnaps: AcGePoint3d[] = []
     polyline.subGetOsnapPoints(
       AcDbOsnapMode.Center,

--- a/packages/data-model/__tests__/AcDbRasterImage.spec.ts
+++ b/packages/data-model/__tests__/AcDbRasterImage.spec.ts
@@ -174,6 +174,35 @@ describe('AcDbRasterImage', () => {
       endPoints
     )
     expect(endPoints.length).toBeGreaterThanOrEqual(4)
+
+    const midPoints: AcGePoint3d[] = []
+    image.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(4)
+
+    const nearestPoints: AcGePoint3d[] = []
+    image.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(8, 4, 0),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0].x).toBeCloseTo(8)
+    expect(nearestPoints[0].y).toBeCloseTo(4)
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    image.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(8, 10, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
   })
 
   it('draws via renderer.lines when image data is absent and renderer.image when present', () => {

--- a/packages/data-model/__tests__/AcDbTrace.spec.ts
+++ b/packages/data-model/__tests__/AcDbTrace.spec.ts
@@ -92,6 +92,36 @@ describe('AcDbTrace', () => {
       otherSnaps
     )
     expect(otherSnaps).toHaveLength(0)
+
+    const midPoints: AcGePoint3d[] = []
+    trace.subGetOsnapPoints(
+      AcDbOsnapMode.MidPoint,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      midPoints
+    )
+    expect(midPoints).toHaveLength(4)
+
+    const nearestPoints: AcGePoint3d[] = []
+    trace.subGetOsnapPoints(
+      AcDbOsnapMode.Nearest,
+      new AcGePoint3d(0.5, -1, 0.5),
+      new AcGePoint3d(),
+      nearestPoints
+    )
+    expect(nearestPoints).toHaveLength(1)
+    expect(nearestPoints[0].x).toBeCloseTo(0.5)
+    expect(nearestPoints[0].y).toBeCloseTo(-1)
+    expect(nearestPoints[0].z).toBeCloseTo(0.5)
+
+    const perpendicularPoints: AcGePoint3d[] = []
+    trace.subGetOsnapPoints(
+      AcDbOsnapMode.Perpendicular,
+      new AcGePoint3d(0.5, 10, 0),
+      new AcGePoint3d(),
+      perpendicularPoints
+    )
+    expect(perpendicularPoints).toHaveLength(1)
   })
 
   it('orders DXF solid corners as a perimeter loop when drawing', () => {

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -266,7 +266,8 @@ export class AcDb2dPolyline extends AcDbCurve {
         break
       case AcDbOsnapMode.MidPoint:
       case AcDbOsnapMode.Nearest:
-      case AcDbOsnapMode.Perpendicular: {
+      case AcDbOsnapMode.Perpendicular:
+      case AcDbOsnapMode.Tangent: {
         const segmentCount = this.closed ? vertexCount : vertexCount - 1
         const candidates: AcGePoint3d[] = []
         for (let index = 0; index < segmentCount; index++) {

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -16,6 +16,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
  * Represents an arc entity in AutoCAD.
@@ -535,9 +536,12 @@ export class AcDbArc extends AcDbCurve {
           snapPoints.push(projectedPoint)
         }
         break
-      case AcDbOsnapMode.Perpendicular:
-        // N/A for perpendicular snap
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates = this._geo.perpendicularPoints(pickPoint)
+        const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+        if (nearest) snapPoints.push(nearest)
         break
+      }
       case AcDbOsnapMode.Tangent: {
         const points = this._geo.tangentPoints(pickPoint)
         snapPoints.push(...points)

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -17,6 +17,7 @@ import {
   AcDbEntityProperties,
   AcDbEntityPropertyGroup
 } from './AcDbEntityProperties'
+import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
  * Represents a block reference entity in AutoCAD.
@@ -441,6 +442,14 @@ export class AcDbBlockReference extends AcDbEntity {
         gsMark,
         parentInsertionMat
       )
+    } else {
+      this.collectBlockOsnapPoints(
+        osnapMode,
+        pickPoint,
+        lastPoint,
+        snapPoints,
+        parentInsertionMat
+      )
     }
   }
 
@@ -761,6 +770,70 @@ export class AcDbBlockReference extends AcDbEntity {
       filer.writeSubclassMarker('AcDbEntity')
     }
     return this
+  }
+
+  /**
+   * Collects object snap points from all entities in this block reference.
+   */
+  private collectBlockOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[],
+    parentInsertionMat: AcGeMatrix3d
+  ) {
+    const blockTableRecord = this.blockTableRecord
+    if (!blockTableRecord) return
+
+    const thisInsertionMat = new AcGeMatrix3d().multiplyMatrices(
+      parentInsertionMat,
+      this.getFullInsertionTransform()
+    )
+    const inverseMat = thisInsertionMat.clone().invert()
+    const localPickPoint = new AcGePoint3d(pickPoint).applyMatrix4(inverseMat)
+    const localLastPoint = new AcGePoint3d(lastPoint).applyMatrix4(inverseMat)
+    const candidates: AcGePoint3d[] = []
+
+    for (const entity of blockTableRecord.newIterator()) {
+      const localSnapPoints: AcGePoint3d[] = []
+      if (entity instanceof AcDbBlockReference) {
+        entity.subGetOsnapPoints(
+          osnapMode,
+          pickPoint,
+          lastPoint,
+          localSnapPoints,
+          undefined,
+          thisInsertionMat
+        )
+        candidates.push(...localSnapPoints)
+        continue
+      }
+
+      entity.subGetOsnapPoints(
+        osnapMode,
+        localPickPoint,
+        localLastPoint,
+        localSnapPoints,
+        undefined,
+        thisInsertionMat
+      )
+      localSnapPoints.forEach(point =>
+        candidates.push(new AcGePoint3d(point).applyMatrix4(thisInsertionMat))
+      )
+    }
+
+    if (candidates.length === 0) return
+
+    if (
+      osnapMode === AcDbOsnapMode.Nearest ||
+      osnapMode === AcDbOsnapMode.Perpendicular ||
+      osnapMode === AcDbOsnapMode.Tangent
+    ) {
+      const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+      if (nearest) snapPoints.push(nearest)
+    } else {
+      snapPoints.push(...candidates)
+    }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -16,6 +16,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
  * Represents a circle entity in AutoCAD.
@@ -225,6 +226,12 @@ export class AcDbCircle extends AcDbCurve {
       case AcDbOsnapMode.Tangent: {
         const points = this._geo.tangentPoints(pickPoint)
         snapPoints.push(...points)
+        break
+      }
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates = this._geo.perpendicularPoints(pickPoint)
+        const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+        if (nearest) snapPoints.push(nearest)
         break
       }
       default:

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -12,6 +12,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
  * Represents an ellipse entity in AutoCAD.
@@ -378,6 +379,15 @@ export class AcDbEllipse extends AcDbCurve {
       case AcDbOsnapMode.Nearest:
         snapPoints.push(this._geo.nearestPoint(pickPoint))
         break
+      case AcDbOsnapMode.Tangent:
+        snapPoints.push(...this._geo.tangentPoints(pickPoint))
+        break
+      case AcDbOsnapMode.Perpendicular: {
+        const candidates = this._geo.perpendicularPoints(pickPoint)
+        const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+        if (nearest) snapPoints.push(nearest)
+        break
+      }
       default:
         break
     }

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -10,6 +10,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 
 /**
  * Represents a three-dimensional surface patch — specifically, a flat polygon that
@@ -201,17 +202,17 @@ export class AcDbFace extends AcDbEntity {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    switch (osnapMode) {
-      case AcDbOsnapMode.EndPoint:
-        snapPoints.push(...this._vertices)
-        break
-      default:
-        break
-    }
+    acdbCollectVertexPathOsnapPoints(
+      this._vertices,
+      true,
+      osnapMode,
+      pickPoint,
+      snapPoints
+    )
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -1105,7 +1105,8 @@ export class AcDbHatch extends AcDbEntity {
             break
           case AcDbOsnapMode.MidPoint:
           case AcDbOsnapMode.Nearest:
-          case AcDbOsnapMode.Perpendicular: {
+          case AcDbOsnapMode.Perpendicular:
+          case AcDbOsnapMode.Tangent: {
             const segmentCount = loop.closed ? vertexCount : vertexCount - 1
             for (let index = 0; index < segmentCount; index++) {
               const segmentSnaps: AcGePoint3d[] = []
@@ -1148,7 +1149,8 @@ export class AcDbHatch extends AcDbEntity {
             snapPoints.push(...segmentSnaps)
           } else if (
             osnapMode === AcDbOsnapMode.Nearest ||
-            osnapMode === AcDbOsnapMode.Perpendicular
+            osnapMode === AcDbOsnapMode.Perpendicular ||
+            osnapMode === AcDbOsnapMode.Tangent
           ) {
             nearestCandidates.push(...segmentSnaps)
           } else {
@@ -1181,6 +1183,84 @@ export class AcDbHatch extends AcDbEntity {
               )
               break
             }
+            case AcDbOsnapMode.Perpendicular: {
+              const perpPoints = curve.perpendicularPoints({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              perpPoints.forEach(point =>
+                nearestCandidates.push(
+                  new AcGePoint3d(point.x, point.y, elevation)
+                )
+              )
+              break
+            }
+            case AcDbOsnapMode.Tangent: {
+              const tangentPoints = curve.tangentPoints({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              tangentPoints.forEach(point =>
+                nearestCandidates.push(
+                  new AcGePoint3d(point.x, point.y, elevation)
+                )
+              )
+              break
+            }
+            default:
+              break
+          }
+        } else if (curve instanceof AcGeEllipseArc2d) {
+          switch (osnapMode) {
+            case AcDbOsnapMode.EndPoint:
+              snapPoints.push(
+                new AcGePoint3d(
+                  curve.startPoint.x,
+                  curve.startPoint.y,
+                  elevation
+                ),
+                new AcGePoint3d(curve.endPoint.x, curve.endPoint.y, elevation)
+              )
+              break
+            case AcDbOsnapMode.MidPoint: {
+              const mid = curve.getPoint(0.5)
+              snapPoints.push(new AcGePoint3d(mid.x, mid.y, elevation))
+              break
+            }
+            case AcDbOsnapMode.Nearest: {
+              const nearest = curve.nearestPoint({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              nearestCandidates.push(
+                new AcGePoint3d(nearest.x, nearest.y, elevation)
+              )
+              break
+            }
+            case AcDbOsnapMode.Perpendicular: {
+              const perpPoints = curve.perpendicularPoints({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              perpPoints.forEach(point =>
+                nearestCandidates.push(
+                  new AcGePoint3d(point.x, point.y, elevation)
+                )
+              )
+              break
+            }
+            case AcDbOsnapMode.Tangent: {
+              const tangentPoints = curve.tangentPoints({
+                x: pickPoint.x,
+                y: pickPoint.y
+              })
+              tangentPoints.forEach(point =>
+                nearestCandidates.push(
+                  new AcGePoint3d(point.x, point.y, elevation)
+                )
+              )
+              break
+            }
             default:
               break
           }
@@ -1190,7 +1270,8 @@ export class AcDbHatch extends AcDbEntity {
 
     if (
       (osnapMode === AcDbOsnapMode.Nearest ||
-        osnapMode === AcDbOsnapMode.Perpendicular) &&
+        osnapMode === AcDbOsnapMode.Perpendicular ||
+        osnapMode === AcDbOsnapMode.Tangent) &&
       nearestCandidates.length > 0
     ) {
       const nearest = acdbPickNearestOsnapPoint(pickPoint, nearestCandidates)

--- a/packages/data-model/src/entity/AcDbOsnapHelpers.ts
+++ b/packages/data-model/src/entity/AcDbOsnapHelpers.ts
@@ -105,6 +105,26 @@ export function acdbCollectPolyline2dSegmentOsnapPoints(
         snapPoints.push(new AcGePoint3d(nearest.x, nearest.y, elevation))
         break
       }
+      case AcDbOsnapMode.Perpendicular: {
+        const perpPoints = arc.perpendicularPoints({
+          x: pickPoint.x,
+          y: pickPoint.y
+        })
+        perpPoints.forEach(point =>
+          snapPoints.push(new AcGePoint3d(point.x, point.y, elevation))
+        )
+        break
+      }
+      case AcDbOsnapMode.Tangent: {
+        const tangentPoints = arc.tangentPoints({
+          x: pickPoint.x,
+          y: pickPoint.y
+        })
+        tangentPoints.forEach(point =>
+          snapPoints.push(new AcGePoint3d(point.x, point.y, elevation))
+        )
+        break
+      }
       default:
         break
     }
@@ -118,4 +138,51 @@ export function acdbCollectPolyline2dSegmentOsnapPoints(
     pickPoint,
     snapPoints
   )
+}
+
+/**
+ * Collects object snap points along a 3D vertex path.
+ */
+export function acdbCollectVertexPathOsnapPoints(
+  vertices: readonly AcGePoint3dLike[],
+  closed: boolean,
+  osnapMode: AcDbOsnapMode,
+  pickPoint: AcGePoint3dLike,
+  snapPoints: AcGePoint3dLike[]
+) {
+  if (vertices.length === 0) return
+
+  switch (osnapMode) {
+    case AcDbOsnapMode.EndPoint:
+      vertices.forEach(vertex =>
+        snapPoints.push(new AcGePoint3d(vertex.x, vertex.y, vertex.z || 0))
+      )
+      break
+    case AcDbOsnapMode.MidPoint:
+    case AcDbOsnapMode.Nearest:
+    case AcDbOsnapMode.Perpendicular: {
+      const segmentCount = closed ? vertices.length : vertices.length - 1
+      const candidates: AcGePoint3d[] = []
+      for (let index = 0; index < segmentCount; index++) {
+        const segmentSnaps: AcGePoint3d[] = []
+        acdbCollectLineSegmentOsnapPoints(
+          vertices[index],
+          vertices[(index + 1) % vertices.length],
+          osnapMode,
+          pickPoint,
+          segmentSnaps
+        )
+        candidates.push(...segmentSnaps)
+      }
+      if (osnapMode === AcDbOsnapMode.MidPoint) {
+        snapPoints.push(...candidates)
+      } else {
+        const nearest = acdbPickNearestOsnapPoint(pickPoint, candidates)
+        if (nearest) snapPoints.push(nearest)
+      }
+      break
+    }
+    default:
+      break
+  }
 }

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -355,7 +355,8 @@ export class AcDbPolyline extends AcDbCurve {
         break
       case AcDbOsnapMode.MidPoint:
       case AcDbOsnapMode.Nearest:
-      case AcDbOsnapMode.Perpendicular: {
+      case AcDbOsnapMode.Perpendicular:
+      case AcDbOsnapMode.Tangent: {
         const segmentCount = this.closed ? vertexCount : vertexCount - 1
         const candidates: AcGePoint3d[] = []
         for (let index = 0; index < segmentCount; index++) {

--- a/packages/data-model/src/entity/AcDbRasterImage.ts
+++ b/packages/data-model/src/entity/AcDbRasterImage.ts
@@ -13,6 +13,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler, AcDbObjectId } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 
 /**
  * Defines the clip boundary type for raster images.
@@ -368,7 +369,7 @@ export class AcDbRasterImage extends AcDbEntity {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
@@ -377,9 +378,34 @@ export class AcDbRasterImage extends AcDbEntity {
       return
     }
 
-    if (osnapMode === AcDbOsnapMode.EndPoint) {
-      snapPoints.push(...this.boundaryPath())
+    const boundary = this.boundaryPath()
+    if (boundary.length === 0) return
+
+    let vertices = boundary
+    if (boundary.length > 1) {
+      const first = boundary[0]
+      const last = boundary[boundary.length - 1]
+      if (
+        first.x === last.x &&
+        first.y === last.y &&
+        (first.z || 0) === (last.z || 0)
+      ) {
+        vertices = boundary.slice(0, -1)
+      }
     }
+
+    if (osnapMode === AcDbOsnapMode.EndPoint) {
+      snapPoints.push(...vertices)
+      return
+    }
+
+    acdbCollectVertexPathOsnapPoints(
+      vertices,
+      true,
+      osnapMode,
+      pickPoint,
+      snapPoints
+    )
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -14,6 +14,7 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
+import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 
 /**
  * Represents a trace entity in AutoCAD.
@@ -252,17 +253,23 @@ export class AcDbTrace extends AcDbCurve {
    */
   subGetOsnapPoints(
     osnapMode: AcDbOsnapMode,
-    _pickPoint: AcGePoint3dLike,
+    pickPoint: AcGePoint3dLike,
     _lastPoint: AcGePoint3dLike,
     snapPoints: AcGePoint3dLike[]
   ) {
-    switch (osnapMode) {
-      case AcDbOsnapMode.EndPoint:
-        snapPoints.push(...this._vertices)
-        break
-      default:
-        break
-    }
+    const perimeter = [
+      this._vertices[0],
+      this._vertices[1],
+      this._vertices[3],
+      this._vertices[2]
+    ]
+    acdbCollectVertexPathOsnapPoints(
+      perimeter,
+      true,
+      osnapMode,
+      pickPoint,
+      snapPoints
+    )
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -13,8 +13,8 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbCurve } from './AcDbCurve'
-import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
+import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
  * Represents a trace entity in AutoCAD.

--- a/packages/geometry-engine/src/geometry/AcGeCircArc2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc2d.ts
@@ -550,6 +550,96 @@ export class AcGeCircArc2d extends AcGeCurve2d {
   }
 
   /**
+   * Returns perpendicular snap point(s) on this arc from the given point.
+   */
+  perpendicularPoints(point: AcGePoint2dLike): AcGePoint2d[] {
+    const p = new AcGePoint2d(point.x, point.y)
+    const dx = p.x - this.center.x
+    const dy = p.y - this.center.y
+    const dist = Math.hypot(dx, dy)
+    if (dist < 1e-12) return []
+
+    const nx = dx / dist
+    const ny = dy / dist
+    const candidates = [
+      new AcGePoint2d(
+        this.center.x + nx * this.radius,
+        this.center.y + ny * this.radius
+      ),
+      new AcGePoint2d(
+        this.center.x - nx * this.radius,
+        this.center.y - ny * this.radius
+      )
+    ]
+
+    const result: AcGePoint2d[] = []
+    const internalStart = this._getInternalAngle(this.startAngle)
+    const internalEnd = this._getInternalAngle(this.endAngle)
+
+    for (const candidate of candidates) {
+      const theta = Math.atan2(
+        candidate.y - this.center.y,
+        candidate.x - this.center.x
+      )
+      const publicAngle = this.clockwise
+        ? this._mirrorAngle(AcGeMathUtil.normalizeAngle(theta))
+        : AcGeMathUtil.normalizeAngle(theta)
+      const internalAngle = this._getInternalAngle(publicAngle)
+      if (
+        this.closed ||
+        AcGeMathUtil.isBetweenAngle(
+          internalAngle,
+          internalStart,
+          internalEnd,
+          this.clockwise
+        )
+      ) {
+        result.push(candidate)
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Returns tangent snap point(s) from the given point to this arc.
+   */
+  tangentPoints(point: AcGePoint2dLike): AcGePoint2d[] {
+    const result: AcGePoint2d[] = []
+    const dx = point.x - this.center.x
+    const dy = point.y - this.center.y
+    const d = Math.hypot(dx, dy)
+    const r = this.radius
+    if (d < r) return result
+
+    const alpha = Math.acos(r / d)
+    const baseAngle = Math.atan2(dy, dx)
+    const angles = [baseAngle + alpha, baseAngle - alpha]
+    const internalStart = this._getInternalAngle(this.startAngle)
+    const internalEnd = this._getInternalAngle(this.endAngle)
+
+    for (const theta of angles) {
+      const publicAngle = this.clockwise
+        ? this._mirrorAngle(AcGeMathUtil.normalizeAngle(theta))
+        : AcGeMathUtil.normalizeAngle(theta)
+      const internalAngle = this._getInternalAngle(publicAngle)
+      if (
+        this.closed ||
+        AcGeMathUtil.isBetweenAngle(
+          internalAngle,
+          internalStart,
+          internalEnd,
+          this.clockwise
+        )
+      ) {
+        result.push(this.getPointAtAngle(publicAngle))
+      }
+    }
+
+    return result
+  }
+
+  /**
    * Divide this arc into the specified nubmer of points and return those points as an array of points.
    * @param numPoints Input the nubmer of points returned
    * @returns Return an array of points

--- a/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
@@ -409,6 +409,46 @@ export class AcGeCircArc3d extends AcGeCurve3d {
   }
 
   /**
+   * Returns perpendicular snap point(s) on this arc from the given point.
+   *
+   * The snap point lies where the line from the query point to the arc is
+   * perpendicular to the arc (i.e. aligned with the radius at that point).
+   */
+  perpendicularPoints(point: AcGePoint3dLike): AcGePoint3d[] {
+    const result: AcGePoint3d[] = []
+
+    const P = new AcGeVector3d(point.x, point.y, point.z || 0)
+    const C = this.center
+    const n = this.normal
+    const r = this.radius
+
+    const v = P.clone().sub(C)
+    const distToPlane = v.dot(n)
+    const Pp = P.clone().sub(n.clone().multiplyScalar(distToPlane))
+    const dVec = Pp.clone().sub(C)
+
+    if (dVec.lengthSq() < 1e-24) return result
+
+    dVec.normalize()
+    const candidates = [
+      C.clone().add(dVec.clone().multiplyScalar(r)),
+      C.clone().sub(dVec.clone().multiplyScalar(r))
+    ]
+
+    for (const candidate of candidates) {
+      const angle = this.getAngle(candidate.clone())
+      const t = AcGeMathUtil.normalizeAngle(angle - this.startAngle)
+      if (t >= 0 && t <= this.deltaAngle) {
+        result.push(
+          new AcGePoint3d(candidate.x, candidate.y, candidate.z || 0)
+        )
+      }
+    }
+
+    return result
+  }
+
+  /**
    * Returns the nearest tangent snap point, or null if none exists.
    */
   nearestTangentPoint(point: AcGePoint3dLike): AcGePoint3d | null {

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
@@ -422,4 +422,86 @@ export class AcGeEllipseArc2d extends AcGeCurve2d {
     }
     return best
   }
+
+  /**
+   * Returns tangent snap point(s) from the given point to this ellipse arc.
+   */
+  tangentPoints(point: AcGePointLike): AcGePoint2d[] {
+    const localP = this._projectPointToLocal(point)
+    const angles = this._findSnapAngles(localP, (qx, qy, cos, sin) => {
+      const tx = -this.majorAxisRadius * sin
+      const ty = this.minorAxisRadius * cos
+      return (qx - localP.x) * ty - (qy - localP.y) * tx
+    })
+    return angles.map(angle => this.getPointAtAngle(angle))
+  }
+
+  /**
+   * Returns perpendicular snap point(s) on this ellipse arc from the given point.
+   */
+  perpendicularPoints(point: AcGePointLike): AcGePoint2d[] {
+    const localP = this._projectPointToLocal(point)
+    const angles = this._findSnapAngles(localP, (qx, qy, cos, sin) => {
+      const nx = this.minorAxisRadius * cos
+      const ny = this.majorAxisRadius * sin
+      return (qx - localP.x) * ny - (qy - localP.y) * nx
+    })
+    return angles.map(angle => this.getPointAtAngle(angle))
+  }
+
+  private _projectPointToLocal(point: AcGePointLike): { x: number; y: number } {
+    const dx = point.x - this.center.x
+    const dy = point.y - this.center.y
+    const cos = Math.cos(-this.rotation)
+    const sin = Math.sin(-this.rotation)
+    return {
+      x: dx * cos - dy * sin,
+      y: dx * sin + dy * cos
+    }
+  }
+
+  private _findSnapAngles(
+    _localP: { x: number; y: number },
+    errorAt: (
+      qx: number,
+      qy: number,
+      cos: number,
+      sin: number
+    ) => number,
+    samples = 144
+  ): number[] {
+    const a = this.majorAxisRadius
+    const b = this.minorAxisRadius
+    const start = this.startAngle
+    const delta = this.deltaAngle
+    const angles: number[] = []
+
+    const evalError = (theta: number) => {
+      const cos = Math.cos(theta)
+      const sin = Math.sin(theta)
+      return errorAt(a * cos, b * sin, cos, sin)
+    }
+
+    let prevT = start
+    let prevE = evalError(prevT)
+    for (let i = 1; i <= samples; i++) {
+      const t = start + (delta * i) / samples
+      const e = evalError(t)
+      if (Math.abs(prevE) < 1e-10) angles.push(prevT)
+      if (prevE * e < 0) {
+        let lo = prevT
+        let hi = t
+        for (let j = 0; j < 32; j++) {
+          const mid = (lo + hi) / 2
+          if (evalError(lo) * evalError(mid) <= 0) hi = mid
+          else lo = mid
+        }
+        angles.push((lo + hi) / 2)
+      }
+      prevT = t
+      prevE = e
+    }
+
+    return angles
+  }
 }

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -5,6 +5,7 @@ import {
   AcGeMatrix3d,
   AcGePlane,
   AcGePoint3d,
+  AcGePoint3dLike,
   AcGePointLike,
   AcGeVector3d,
   AcGeVector3dLike
@@ -444,6 +445,90 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
     if (dEnd < bestDistSq && dEnd < dStart) return this.endPoint.clone()
 
     return best.clone()
+  }
+
+  /**
+   * Returns tangent snap point(s) from the given point to this ellipse arc.
+   */
+  tangentPoints(point: AcGePoint3dLike): AcGePoint3d[] {
+    const localP = this._projectPointToLocalPlane(point)
+    const angles = this._findSnapParameterAngles((qx, qy, cos, sin) => {
+      const tx = -this.majorAxisRadius * sin
+      const ty = this.minorAxisRadius * cos
+      return (qx - localP.x) * ty - (qy - localP.y) * tx
+    })
+    return angles.map(angle => this.getPointAtAngle(angle))
+  }
+
+  /**
+   * Returns perpendicular snap point(s) on this ellipse arc from the given point.
+   */
+  perpendicularPoints(point: AcGePoint3dLike): AcGePoint3d[] {
+    const localP = this._projectPointToLocalPlane(point)
+    const angles = this._findSnapParameterAngles((qx, qy, cos, sin) => {
+      const nx = this.minorAxisRadius * cos
+      const ny = this.majorAxisRadius * sin
+      return (qx - localP.x) * ny - (qy - localP.y) * nx
+    })
+    return angles.map(angle => this.getPointAtAngle(angle))
+  }
+
+  private _projectPointToLocalPlane(point: AcGePoint3dLike): {
+    x: number
+    y: number
+  } {
+    const query = new AcGePoint3d(point.x, point.y, point.z || 0)
+    const offset = new AcGeVector3d(query).sub(this.center)
+    const distToPlane = offset.dot(this.normal)
+    offset.sub(this.normal.clone().multiplyScalar(distToPlane))
+    return {
+      x: offset.dot(this.majorAxis),
+      y: offset.dot(this.minorAxis)
+    }
+  }
+
+  private _findSnapParameterAngles(
+    errorAt: (
+      qx: number,
+      qy: number,
+      cos: number,
+      sin: number
+    ) => number,
+    samples = 144
+  ): number[] {
+    const a = this.majorAxisRadius
+    const b = this.minorAxisRadius
+    const start = this.startAngle
+    const delta = this.deltaAngle
+    const angles: number[] = []
+
+    const evalError = (theta: number) => {
+      const cos = Math.cos(theta)
+      const sin = Math.sin(theta)
+      return errorAt(a * cos, b * sin, cos, sin)
+    }
+
+    let prevT = start
+    let prevE = evalError(prevT)
+    for (let i = 1; i <= samples; i++) {
+      const t = start + (delta * i) / samples
+      const e = evalError(t)
+      if (Math.abs(prevE) < 1e-10) angles.push(prevT)
+      if (prevE * e < 0) {
+        let lo = prevT
+        let hi = t
+        for (let j = 0; j < 32; j++) {
+          const mid = (lo + hi) / 2
+          if (evalError(lo) * evalError(mid) <= 0) hi = mid
+          else lo = mid
+        }
+        angles.push((lo + hi) / 2)
+      }
+      prevT = t
+      prevE = e
+    }
+
+    return angles
   }
 
   /**


### PR DESCRIPTION
## Summary
- Complete `subGetOsnapPoints` coverage for all supported AutoCAD osnap modes across entity types (Arc, Circle, Ellipse, Polyline, Hatch, Face, Trace, RasterImage, BlockReference, and related helpers).
- Add geometry-engine support for arc/ellipse tangent and perpendicular snap calculations (`AcGeCircArc2d/3d`, `AcGeEllipseArc2d/3d`).
- Expand osnap test coverage for edge-based entities and block geometry aggregation.

## Test plan
- [x] `npm run build` in `packages/geometry-engine`
- [x] `npm test -- --testPathPattern="osnap|AcDb(Arc|Circle|Ellipse|Polyline|3dPolyline|MLine|MLeader|Hatch|Leader|3dVertex|BlockReference|Face|Trace|2dPolyline|Line|Point|Ray|Xline|Spline|Text|MText|RasterImage|PolygonMesh|PolyFaceMesh|2dVertex)"`
- [ ] Manual snap verification in the example app for arc/circle tangent, hatch boundaries, and block references