### PR TITLE
feat(data-model): implement geometricExtents for text, dimensions, table, and viewport

### DIFF
--- a/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dPolyline.spec.ts
@@ -83,6 +83,24 @@ describe('AcDb2dPolyline', () => {
     expect(ext.max).toMatchObject({ x: 3, y: 2, z: 7 })
   })
 
+  it('updates geometricExtents when elevation changes', () => {
+    const polyline = new AcDb2dPolyline(
+      AcDbPoly2dType.SimplePoly,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: 3, z: 0 }
+      ],
+      1
+    )
+
+    expect(polyline.geometricExtents.min.z).toBe(1)
+
+    polyline.elevation = 9
+
+    expect(polyline.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 9 })
+    expect(polyline.geometricExtents.max).toMatchObject({ x: 4, y: 3, z: 9 })
+  })
+
   it('returns grip points and osnap points for supported modes', () => {
     const polyline = new AcDb2dPolyline(AcDbPoly2dType.SimplePoly, [
       { x: 0, y: 0, z: 0 },

--- a/packages/data-model/__tests__/AcDb2dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb2dVertex.spec.ts
@@ -45,6 +45,18 @@ describe('AcDb2dVertex', () => {
     expect(extents.max).toMatchObject({ x: 6, y: 7, z: 8 })
   })
 
+  it('updates geometricExtents when position changes', () => {
+    const vertex = new AcDb2dVertex()
+    vertex.position = { x: 1, y: 2, z: 3 }
+
+    expect(vertex.geometricExtents.min).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    vertex.position = { x: 9, y: -4, z: 6 }
+
+    expect(vertex.geometricExtents.min).toMatchObject({ x: 9, y: -4, z: 6 })
+    expect(vertex.geometricExtents.max).toMatchObject({ x: 9, y: -4, z: 6 })
+  })
+
   it('returns one grip point and one osnap point at vertex position', () => {
     const vertex = new AcDb2dVertex()
     vertex.position = { x: 9, y: 10, z: 11 }

--- a/packages/data-model/__tests__/AcDb3PointAngularDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDb3PointAngularDimension.spec.ts
@@ -14,4 +14,22 @@ describe('AcDb3PointAngularDimension', () => {
         )
     )
   })
+
+  it('returns geometricExtents and recomputes when center point changes', () => {
+    const dim = new AcDb3PointAngularDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(0, 1, 0),
+      new AcGePoint3d(1, 1, 0)
+    )
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 1, y: 1, z: 0 })
+
+    dim.centerPoint = new AcGePoint3d(10, 20, 0)
+    dim.arcPoint = new AcGePoint3d(12, 22, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 12, y: 22, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dPolyline.spec.ts
@@ -107,6 +107,20 @@ describe('AcDb3dPolyline', () => {
     expect(unsupportedPoints).toHaveLength(0)
   })
 
+  it('updates geometricExtents when vertices are transformed', () => {
+    const polyline = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 0 }
+    ])
+
+    expect(polyline.geometricExtents.max).toMatchObject({ x: 2, y: 0, z: 0 })
+
+    polyline.transformBy(new AcGeMatrix3d().makeTranslation(5, 3, 1))
+
+    expect(polyline.geometricExtents.min).toMatchObject({ x: 5, y: 3, z: 1 })
+    expect(polyline.geometricExtents.max).toMatchObject({ x: 7, y: 3, z: 1 })
+  })
+
   it('transforms vertices and returns itself for chaining', () => {
     const polyline = new AcDb3dPolyline(AcDbPoly3dType.SimplePoly, [
       { x: 0, y: 0, z: 0 },

--- a/packages/data-model/__tests__/AcDb3dVertex.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dVertex.spec.ts
@@ -37,6 +37,18 @@ describe('AcDb3dVertex', () => {
     expect(extents.max).toMatchObject({ x: 1, y: 2, z: 3 })
   })
 
+  it('updates geometricExtents when position changes', () => {
+    const vertex = new AcDb3dVertex()
+    vertex.position = { x: 0, y: 0, z: 0 }
+
+    expect(vertex.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    vertex.position = { x: 5, y: -2, z: 7 }
+
+    expect(vertex.geometricExtents.min).toMatchObject({ x: 5, y: -2, z: 7 })
+    expect(vertex.geometricExtents.max).toMatchObject({ x: 5, y: -2, z: 7 })
+  })
+
   it('gets and sets vertexType', () => {
     const vertex = new AcDb3dVertex()
 

--- a/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
@@ -92,4 +92,64 @@ describe('AcDbAlignedDimension', () => {
     expect(extents.min).toMatchObject({ x: 11, y: 22, z: 0 })
     expect(extents.max).toMatchObject({ x: 14, y: 26, z: 0 })
   })
+
+  it('updates geometricExtents when dimBlockPosition changes', () => {
+    const db = createDb()
+
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_MOVE'
+    dimBlock.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(2, 0, 0))
+    )
+    db.tables.blockTable.add(dimBlock)
+
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.dimBlockId = '*D_MOVE'
+    dim.dimBlockPosition = new AcGePoint3d(0, 0, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    expect(dim.geometricExtents.max).toMatchObject({ x: 2, y: 0, z: 0 })
+
+    dim.dimBlockPosition = new AcGePoint3d(10, 20, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 12, y: 20, z: 0 })
+  })
+
+  it('returns geometricExtents from definition points when dim block is absent', () => {
+    const db = createDb()
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 2, 0)
+    )
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    const extents = dim.geometricExtents
+    expect(extents.isEmpty()).toBe(false)
+    expect(extents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(extents.max).toMatchObject({ x: 5, y: 2, z: 0 })
+
+    dim.dimLinePoint = new AcGePoint3d(5, 8, 0)
+
+    expect(dim.geometricExtents.max.y).toBeCloseTo(8)
+  })
+
+  it('includes textPosition in fallback extents when text is placed away from origin', () => {
+    const db = createDb()
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(10, 10, 0),
+      new AcGePoint3d(20, 10, 0),
+      new AcGePoint3d(20, 12, 0)
+    )
+    dim.textPosition = new AcGePoint3d(5, 5, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 5, y: 5, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 20, y: 12, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -62,6 +62,24 @@ describe('AcDbArc', () => {
     expect(typeof arc.closed).toBe('boolean')
   })
 
+  it('returns geometricExtents and updates when center or radius change', () => {
+    createWorkingDb()
+    const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 3, 0, Math.PI / 2)
+
+    expect(arc.geometricExtents.min.x).toBeCloseTo(0, 5)
+    expect(arc.geometricExtents.min.y).toBeCloseTo(0, 5)
+    expect(arc.geometricExtents.max.x).toBeCloseTo(3, 5)
+    expect(arc.geometricExtents.max.y).toBeCloseTo(3, 5)
+
+    arc.center = new AcGePoint3d(10, 10, 0)
+    arc.radius = 2
+
+    expect(arc.geometricExtents.min.x).toBeCloseTo(10, 5)
+    expect(arc.geometricExtents.min.y).toBeCloseTo(10, 5)
+    expect(arc.geometricExtents.max.x).toBeCloseTo(12, 5)
+    expect(arc.geometricExtents.max.y).toBeCloseTo(12, 5)
+  })
+
   it('exposes runtime properties and accessors', () => {
     createWorkingDb()
     const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 3, 0, Math.PI / 2)

--- a/packages/data-model/__tests__/AcDbArcDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbArcDimension.spec.ts
@@ -14,4 +14,22 @@ describe('AcDbArcDimension', () => {
         )
     )
   })
+
+  it('returns geometricExtents and recomputes when arc point changes', () => {
+    const dim = new AcDbArcDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(0, 1, 0),
+      new AcGePoint3d(1, 1, 0)
+    )
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 1, y: 1, z: 0 })
+
+    dim.arcPoint = new AcGePoint3d(10, 20, 0)
+    dim.centerPoint = new AcGePoint3d(5, 5, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 10, y: 20, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbAttribute.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttribute.spec.ts
@@ -1,6 +1,7 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbAttribute, AcDbMText } from '../src/entity'
+import { AcDbAttribute, AcDbMText, AcDbTextVerticalMode } from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const setWorkingDb = () => {
@@ -142,5 +143,22 @@ describe('AcDbAttribute', () => {
 
   it('clone creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbAttribute())
+  })
+
+  it('returns geometricExtents and recomputes when position changes', () => {
+    setWorkingDb()
+    const attribute = new AcDbAttribute()
+    attribute.textString = 'A'
+    attribute.height = 2
+    attribute.verticalMode = AcDbTextVerticalMode.BASELINE
+    attribute.position = new AcGePoint3d(1, 2, 3)
+
+    expect(attribute.geometricExtents.min).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(attribute.geometricExtents.max.x).toBeCloseTo(3)
+
+    attribute.position = new AcGePoint3d(8, 9, 10)
+
+    expect(attribute.geometricExtents.min).toMatchObject({ x: 8, y: 9, z: 10 })
+    expect(attribute.geometricExtents.max.x).toBeCloseTo(10)
   })
 })

--- a/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
@@ -1,6 +1,11 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbAttributeDefinition, AcDbMText } from '../src/entity'
+import {
+  AcDbAttributeDefinition,
+  AcDbMText,
+  AcDbTextVerticalMode
+} from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const setWorkingDb = () => {
@@ -128,5 +133,22 @@ describe('AcDbAttributeDefinition', () => {
 
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbAttributeDefinition())
+  })
+
+  it('returns geometricExtents and recomputes when position changes', () => {
+    setWorkingDb()
+    const attDef = new AcDbAttributeDefinition()
+    attDef.textString = 'TAG'
+    attDef.height = 2
+    attDef.verticalMode = AcDbTextVerticalMode.BASELINE
+    attDef.position = new AcGePoint3d(2, 3, 4)
+
+    expect(attDef.geometricExtents.min).toMatchObject({ x: 2, y: 3, z: 4 })
+    expect(attDef.geometricExtents.max.x).toBeCloseTo(8)
+
+    attDef.position = new AcGePoint3d(11, 12, 13)
+
+    expect(attDef.geometricExtents.min).toMatchObject({ x: 11, y: 12, z: 13 })
+    expect(attDef.geometricExtents.max.x).toBeCloseTo(17)
   })
 })

--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -331,6 +331,23 @@ describe('AcDbBlockReference', () => {
     expect(extents.max).toMatchObject({ x: 7, y: 9, z: 0 })
   })
 
+  it('updates geometricExtents when block reference position changes', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'MOVE_BLOCK')
+    block.appendEntity(new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 0 }))
+
+    const blockRef = new AcDbBlockReference('MOVE_BLOCK')
+    blockRef.position = new AcGePoint3d(0, 0, 0)
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    expect(blockRef.geometricExtents.max).toMatchObject({ x: 1, y: 1, z: 0 })
+
+    blockRef.position = new AcGePoint3d(5, 10, 0)
+
+    expect(blockRef.geometricExtents.min).toMatchObject({ x: 5, y: 10, z: 0 })
+    expect(blockRef.geometricExtents.max).toMatchObject({ x: 6, y: 11, z: 0 })
+  })
+
   it('skips invisible entities inside block definitions when drawing through cache', () => {
     const db = createDb()
     const block = createNamedBlock(db, 'INV_BLK')

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -49,6 +49,19 @@ describe('AcDbCircle', () => {
     expect(circle.radius).toBe(7)
   })
 
+  it('updates geometricExtents when center and radius change', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(1, 2, 3), 4)
+
+    expect(circle.geometricExtents.min).toMatchObject({ x: -3, y: -2, z: 3 })
+    expect(circle.geometricExtents.max).toMatchObject({ x: 5, y: 6, z: 3 })
+
+    circle.center = new AcGePoint3d(10, 20, 0)
+    circle.radius = 2
+
+    expect(circle.geometricExtents.min).toMatchObject({ x: 8, y: 18, z: 0 })
+    expect(circle.geometricExtents.max).toMatchObject({ x: 12, y: 22, z: 0 })
+  })
+
   it('returns grip points with center point', () => {
     const circle = new AcDbCircle(new AcGePoint3d(2, 3, 4), 5)
 

--- a/packages/data-model/__tests__/AcDbDiametricDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbDiametricDimension.spec.ts
@@ -13,4 +13,21 @@ describe('AcDbDiametricDimension', () => {
         )
     )
   })
