### PR TITLE
feat(data-model): add POLARMODE, POLARANG, and POLARADDANG system variables

### DIFF
--- a/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
@@ -84,6 +84,13 @@ describe('AcDbSysVarManager', () => {
     manager.setVar(AcDbSystemVariables.CELTYPE, 'BYLAYER', db)
     expect(manager.getVar(AcDbSystemVariables.CELTYPE, db)).toBe('ByLayer')
 
+    manager.setVar(AcDbSystemVariables.POLARMODE, 3, db)
+    expect(manager.getVar(AcDbSystemVariables.POLARMODE, db)).toBe(3)
+    manager.setVar(AcDbSystemVariables.POLARANG, '45', db)
+    expect(manager.getVar(AcDbSystemVariables.POLARANG, db)).toBe(45)
+    manager.setVar(AcDbSystemVariables.POLARADDANG, '15;30;60', db)
+    expect(manager.getVar(AcDbSystemVariables.POLARADDANG, db)).toBe('15;30;60')
+
     expect(() =>
       manager.setVar(AcDbSystemVariables.PICKBOX, 'NaN-input', db)
     ).toThrow('Invalid number input!')
@@ -153,6 +160,9 @@ describe('AcDbSysVarManager', () => {
       manager.getDefaultValue(AcDbSystemVariables.HPTRANSPARENCY)?.toString()
     ).toBe('ByLayer')
     expect(manager.getDefaultValue(AcDbSystemVariables.CELTYPE)).toBe('ByLayer')
+    expect(manager.getDefaultValue(AcDbSystemVariables.POLARADDANG)).toBe('')
+    expect(manager.getDefaultValue(AcDbSystemVariables.POLARMODE)).toBe(0)
+    expect(manager.getDefaultValue(AcDbSystemVariables.POLARANG)).toBe(90)
     expect(manager.getAllDescriptors().length).toBeGreaterThan(0)
     expect(() => manager.getDefaultValue('__NOT_FOUND__')).toThrow(
       'System variable __not_found__ not found!'

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -499,6 +499,46 @@ export class AcDbSysVarManager {
       defaultValue: 10
     })
     /**
+     * Stores additional angles for polar tracking and polar snap.
+     * Up to 10 angles separated by semicolons (;). Unlike POLARANG, values are
+     * absolute angles rather than increments. Only effective when POLARMODE bit 4 is on.
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-73162BAB-C98D-4159-A653-E4C7D4CB38C3
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.POLARADDANG,
+      type: 'string',
+      isDbVar: false,
+      defaultValue: ''
+    })
+    /**
+     * Controls settings for polar and object snap tracking (bitcode sum):
+     * - Bit 0: `0` = measure polar angles from current UCS; `1` = from selected objects
+     * - Bit 2: `0` = track orthogonally only; `2` = use polar tracking in object snap tracking
+     * - Bit 4: `0` = do not use additional polar angles; `4` = use POLARADDANG angles
+     * - Bit 8: `0` = acquire tracking points automatically; `8` = press SHIFT to acquire
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-D91628CC-9975-4DBF-8D02-10B23A6F3ED5
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.POLARMODE,
+      type: 'number',
+      isDbVar: false,
+      defaultValue: 0
+    })
+    /**
+     * Sets the polar angle increment for polar tracking alignment paths, in degrees.
+     * Common values: 90, 45, 30, 22.5, 18, 15, 10, and 5.
+     *
+     * @see https://help.autodesk.com/view/ACD/2027/ENU/?guid=GUID-0CF67F9E-F953-43D6-9227-0D56E0E693ED
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.POLARANG,
+      type: 'number',
+      isDbVar: false,
+      defaultValue: 90
+    })
+    /**
      * Controls whether Default, Edit, and Command mode shortcut menus are available in the drawing area.
      * - 0: Disables all Default, Edit, and Command mode shortcut menus.
      * - 1: Enables Default mode shortcut menus.

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -112,6 +112,17 @@ export const AcDbSystemVariables = {
   PDSIZE: 'PDSIZE',
   /** Pickbox half-size, in pixels, used for selection hit testing in the UI. */
   PICKBOX: 'PICKBOX',
+  /**
+   * Additional polar tracking angles, stored as a semicolon-separated list (up to 10).
+   * Only effective when POLARMODE bit 4 is set.
+   */
+  POLARADDANG: 'POLARADDANG',
+  /**
+   * Polar and object snap tracking settings stored as a bitcode (sum of bit values).
+   */
+  POLARMODE: 'POLARMODE',
+  /** Polar angle increment, in degrees, for polar tracking alignment paths. */
+  POLARANG: 'POLARANG',
   /** Controls whether Default, Edit, and Command mode shortcut menus are available in the drawing area. */
   SHORTCUTMENU: 'SHORTCUTMENU',
   /** Current text style name used when creating new text entities. */


### PR DESCRIPTION
## Summary
- Add AutoCAD polar tracking system variables POLARMODE, POLARANG, and POLARADDANG to data-model
- Register them in AcDbSysVarManager as non-db-resident (registry) variables with AutoCAD-compatible defaults
- Add unit tests for default values and get/set behavior

## Test plan
- [x] Run \jest packages/data-model/__tests__/AcDbSysVarManager.spec.ts\

Made with [Cursor](https://cursor.com)