+
+  it('returns geometricExtents and recomputes when chord points change', () => {
+    const dim = new AcDbDiametricDimension(
+      new AcGePoint3d(1, 0, 0),
+      new AcGePoint3d(-1, 0, 0),
+      1
+    )
+
+    expect(dim.geometricExtents.min.x).toBeCloseTo(-2)
+    expect(dim.geometricExtents.max.x).toBeCloseTo(1)
+
+    dim.chordPoint = new AcGePoint3d(10, 0, 0)
+    dim.farChordPoint = new AcGePoint3d(20, 0, 0)
+
+    expect(dim.geometricExtents.min.x).toBeCloseTo(10)
+    expect(dim.geometricExtents.max.x).toBeCloseTo(21)
+  })
 })

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -93,6 +93,31 @@ describe('AcDbEllipse', () => {
     expect(ellipse.normal.y).toBeCloseTo(1)
   })
 
+  it('returns geometricExtents and updates when center or radii change', () => {
+    createWorkingDb()
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(0, 0, 0),
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      5,
+      2,
+      0,
+      Math.PI / 2
+    )
+
+    expect(ellipse.geometricExtents.min.x).toBeCloseTo(0, 5)
+    expect(ellipse.geometricExtents.max.x).toBeCloseTo(5, 5)
+    expect(ellipse.geometricExtents.max.y).toBeCloseTo(2, 5)
+
+    ellipse.center = new AcGePoint3d(10, 20, 0)
+    ellipse.majorAxisRadius = 4
+    ellipse.minorAxisRadius = 1
+
+    expect(ellipse.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(ellipse.geometricExtents.max.x).toBeCloseTo(14, 5)
+    expect(ellipse.geometricExtents.max.y).toBeCloseTo(21, 5)
+  })
+
   it('computes osnap points for supported modes', () => {
     createWorkingDb()
     const openEllipse = new AcDbEllipse(

--- a/packages/data-model/__tests__/AcDbFace.spec.ts
+++ b/packages/data-model/__tests__/AcDbFace.spec.ts
@@ -147,6 +147,20 @@ describe('AcDbFace', () => {
     expect(perpendicularPoints).toHaveLength(1)
   })
 
+  it('updates geometricExtents when a vertex changes', () => {
+    const face = new AcDbFace()
+    face.setVertexAt(0, { x: 0, y: 0, z: 0 })
+    face.setVertexAt(1, { x: 2, y: 0, z: 0 })
+    face.setVertexAt(2, { x: 2, y: 2, z: 0 })
+    face.setVertexAt(3, { x: 0, y: 2, z: 0 })
+
+    expect(face.geometricExtents.max).toMatchObject({ x: 2, y: 2, z: 0 })
+
+    face.setVertexAt(2, { x: 8, y: 6, z: 4 })
+
+    expect(face.geometricExtents.max).toMatchObject({ x: 8, y: 6, z: 4 })
+  })
+
   it('transforms vertices and draws visible edges via line segments', () => {
     const face = new AcDbFace()
     face.setVertexAt(0, { x: 0, y: 0, z: 0 })

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -353,6 +353,18 @@ describe('AcDbHatch', () => {
     expect(hatch.elevation).toBe(6)
   })
 
+  it('updates geometricExtents when elevation changes', () => {
+    const hatch = new AcDbHatch()
+    hatch.add(createRectLoop(0, 0, 10, 5))
+
+    expect(hatch.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    hatch.elevation = 12
+
+    expect(hatch.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 12 })
+    expect(hatch.geometricExtents.max).toMatchObject({ x: 10, y: 5, z: 12 })
+  })
+
   it('computes osnap points on hatch boundary loops', () => {
     const hatch = new AcDbHatch()
     hatch.add(createRectLoop(0, 0, 10, 5))

--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -109,6 +109,18 @@ describe('AcDbLeader', () => {
     expect(splineExtents.isEmpty()).toBe(false)
   })
 
+  it('updates geometricExtents when a vertex is moved', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(4, 0, 0))
+
+    expect(leader.geometricExtents.max.x).toBeCloseTo(4)
+
+    leader.setVertexAt(1, new AcGePoint3d(4, 8, 0))
+
+    expect(leader.geometricExtents.max.y).toBeCloseTo(8)
+  })
+
   it('draws polyline/spline branches in subWorldDraw', () => {
     const rendererA = createRenderer()
     const leaderA = new AcDbLeader()

--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -339,3 +339,24 @@ describe('AcDbMLeader arrowhead rendering', () => {
     expect(perpendicularPoints[0]).toMatchObject({ x: 2, y: 0, z: 0 })
   })
 })
+
+describe('AcDbMLeader geometricExtents', () => {
+  it('returns geometricExtents and updates when leader vertices change', () => {
+    const db = createWorkingDb()
+    const mleader = createSimpleLeader(db)
+
+    const before = mleader.geometricExtents
+    expect(before.isEmpty()).toBe(false)
+    expect(before.min.x).toBeCloseTo(0)
+    expect(before.max.x).toBeCloseTo(5)
+
+    mleader.addLeaderLine(0, [
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 12, 0)
+    ])
+
+    const after = mleader.geometricExtents
+    expect(after.max.y).toBeCloseTo(12)
+    expect(after.max.y).toBeGreaterThan(before.max.y)
+  })
+})

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -714,4 +714,28 @@ describe('AcDbMLine', () => {
 
     expect(renderer.lines).toHaveBeenCalledTimes(3)
   })
+
+  it('returns geometricExtents and updates when segment positions change', () => {
+    const db = createDb()
+    const style = new AcDbMlineStyle()
+    style.styleName = 'EXTENTS_STYLE'
+    style.elements = [
+      { offset: 0.5, color: createAciColor(3), lineType: 'BYLAYER' },
+      { offset: -0.5, color: createAciColor(5), lineType: 'BYLAYER' }
+    ]
+    db.objects.mlineStyle.setAt(style.styleName, style)
+
+    const mline = createBasicMline(style)
+    const before = mline.geometricExtents
+    expect(before.isEmpty()).toBe(false)
+    expect(before.max.x).toBeCloseTo(20)
+
+    const updatedSegments = mline.segments
+    updatedSegments[1].position = { x: 40, y: 10, z: 0 }
+    mline.segments = updatedSegments
+
+    const after = mline.geometricExtents
+    expect(after.max.x).toBeCloseTo(40)
+    expect(after.max.y).toBeGreaterThan(before.max.y)
+  })
 })

--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -69,6 +69,36 @@ describe('AcDbMText', () => {
     expect(mtext.geometricExtents).toBeInstanceOf(AcGeBox3d)
   })
 
+  it('returns geometricExtents and recomputes when location changes', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.contents = 'X'
+    mtext.height = 2
+    mtext.location = { x: 0, y: 0, z: 0 }
+
+    expect(mtext.geometricExtents.min.y).toBeCloseTo(-2)
+    expect(mtext.geometricExtents.max.x).toBeCloseTo(2)
+
+    mtext.location = { x: 10, y: 10, z: 0 }
+
+    expect(mtext.geometricExtents.min.x).toBeCloseTo(10)
+    expect(mtext.geometricExtents.min.y).toBeCloseTo(8)
+    expect(mtext.geometricExtents.max.x).toBeCloseTo(12)
+    expect(mtext.geometricExtents.max.y).toBeCloseTo(10)
+  })
+
+  it('includes multi-line height from line spacing factor in geometricExtents', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.contents = 'A\nB'
+    mtext.height = 2
+    mtext.lineSpacingFactor = 1
+    mtext.location = { x: 0, y: 0, z: 0 }
+
+    expect(mtext.geometricExtents.min.y).toBeCloseTo(-4)
+    expect(mtext.geometricExtents.max.y).toBeCloseTo(0)
+  })
+
   it('returns insertion osnap point only for insertion mode', () => {
     createWorkingDb()
     const mtext = new AcDbMText()

--- a/packages/data-model/__tests__/AcDbOrdinateDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbOrdinateDimension.spec.ts
@@ -9,4 +9,20 @@ describe('AcDbOrdinateDimension', () => {
         new AcDbOrdinateDimension(new AcGePoint3d(), new AcGePoint3d(1, 0, 0))
     )
   })
+
+  it('returns geometricExtents and recomputes when defining point changes', () => {
+    const dim = new AcDbOrdinateDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0)
+    )
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 5, y: 0, z: 0 })
+
+    dim.definingPoint = new AcGePoint3d(10, 20, 0)
+    dim.leaderEndPoint = new AcGePoint3d(15, 25, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(dim.geometricExtents.max).toMatchObject({ x: 15, y: 25, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbPoint.spec.ts
+++ b/packages/data-model/__tests__/AcDbPoint.spec.ts
@@ -50,6 +50,19 @@ describe('AcDbPoint', () => {
     expect(extents.max).toMatchObject({ x: 7.5, y: -2, z: 9 })
   })
 
+  it('updates geometricExtents when position changes', () => {
+    createWorkingDb()
+    const point = new AcDbPoint()
+    point.position = { x: 1, y: 2, z: 3 }
+
+    expect(point.geometricExtents.min).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    point.position = { x: 10, y: -5, z: 8 }
+
+    expect(point.geometricExtents.min).toMatchObject({ x: 10, y: -5, z: 8 })
+    expect(point.geometricExtents.max).toMatchObject({ x: 10, y: -5, z: 8 })
+  })
+
   it('adds osnap point only in Node mode', () => {
     createWorkingDb()
     const point = new AcDbPoint()

--- a/packages/data-model/__tests__/AcDbPolyFaceMesh.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyFaceMesh.spec.ts
@@ -79,6 +79,23 @@ describe('AcDbPolyFaceMesh', () => {
     expect(grips[1]).toMatchObject({ x: 6, y: -5, z: 0 })
   })
 
+  it('updates geometricExtents when a vertex position changes', () => {
+    const mesh = new AcDbPolyFaceMesh(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: 0, z: 0 },
+        { x: 4, y: 3, z: 0 }
+      ],
+      [[1, 2, 3]]
+    )
+
+    expect(mesh.geometricExtents.max).toMatchObject({ x: 4, y: 3, z: 0 })
+
+    mesh.getVertexAt(1).position.set(10, 6, 2)
+
+    expect(mesh.geometricExtents.max).toMatchObject({ x: 10, y: 6, z: 2 })
+  })
+
   it('returns endpoint osnap points only for EndPoint mode', () => {
     const mesh = new AcDbPolyFaceMesh(
       [

--- a/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
@@ -79,6 +79,21 @@ describe('AcDbPolygonMesh', () => {
     expect(empty.geometricExtents.max).toMatchObject({ x: 0, y: 0, z: 0 })
   })
 
+  it('updates geometricExtents when a vertex position changes', () => {
+    const mesh = new AcDbPolygonMesh(2, 2, [
+      { x: 0, y: 0, z: 0 },
+      { x: 5, y: 0, z: 0 },
+      { x: 0, y: 3, z: 0 },
+      { x: 5, y: 3, z: 0 }
+    ])
+
+    expect(mesh.geometricExtents.max).toMatchObject({ x: 5, y: 3, z: 0 })
+
+    mesh.getVertexAt(1).position.set(10, 8, 4)
+
+    expect(mesh.geometricExtents.max).toMatchObject({ x: 10, y: 8, z: 4 })
+  })
+
   it('returns grip points and endpoint osnap points only', () => {
     const mesh = new AcDbPolygonMesh(1, 3, [
       { x: 0, y: 0, z: 0 },

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -87,6 +87,20 @@ describe('AcDbPolyline', () => {
     expect(extents.max).toMatchObject({ x: 3, y: 2, z: 6 })
   })
 
+  it('updates geometricExtents when vertices and elevation change', () => {
+    const polyline = new AcDbPolyline()
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(2, 0))
+
+    expect(polyline.geometricExtents.max).toMatchObject({ x: 2, y: 0, z: 0 })
+
+    polyline.addVertexAt(2, new AcGePoint2d(2, 5))
+    polyline.elevation = 3
+
+    expect(polyline.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 3 })
+    expect(polyline.geometricExtents.max).toMatchObject({ x: 2, y: 5, z: 3 })
+  })
+
   it('returns grip points and osnap points for supported modes', () => {
     const polyline = new AcDbPolyline()
     polyline.elevation = 2

--- a/packages/data-model/__tests__/AcDbRadialDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbRadialDimension.spec.ts
@@ -9,4 +9,21 @@ describe('AcDbRadialDimension', () => {
         new AcDbRadialDimension(new AcGePoint3d(), new AcGePoint3d(1, 0, 0), 1)
     )
   })
+
+  it('returns geometricExtents and recomputes when center changes', () => {
+    const dim = new AcDbRadialDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      1
+    )
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(dim.geometricExtents.max.x).toBeCloseTo(6)
+
+    dim.center = new AcGePoint3d(10, 20, 0)
+    dim.chordPoint = new AcGePoint3d(15, 20, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(dim.geometricExtents.max.x).toBeCloseTo(16)
+  })
 })

--- a/packages/data-model/__tests__/AcDbRasterImage.spec.ts
+++ b/packages/data-model/__tests__/AcDbRasterImage.spec.ts
@@ -123,6 +123,22 @@ describe('AcDbRasterImage', () => {
     expect(extents.max.y).toBe(60)
   })
 
+  it('updates geometricExtents when position and size change', () => {
+    const { image } = setupInDatabase()
+    image.position = new AcGePoint3d(0, 0, 0)
+    image.width = 10
+    image.height = 10
+
+    expect(image.geometricExtents.max).toMatchObject({ x: 10, y: 10 })
+
+    image.position = new AcGePoint3d(5, 5, 0)
+    image.width = 20
+    image.height = 30
+
+    expect(image.geometricExtents.min).toMatchObject({ x: 5, y: 5 })
+    expect(image.geometricExtents.max).toMatchObject({ x: 25, y: 35 })
+  })
+
   it('returns grip points with rectangular boundary and clipping boundary', () => {
     const { image } = setupInDatabase()
     image.position = new AcGePoint3d(1, 2, 0)

--- a/packages/data-model/__tests__/AcDbRay.spec.ts
+++ b/packages/data-model/__tests__/AcDbRay.spec.ts
@@ -51,6 +51,20 @@ describe('AcDbRay', () => {
     expect(extents.max).toMatchObject({ x: 1, y: 22, z: 13 })
   })
 
+  it('updates geometricExtents when basePoint changes', () => {
+    const ray = new AcDbRay()
+    ray.basePoint = new AcGePoint3d(0, 0, 0)
+    ray.unitDir = new AcGeVector3d(1, 0, 0)
+
+    expect(ray.geometricExtents.min).toMatchObject({ x: -10, y: 0, z: 0 })
+    expect(ray.geometricExtents.max).toMatchObject({ x: 10, y: 0, z: 0 })
+
+    ray.basePoint = new AcGePoint3d(5, 0, 0)
+
+    expect(ray.geometricExtents.min).toMatchObject({ x: -5, y: 0, z: 0 })
+    expect(ray.geometricExtents.max).toMatchObject({ x: 15, y: 0, z: 0 })
+  })
+
   it('exposes editable geometry properties and updates ray coordinates via accessors', () => {
     const ray = new AcDbRay()
     const geometryGroup = ray.properties.groups.find(

--- a/packages/data-model/__tests__/AcDbRotatedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbRotatedDimension.spec.ts
@@ -1,7 +1,15 @@
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
-import { AcDbDatabase } from '../src/database/AcDbDatabase'
-import { AcDbRotatedDimension } from '../src/entity'
+import { acdbHostApplicationServices } from '../src/base'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import { AcDbLine, AcDbRotatedDimension } from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
 
 describe('AcDbRotatedDimension', () => {
   it('creates a detached clone with a new objectId', () => {
@@ -16,8 +24,7 @@ describe('AcDbRotatedDimension', () => {
   })
 
   it('writes AcDbRotatedDimension subclass marker in DXF output', () => {
-    const db = new AcDbDatabase()
-    db.createDefaultData()
+    const db = createDb()
 
     const rotated = new AcDbRotatedDimension(
       new AcGePoint3d(0, 0, 0),
@@ -28,5 +35,32 @@ describe('AcDbRotatedDimension', () => {
 
     const dxf = db.dxfOut(undefined, 6)
     expect(dxf).toContain('100\nAcDbRotatedDimension\n')
+  })
+
+  it('returns geometricExtents and updates when dimBlockPosition changes', () => {
+    const db = createDb()
+
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_ROTATED'
+    dimBlock.appendEntity(
+      new AcDbLine(new AcGePoint3d(0, 0, 0), new AcGePoint3d(3, 0, 0))
+    )
+    db.tables.blockTable.add(dimBlock)
+
+    const dim = new AcDbRotatedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.dimBlockId = '*D_ROTATED'
+    dim.dimBlockPosition = new AcGePoint3d(0, 0, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    expect(dim.geometricExtents.max.x).toBeCloseTo(3)
+
+    dim.dimBlockPosition = new AcGePoint3d(10, 20, 0)
+
+    expect(dim.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(dim.geometricExtents.max.x).toBeCloseTo(13)
   })
 })

--- a/packages/data-model/__tests__/AcDbShape.spec.ts
+++ b/packages/data-model/__tests__/AcDbShape.spec.ts
@@ -60,6 +60,22 @@ describe('AcDbShape', () => {
     expect(shape.styleName).toBe('STANDARD')
   })
 
+  it('returns geometricExtents and updates when position or size change', () => {
+    createWorkingDb()
+    const shape = new AcDbShape()
+    shape.position = { x: 10, y: 20, z: 0 }
+    shape.size = 4
+
+    expect(shape.geometricExtents.min).toMatchObject({ x: 8, y: 18, z: 0 })
+    expect(shape.geometricExtents.max).toMatchObject({ x: 12, y: 22, z: 0 })
+
+    shape.position = { x: 0, y: 0, z: 0 }
+    shape.size = 10
+
+    expect(shape.geometricExtents.min).toMatchObject({ x: -5, y: -5, z: 0 })
+    expect(shape.geometricExtents.max).toMatchObject({ x: 5, y: 5, z: 0 })
+  })
+
   it('returns insertion point for grips and osnap', () => {
     createWorkingDb()
     const shape = new AcDbShape()

--- a/packages/data-model/__tests__/AcDbSpline.spec.ts
+++ b/packages/data-model/__tests__/AcDbSpline.spec.ts
@@ -43,6 +43,24 @@ describe('AcDbSpline', () => {
     expect(spline.closed).toBe(true)
   })
 
+  it('updates geometricExtents when control points are rebuilt', () => {
+    const spline = new AcDbSpline(controlPoints, knots)
+    const beforeMaxX = spline.geometricExtents.max.x
+
+    spline.rebuild(
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        { x: 10, y: 5, z: 0 },
+        { x: 0, y: 5, z: 0 }
+      ],
+      knots
+    )
+
+    expect(spline.geometricExtents.max.x).toBeGreaterThan(beforeMaxX)
+    expect(spline.geometricExtents.max.y).toBeGreaterThan(2)
+  })
+
   it('supports fit-point constructor and rebuild overloads', () => {
     const fitPoints = [
       { x: 0, y: 0, z: 0 },

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -120,6 +120,21 @@ describe('AcDbTable', () => {
     expect(table.geometricExtents).toBeInstanceOf(AcGeBox3d)
   })
 
+  it('returns geometricExtents and recomputes when position changes', () => {
+    const table = new AcDbTable('TABLE_EXTENTS', 2, 2)
+    table.position = new AcGePoint3d(0, 0, 0)
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(20)
+
+    expect(table.geometricExtents.min).toMatchObject({ x: 0, y: -20, z: 0 })
+    expect(table.geometricExtents.max).toMatchObject({ x: 40, y: 0, z: 0 })
+
+    table.position = new AcGePoint3d(5, 5, 0)
+
+    expect(table.geometricExtents.min).toMatchObject({ x: 5, y: -15, z: 0 })
+    expect(table.geometricExtents.max).toMatchObject({ x: 45, y: 5, z: 0 })
+  })
+
   it('exposes editable runtime properties for table and geometry groups', () => {
     const table = new AcDbTable('TABLE_PROPERTIES', 2, 2)
     table.position = new AcGePoint3d(1, 2, 3)

--- a/packages/data-model/__tests__/AcDbText.spec.ts
+++ b/packages/data-model/__tests__/AcDbText.spec.ts
@@ -69,6 +69,37 @@ describe('AcDbText', () => {
     expect(text.geometricExtents).toBeInstanceOf(AcGeBox3d)
   })
 
+  it('returns geometricExtents and recomputes when position changes', () => {
+    const text = new AcDbText()
+    text.textString = 'AB'
+    text.height = 2
+    text.verticalMode = AcDbTextVerticalMode.BASELINE
+    text.position = new AcGePoint3d(10, 20, 0)
+
+    expect(text.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(text.geometricExtents.max.x).toBeCloseTo(14)
+    expect(text.geometricExtents.max.y).toBeCloseTo(22)
+
+    text.position = new AcGePoint3d(0, 0, 0)
+
+    expect(text.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(text.geometricExtents.max.x).toBeCloseTo(4)
+    expect(text.geometricExtents.max.y).toBeCloseTo(2)
+  })
+
+  it('uses baseline-left extents when center alignment lacks alignment point', () => {
+    const text = new AcDbText()
+    text.textString = 'AB'
+    text.height = 2
+    text.horizontalMode = AcDbTextHorizontalMode.CENTER
+    text.verticalMode = AcDbTextVerticalMode.BASELINE
+    text.position = new AcGePoint3d(10, 20, 0)
+
+    expect(text.geometricExtents.min).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(text.geometricExtents.max.x).toBeCloseTo(14)
+    expect(text.geometricExtents.max.y).toBeCloseTo(22)
+  })
+
   it('returns insertion osnap point only for insertion mode', () => {
     const text = new AcDbText()
     text.position = new AcGePoint3d(3, 4, 5)

--- a/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
@@ -1,0 +1,123 @@
+import { AcGeBox3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
+import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
+
+import {
+  acdbCountMTextLines,
+  acdbEstimateMTextHeight,
+  acdbEstimatePlainTextWidth,
+  acdbExpandBoxByOrientedTextRect,
+  acdbGetLocalBoundsFromAttachment,
+  acdbStripMTextControlCodes
+} from '../src/entity/AcDbTextExtentsHelpers'
+
+describe('AcDbTextExtentsHelpers', () => {
+  describe('acdbStripMTextControlCodes', () => {
+    it('converts paragraph breaks and removes formatting codes', () => {
+      expect(acdbStripMTextControlCodes('A\\PB')).toBe('A\nB')
+      expect(acdbStripMTextControlCodes('{\\C1;Red}')).toBe('Red')
+    })
+  })
+
+  describe('acdbEstimatePlainTextWidth', () => {
+    it('returns zero for empty or zero-height text', () => {
+      expect(acdbEstimatePlainTextWidth('', 2)).toBe(0)
+      expect(acdbEstimatePlainTextWidth('AB', 0)).toBe(0)
+    })
+
+    it('uses the longest line and width factor', () => {
+      expect(acdbEstimatePlainTextWidth('AB\nC', 2, 0.5)).toBeCloseTo(2)
+      expect(acdbEstimatePlainTextWidth('ABCD', 2)).toBeCloseTo(8)
+    })
+  })
+
+  describe('acdbCountMTextLines', () => {
+    it('counts lines after control-code normalization', () => {
+      expect(acdbCountMTextLines('one')).toBe(1)
+      expect(acdbCountMTextLines('one\\Ptwo')).toBe(2)
+    })
+  })
+
+  describe('acdbEstimateMTextHeight', () => {
+    it('returns single-line height unchanged', () => {
+      expect(acdbEstimateMTextHeight(1, 2, 0.25)).toBe(2)
+    })
+
+    it('adds inter-line spacing for multiple lines', () => {
+      expect(acdbEstimateMTextHeight(2, 2, 1)).toBeCloseTo(4)
+      expect(acdbEstimateMTextHeight(2, 2, 0.25)).toBeCloseTo(2.5)
+      expect(acdbEstimateMTextHeight(3, 2, 1.5)).toBeCloseTo(8)
+    })
+  })
+
+  describe('acdbGetLocalBoundsFromAttachment', () => {
+    it('returns top-left bounds relative to the anchor', () => {
+      expect(
+        acdbGetLocalBoundsFromAttachment(
+          10,
+          4,
+          AcGiMTextAttachmentPoint.TopLeft
+        )
+      ).toEqual({ minX: 0, minY: -4, maxX: 10, maxY: 0 })
+    })
+
+    it('returns middle-center bounds relative to the anchor', () => {
+      expect(
+        acdbGetLocalBoundsFromAttachment(
+          10,
+          4,
+          AcGiMTextAttachmentPoint.MiddleCenter
+        )
+      ).toEqual({ minX: -5, minY: -2, maxX: 5, maxY: 2 })
+    })
+  })
+
+  describe('acdbExpandBoxByOrientedTextRect', () => {
+    it('expands only the anchor when width and height are zero', () => {
+      const box = new AcGeBox3d()
+      acdbExpandBoxByOrientedTextRect(
+        box,
+        new AcGePoint3d(3, 4, 5),
+        0,
+        0,
+        AcGiMTextAttachmentPoint.TopLeft
+      )
+
+      expect(box.min).toMatchObject({ x: 3, y: 4, z: 5 })
+      expect(box.max).toMatchObject({ x: 3, y: 4, z: 5 })
+    })
+
+    it('rotates local bounds around the anchor', () => {
+      const box = new AcGeBox3d()
+      acdbExpandBoxByOrientedTextRect(
+        box,
+        new AcGePoint3d(0, 0, 0),
+        4,
+        2,
+        AcGiMTextAttachmentPoint.BaselineLeft,
+        Math.PI / 2
+      )
+
+      expect(box.min.x).toBeCloseTo(-2)
+      expect(box.min.y).toBeCloseTo(0)
+      expect(box.max.x).toBeCloseTo(0)
+      expect(box.max.y).toBeCloseTo(4)
+    })
+
+    it('uses direction vector when provided', () => {
+      const box = new AcGeBox3d()
+      acdbExpandBoxByOrientedTextRect(
+        box,
+        new AcGePoint3d(0, 0, 0),
+        4,
+        2,
+        AcGiMTextAttachmentPoint.BaselineLeft,
+        0,
+        new AcGeVector3d(0, 1, 0)
+      )
+
+      expect(box.min.x).toBeCloseTo(-2)
+      expect(box.max.x).toBeCloseTo(0)
+      expect(box.max.y).toBeCloseTo(4)
+    })
+  })
+})

--- a/packages/data-model/__tests__/AcDbTrace.spec.ts
+++ b/packages/data-model/__tests__/AcDbTrace.spec.ts
@@ -124,6 +124,20 @@ describe('AcDbTrace', () => {
     expect(perpendicularPoints).toHaveLength(1)
   })
 
+  it('updates geometricExtents when a corner point changes', () => {
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, { x: 0, y: 0, z: 0 })
+    trace.setPointAt(1, { x: 4, y: 0, z: 0 })
+    trace.setPointAt(2, { x: 4, y: 3, z: 0 })
+    trace.setPointAt(3, { x: 0, y: 3, z: 0 })
+
+    expect(trace.geometricExtents.max).toMatchObject({ x: 4, y: 3, z: 0 })
+
+    trace.setPointAt(1, { x: 10, y: 0, z: 0 })
+
+    expect(trace.geometricExtents.max).toMatchObject({ x: 10, y: 3, z: 0 })
+  })
+
   it('orders DXF solid corners as a perimeter loop when drawing', () => {
     const trace = new AcDbTrace()
     trace.setPointAt(0, { x: 0, y: 0, z: 0 })

--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -72,6 +72,21 @@ describe('AcDbViewport', () => {
     expect(giViewport.viewCenter).toMatchObject({ x: 1, y: 1, z: 0 })
   })
 
+  it('returns geometricExtents and recomputes when centerPoint changes', () => {
+    const viewport = new AcDbViewport()
+    viewport.width = 10
+    viewport.height = 6
+    viewport.centerPoint = new AcGePoint3d(10, 20, 0)
+
+    expect(viewport.geometricExtents.min).toMatchObject({ x: 5, y: 17, z: 0 })
+    expect(viewport.geometricExtents.max).toMatchObject({ x: 15, y: 23, z: 0 })
+
+    viewport.centerPoint = new AcGePoint3d(0, 0, 0)
+
+    expect(viewport.geometricExtents.min).toMatchObject({ x: -5, y: -3, z: 0 })
+    expect(viewport.geometricExtents.max).toMatchObject({ x: 5, y: 3, z: 0 })
+  })
+
   it('transforms center/size/viewHeight and returns self', () => {
     const viewport = new AcDbViewport()
     viewport.centerPoint = new AcGePoint3d(1, 2, 0)

--- a/packages/data-model/__tests__/AcDbWipeout.spec.ts
+++ b/packages/data-model/__tests__/AcDbWipeout.spec.ts
@@ -104,4 +104,21 @@ describe('AcDbWipeout', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbWipeout())
   })
+
+  it('returns geometricExtents and updates when position and size change', () => {
+    createWorkingDb()
+    const wipeout = new AcDbWipeout()
+    wipeout.position = new AcGePoint3d(0, 0, 0)
+    wipeout.width = 10
+    wipeout.height = 10
+
+    expect(wipeout.geometricExtents.max).toMatchObject({ x: 10, y: 10 })
+
+    wipeout.position = new AcGePoint3d(5, 5, 0)
+    wipeout.width = 20
+    wipeout.height = 30
+
+    expect(wipeout.geometricExtents.min).toMatchObject({ x: 5, y: 5 })
+    expect(wipeout.geometricExtents.max).toMatchObject({ x: 25, y: 35 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbXline.spec.ts
+++ b/packages/data-model/__tests__/AcDbXline.spec.ts
@@ -52,6 +52,19 @@ describe('AcDbXline', () => {
     expect(extents.max).toMatchObject({ x: 21, y: 12, z: 8 })
   })
 
+  it('updates geometricExtents when basePoint changes', () => {
+    const xline = new AcDbXline()
+    xline.basePoint = new AcGePoint3d(0, 0, 0)
+    xline.unitDir = new AcGeVector3d(1, 0, 0)
+
+    expect(xline.geometricExtents.min).toMatchObject({ x: -10, y: 0, z: 0 })
+
+    xline.basePoint = new AcGePoint3d(20, 0, 0)
+
+    expect(xline.geometricExtents.min).toMatchObject({ x: 10, y: 0, z: 0 })
+    expect(xline.geometricExtents.max).toMatchObject({ x: 30, y: 0, z: 0 })
+  })
+
   it('exposes editable geometry properties via runtime accessors', () => {
     const xline = new AcDbXline()
     const geometryGroup = xline.properties.groups.find(

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -17,6 +17,12 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbCountMTextLines,
+  acdbEstimateMTextHeight,
+  acdbEstimatePlainTextWidth,
+  acdbExpandBoxByOrientedTextRect
+} from './AcDbTextExtentsHelpers'
 
 /**
  * Represents a multiline text (mtext) entity in AutoCAD.
@@ -347,8 +353,27 @@ export class AcDbMText extends AcDbEntity {
    * @inheritdoc
    */
   get geometricExtents(): AcGeBox3d {
-    // TODO: Implement it correctly
-    return new AcGeBox3d()
+    const box = new AcGeBox3d()
+    const width =
+      this.width > 0
+        ? this.width
+        : acdbEstimatePlainTextWidth(this.contents, this.height)
+    const lineCount = acdbCountMTextLines(this.contents)
+    const height = acdbEstimateMTextHeight(
+      lineCount,
+      this.height,
+      this.lineSpacingFactor
+    )
+
+    return acdbExpandBoxByOrientedTextRect(
+      box,
+      this._location,
+      width,
+      height,
+      this.attachmentPoint,
+      this.rotation,
+      this.direction
+    )
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -2,6 +2,7 @@ import { AcCmColor } from '@mlightcad/common'
 import {
   AcGeBox3d,
   AcGeMatrix3d,
+  AcGePoint3d,
   AcGeQuaternion,
   AcGeVector3d
 } from '@mlightcad/geometry-engine'
@@ -388,8 +389,47 @@ export class AcDbTable extends AcDbBlockReference {
    * @inheritdoc
    */
   get geometricExtents(): AcGeBox3d {
-    // TODO: Implement it
-    return new AcGeBox3d()
+    let blockTableRecord
+    try {
+      blockTableRecord = this.blockTableRecord
+    } catch {
+      blockTableRecord = undefined
+    }
+
+    if (blockTableRecord && blockTableRecord.newIterator().count > 0) {
+      const box = new AcGeBox3d()
+      for (const entity of blockTableRecord.newIterator()) {
+        box.union(entity.geometricExtents)
+      }
+      box.applyMatrix4(this.blockTransform)
+      return box
+    }
+
+    const totalWidth = this._columnWidth.reduce((sum, value) => sum + value, 0)
+    const totalHeight = this._rowHeight.reduce((sum, value) => sum + value, 0)
+    const box = new AcGeBox3d()
+
+    if (totalWidth === 0 && totalHeight === 0) {
+      box.expandByPoint(this.position)
+      return box
+    }
+
+    const quaternion = new AcGeQuaternion()
+    quaternion.setFromAxisAngle(AcGeVector3d.Z_AXIS, this.rotation)
+    _tmpMatrix.compose(this.position, quaternion, this.scaleFactors)
+
+    const localCorners = [
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(totalWidth, 0, 0),
+      new AcGePoint3d(totalWidth, -totalHeight, 0),
+      new AcGePoint3d(0, -totalHeight, 0)
+    ]
+
+    for (const corner of localCorners) {
+      box.expandByPoint(corner.applyMatrix4(_tmpMatrix))
+    }
+
+    return box
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -18,6 +18,10 @@ import { AcDbDxfFiler } from '../base'
 import { AcDbOsnapMode } from '../misc'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbEstimatePlainTextWidth,
+  acdbExpandBoxByOrientedTextRect
+} from './AcDbTextExtentsHelpers'
 
 /**
  * Defines the horizontal alignment mode for text entities.
@@ -487,8 +491,22 @@ export class AcDbText extends AcDbEntity {
    * ```
    */
   get geometricExtents(): AcGeBox3d {
-    // TODO: Implement it correctly
-    return new AcGeBox3d()
+    const box = new AcGeBox3d()
+    const { anchor, attachmentPoint } = this.resolveTextAnchor()
+
+    const width = acdbEstimatePlainTextWidth(
+      this.textString,
+      this.height,
+      this.widthFactor
+    )
+    return acdbExpandBoxByOrientedTextRect(
+      box,
+      anchor,
+      width,
+      this.height,
+      attachmentPoint,
+      this.rotation
+    )
   }
 
   /**
@@ -739,30 +757,7 @@ export class AcDbText extends AcDbEntity {
     // or MIDDLE/TOP/BOTTOM modes. Pick the right reference + the matching
     // attachment point so the renderer can compute the offset itself
     // from the real bbox of the laid-out glyphs.
-    let attachmentPoint = this.resolveAttachmentPoint()
-    let position: AcGePoint3d
-    if (attachmentPoint === AcGiMTextAttachmentPoint.BaselineLeft) {
-      // Default LEFT + BASELINE: `position` (group 10) is the anchor.
-      position = this._position
-    } else {
-      // Non-default alignment: anchor is in `alignmentPoint` (group 11).
-      // If group 11 was not propagated by the converter (still zero) or
-      // is the same as `position`, fall back to LEFT/BASELINE so the
-      // entity renders at a sensible spot instead of jumping to the
-      // world origin (0, 0).
-      const ap = this._alignmentPoint
-      const apIsUnset =
-        (ap.x === 0 && ap.y === 0 && ap.z === 0) ||
-        (ap.x === this._position.x &&
-          ap.y === this._position.y &&
-          ap.z === this._position.z)
-      if (apIsUnset) {
-        attachmentPoint = AcGiMTextAttachmentPoint.BaselineLeft
-        position = this._position
-      } else {
-        position = ap
-      }
-    }
+    const { anchor: position, attachmentPoint } = this.resolveTextAnchor()
     const mtextData: AcGiMTextData = {
       text: this.textString,
       height: this.height,
@@ -777,6 +772,39 @@ export class AcDbText extends AcDbEntity {
       attachmentPoint
     }
     return renderer.mtext(mtextData, this.getTextStyle(), delay)
+  }
+
+  /**
+   * Resolves the anchor point and attachment used for rendering and extents.
+   *
+   * For default LEFT + BASELINE, `position` (group 10) is the anchor.
+   * For other alignments, `alignmentPoint` (group 11) is used when set.
+   * When group 11 is missing, falls back to LEFT/BASELINE at `position`.
+   */
+  private resolveTextAnchor(): {
+    anchor: AcGePoint3d
+    attachmentPoint: AcGiMTextAttachmentPoint
+  } {
+    const attachmentPoint = this.resolveAttachmentPoint()
+
+    if (attachmentPoint === AcGiMTextAttachmentPoint.BaselineLeft) {
+      return { anchor: this._position, attachmentPoint }
+    }
+
+    const ap = this._alignmentPoint
+    const apIsUnset =
+      (ap.x === 0 && ap.y === 0 && ap.z === 0) ||
+      (ap.x === this._position.x &&
+        ap.y === this._position.y &&
+        ap.z === this._position.z)
+    if (apIsUnset) {
+      return {
+        anchor: this._position,
+        attachmentPoint: AcGiMTextAttachmentPoint.BaselineLeft
+      }
+    }
+
+    return { anchor: ap, attachmentPoint }
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
+++ b/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
@@ -1,0 +1,198 @@
+import {
+  AcGeBox3d,
+  AcGePoint3d,
+  AcGePoint3dLike,
+  AcGeVector3d,
+  AcGeVector3dLike
+} from '@mlightcad/geometry-engine'
+import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
+
+const CHAR_WIDTH_FACTOR = 1
+
+/**
+ * Strips MTEXT control codes and returns plain text for width/line estimation.
+ */
+export function acdbStripMTextControlCodes(text: string): string {
+  return text
+    .replace(/\\[PpNn]/g, '\n')
+    .replace(/\\[A-Za-z][^;]*;/g, '')
+    .replace(/[{}]/g, '')
+}
+
+/**
+ * Estimates rendered text width from plain text length and height.
+ */
+export function acdbEstimatePlainTextWidth(
+  text: string,
+  textHeight: number,
+  widthFactor = 1
+): number {
+  if (!text || textHeight <= 0) return 0
+
+  const plainText = acdbStripMTextControlCodes(text)
+  const longestLineLength = Math.max(
+    ...plainText.split(/\r\n|\r|\n/g).map(line => line.length),
+    0
+  )
+  if (longestLineLength === 0) return 0
+
+  return Math.max(
+    textHeight,
+    longestLineLength * textHeight * CHAR_WIDTH_FACTOR * widthFactor
+  )
+}
+
+/**
+ * Counts logical MTEXT lines after control-code normalization.
+ */
+export function acdbCountMTextLines(text: string): number {
+  const plainText = acdbStripMTextControlCodes(text)
+  return Math.max(plainText.split(/\r\n|\r|\n/g).length, 1)
+}
+
+/**
+ * Estimates total MTEXT height from line count and line-spacing factor.
+ *
+ * Line spacing factor multiplies text height to get the distance between
+ * consecutive line baselines (AutoCAD DXF group 44 semantics).
+ */
+export function acdbEstimateMTextHeight(
+  lineCount: number,
+  textHeight: number,
+  lineSpacingFactor: number
+): number {
+  if (textHeight <= 0 || lineCount <= 0) return 0
+  if (lineCount === 1) return textHeight
+
+  const spacing = Math.max(lineSpacingFactor, 0)
+  return textHeight + (lineCount - 1) * textHeight * spacing
+}
+
+interface LocalBounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+/**
+ * Returns axis-aligned bounds in text-local coordinates relative to the attachment anchor.
+ */
+export function acdbGetLocalBoundsFromAttachment(
+  width: number,
+  height: number,
+  attachment: AcGiMTextAttachmentPoint
+): LocalBounds {
+  switch (attachment) {
+    case AcGiMTextAttachmentPoint.TopCenter:
+      return {
+        minX: -width / 2,
+        minY: -height,
+        maxX: width / 2,
+        maxY: 0
+      }
+    case AcGiMTextAttachmentPoint.TopRight:
+      return { minX: -width, minY: -height, maxX: 0, maxY: 0 }
+    case AcGiMTextAttachmentPoint.MiddleLeft:
+      return {
+        minX: 0,
+        minY: -height / 2,
+        maxX: width,
+        maxY: height / 2
+      }
+    case AcGiMTextAttachmentPoint.MiddleCenter:
+      return {
+        minX: -width / 2,
+        minY: -height / 2,
+        maxX: width / 2,
+        maxY: height / 2
+      }
+    case AcGiMTextAttachmentPoint.MiddleRight:
+      return {
+        minX: -width,
+        minY: -height / 2,
+        maxX: 0,
+        maxY: height / 2
+      }
+    case AcGiMTextAttachmentPoint.BottomLeft:
+    case AcGiMTextAttachmentPoint.BaselineLeft:
+      return { minX: 0, minY: 0, maxX: width, maxY: height }
+    case AcGiMTextAttachmentPoint.BottomCenter:
+    case AcGiMTextAttachmentPoint.BaselineCenter:
+      return {
+        minX: -width / 2,
+        minY: 0,
+        maxX: width / 2,
+        maxY: height
+      }
+    case AcGiMTextAttachmentPoint.BottomRight:
+    case AcGiMTextAttachmentPoint.BaselineRight:
+      return { minX: -width, minY: 0, maxX: 0, maxY: height }
+    case AcGiMTextAttachmentPoint.TopLeft:
+    default:
+      return { minX: 0, minY: -height, maxX: width, maxY: 0 }
+  }
+}
+
+function getTextAxes(rotation: number, direction?: AcGeVector3d) {
+  let xAxis: AcGeVector3d
+  if (direction && direction.lengthSq() > 0) {
+    xAxis = direction.clone().normalize()
+  } else {
+    xAxis = new AcGeVector3d(Math.cos(rotation), Math.sin(rotation), 0)
+  }
+
+  const yAxis = new AcGeVector3d(-xAxis.y, xAxis.x, xAxis.z)
+  if (yAxis.lengthSq() === 0) {
+    yAxis.set(0, 1, 0)
+  } else {
+    yAxis.normalize()
+  }
+
+  return { xAxis, yAxis }
+}
+
+/**
+ * Expands a box with an oriented text rectangle anchored at `anchor`.
+ */
+export function acdbExpandBoxByOrientedTextRect(
+  box: AcGeBox3d,
+  anchor: AcGePoint3dLike,
+  width: number,
+  height: number,
+  attachment: AcGiMTextAttachmentPoint,
+  rotation = 0,
+  direction?: AcGeVector3dLike
+) {
+  if (width <= 0 && height <= 0) {
+    box.expandByPoint(anchor)
+    return box
+  }
+
+  const bounds = acdbGetLocalBoundsFromAttachment(width, height, attachment)
+  const { xAxis, yAxis } = getTextAxes(
+    rotation,
+    direction
+      ? new AcGeVector3d(direction.x, direction.y, direction.z || 0)
+      : undefined
+  )
+
+  const corners: Array<[number, number]> = [
+    [bounds.minX, bounds.minY],
+    [bounds.maxX, bounds.minY],
+    [bounds.maxX, bounds.maxY],
+    [bounds.minX, bounds.maxY]
+  ]
+
+  for (const [localX, localY] of corners) {
+    box.expandByPoint(
+      new AcGePoint3d(
+        anchor.x + xAxis.x * localX + yAxis.x * localY,
+        anchor.y + xAxis.y * localX + yAxis.y * localY,
+        anchor.z + xAxis.z * localX + yAxis.z * localY
+      )
+    )
+  }
+
+  return box
+}

--- a/packages/data-model/src/entity/AcDbViewport.ts
+++ b/packages/data-model/src/entity/AcDbViewport.ts
@@ -188,8 +188,24 @@ export class AcDbViewport extends AcDbEntity {
    * @inheritdoc
    */
   get geometricExtents(): AcGeBox3d {
-    // TODO: Implement it correctly
-    return new AcGeBox3d()
+    const halfWidth = this._width / 2
+    const halfHeight = this._height / 2
+    const box = new AcGeBox3d()
+    box.expandByPoint(
+      new AcGePoint3d(
+        this._centerPoint.x - halfWidth,
+        this._centerPoint.y - halfHeight,
+        this._centerPoint.z
+      )
+    )
+    box.expandByPoint(
+      new AcGePoint3d(
+        this._centerPoint.x + halfWidth,
+        this._centerPoint.y + halfHeight,
+        this._centerPoint.z
+      )
+    )
+    return box
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
@@ -1,5 +1,4 @@
 import {
-  AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePointLike
@@ -175,8 +174,12 @@ export class AcDb3PointAngularDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    return this.getGeometricExtentsFromDimBlockOrPoints([
+      this.xLine1Point,
+      this.xLine2Point,
+      this.centerPoint,
+      this.arcPoint
+    ])
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
@@ -324,7 +324,11 @@ export class AcDbAlignedDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    return this.getDimBlockGeometricExtents()
+    return this.getGeometricExtentsFromDimBlockOrPoints([
+      this.xLine1Point,
+      this.xLine2Point,
+      this.dimLinePoint
+    ])
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
@@ -1,5 +1,4 @@
 import {
-  AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
@@ -177,8 +176,12 @@ export class AcDbArcDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    return this.getGeometricExtentsFromDimBlockOrPoints([
+      this.xLine1Point,
+      this.xLine2Point,
+      this.centerPoint,
+      this.arcPoint
+    ])
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
@@ -1,5 +1,4 @@
 import {
-  AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
@@ -221,8 +220,15 @@ export class AcDbDiametricDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    const points = [this.chordPoint, this.farChordPoint]
+    if (this.leaderLength > 0) {
+      const direction = this.farChordPoint.clone().sub(this.chordPoint)
+      if (direction.lengthSq() > 0) {
+        direction.normalize().multiplyScalar(this.leaderLength)
+        points.push(this.farChordPoint.clone().add(direction))
+      }
+    }
+    return this.getGeometricExtentsFromDimBlockOrPoints(points)
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -488,6 +488,36 @@ export abstract class AcDbDimension extends AcDbEntity {
   }
 
   /**
+   * Builds geometric extents from a dimension block when present, otherwise from
+   * the supplied WCS definition points and user-placed text position.
+   */
+  protected getGeometricExtentsFromDimBlockOrPoints(
+    points: AcGePoint3dLike[]
+  ): AcGeBox3d {
+    const blockExtents = this.getDimBlockGeometricExtents()
+    if (!blockExtents.isEmpty()) {
+      return blockExtents
+    }
+
+    const box = new AcGeBox3d()
+    for (const point of points) {
+      box.expandByPoint(point)
+    }
+    if (this.hasExplicitTextPosition()) {
+      box.expandByPoint(this.textPosition)
+    }
+    return box
+  }
+
+  /**
+   * Returns true when dimension text has been placed away from the default origin.
+   */
+  private hasExplicitTextPosition(): boolean {
+    const { x, y, z } = this.textPosition
+    return x !== 0 || y !== 0 || z !== 0
+  }
+
+  /**
    * Looks up the anonymous block referenced by `dimBlockId`.
    */
   protected getDimBlockTableRecord() {

--- a/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
@@ -1,5 +1,4 @@
 import {
-  AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
@@ -130,8 +129,10 @@ export class AcDbOrdinateDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    return this.getGeometricExtentsFromDimBlockOrPoints([
+      this.definingPoint,
+      this.leaderEndPoint
+    ])
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
@@ -1,5 +1,4 @@
 import {
-  AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike
@@ -323,8 +322,15 @@ export class AcDbRadialDimension extends AcDbDimension {
    * @inheritdoc
    */
   get geometricExtents() {
-    // TODO: Finish it
-    return new AcGeBox3d()
+    const points = [this.center, this.chordPoint]
+    if (this.leaderLength > 0) {
+      const direction = this.chordPoint.clone().sub(this.center)
+      if (direction.lengthSq() > 0) {
+        direction.normalize().multiplyScalar(this.leaderLength)
+        points.push(this.chordPoint.clone().add(direction))
+      }
+    }
+    return this.getGeometricExtentsFromDimBlockOrPoints(points)
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
@@ -439,9 +439,7 @@ export class AcGeCircArc3d extends AcGeCurve3d {
       const angle = this.getAngle(candidate.clone())
       const t = AcGeMathUtil.normalizeAngle(angle - this.startAngle)
       if (t >= 0 && t <= this.deltaAngle) {
-        result.push(
-          new AcGePoint3d(candidate.x, candidate.y, candidate.z || 0)
-        )
+        result.push(new AcGePoint3d(candidate.x, candidate.y, candidate.z || 0))
       }
     }
 

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc2d.ts
@@ -462,12 +462,7 @@ export class AcGeEllipseArc2d extends AcGeCurve2d {
 
   private _findSnapAngles(
     _localP: { x: number; y: number },
-    errorAt: (
-      qx: number,
-      qy: number,
-      cos: number,
-      sin: number
-    ) => number,
+    errorAt: (qx: number, qy: number, cos: number, sin: number) => number,
     samples = 144
   ): number[] {
     const a = this.majorAxisRadius

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -488,12 +488,7 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
   }
 
   private _findSnapParameterAngles(
-    errorAt: (
-      qx: number,
-      qy: number,
-      cos: number,
-      sin: number
-    ) => number,
+    errorAt: (qx: number, qy: number, cos: number, sin: number) => number,
     samples = 144
   ): number[] {
     const a = this.majorAxisRadius


### PR DESCRIPTION
## Summary

- Add \AcDbTextExtentsHelpers\ to estimate TEXT/MTEXT bounds from attachment point, rotation, and line spacing, and wire it into \AcDbText\, \AcDbMText\, and related entities.
- Implement \geometricExtents\ for \AcDbTable\ (block union or row/column fallback), \AcDbViewport\, and all dimension subtypes via a shared \getGeometricExtentsFromDimBlockOrPoints\ fallback when the dim block is absent.
- Add regression tests across entity specs to verify extents recompute when geometry properties change.

## Test plan

- [x] \pnpm test -- packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts packages/data-model/__tests__/AcDbText.spec.ts packages/data-model/__tests__/AcDbMText.spec.ts\`n- [ ] \pnpm test -- packages/data-model\ (full data-model suite)
- [ ] Verify zoom-to-extents and selection bounding boxes for TEXT, MTEXT, TABLE, VIEWPORT, and dimension entities in the viewer

Made with [Cursor](https://cursor.com)