### PR TITLE
fix(data-model): normalize VPORT table names case-insensitively

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfConverter.spec.ts
@@ -6,6 +6,7 @@ import { AcDbBlockReference } from '../src/entity/AcDbBlockReference'
 import { AcDbBlockTableRecord } from '../src/database/AcDbBlockTableRecord'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
+import { ACTIVE_VPORT_NAME } from '../src/misc/AcDbConstants'
 
 class TestDxfConverter extends AcDbDxfConverter {
   parsePublic(data: ArrayBuffer, timeout?: number) {
@@ -184,7 +185,7 @@ describe('AcDbDxfConverter', () => {
           VPORT: {
             entries: [
               {
-                name: '*ACTIVE',
+                name: ACTIVE_VPORT_NAME,
                 standardFlag: 0,
                 center: { x: 100, y: 200 },
                 lowerLeftCorner: { x: 0, y: 0 },
@@ -199,7 +200,7 @@ describe('AcDbDxfConverter', () => {
       db
     )
 
-    const active = db.tables.viewportTable.getAt('*ACTIVE')
+    const active = db.tables.viewportTable.getAt(ACTIVE_VPORT_NAME)
 
     expect(active?.viewHeight).toBe(50)
     expect(active?.aspectRatio).toBe(1.6)

--- a/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
@@ -1,4 +1,8 @@
-import { AcGeBox3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
+import {
+  AcGeBox3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
 import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
 import {

--- a/packages/data-model/__tests__/AcDbViewportTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewportTable.spec.ts
@@ -1,6 +1,7 @@
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbViewportTable } from '../src/database/AcDbViewportTable'
 import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
+import { ACTIVE_VPORT_NAME } from '../src/misc/AcDbConstants'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 describe('AcDbViewportTable', () => {
@@ -12,11 +13,31 @@ describe('AcDbViewportTable', () => {
     const db = new AcDbDatabase()
     const table = db.tables.viewportTable
     const record = new AcDbViewportTableRecord()
-    record.name = '*Active'
+    record.name = ACTIVE_VPORT_NAME
     table.add(record)
 
-    expect(table.has('*Active')).toBe(true)
-    expect(table.remove('*Active')).toBe(true)
-    expect(table.getAt('*Active')).toBeUndefined()
+    expect(table.has(ACTIVE_VPORT_NAME)).toBe(true)
+    expect(table.remove(ACTIVE_VPORT_NAME)).toBe(true)
+    expect(table.getAt(ACTIVE_VPORT_NAME)).toBeUndefined()
+  })
+
+  it('normalizes *Active and other configuration names case-insensitively', () => {
+    const db = new AcDbDatabase()
+    const table = db.tables.viewportTable
+    const active = new AcDbViewportTableRecord()
+    active.name = '*ACTIVE'
+    table.add(active)
+
+    expect(table.getAt('*Active')).toBe(active)
+    expect(table.getAt('*active')).toBe(active)
+    expect(table.has('*ACTIVE')).toBe(true)
+
+    const config = new AcDbViewportTableRecord()
+    config.name = '4view'
+    table.add(config)
+
+    expect(table.getAt('4VIEW')).toBe(config)
+    expect(table.remove('4View')).toBe(true)
+    expect(table.has('4view')).toBe(false)
   })
 })

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -17,6 +17,7 @@ import {
 import { AcDbEntity } from '../entity'
 import {
   ACAD_APPID,
+  ACTIVE_VPORT_NAME,
   AcDbAngleUnits,
   AcDbDataGenerator,
   AcDbFormatter,
@@ -1763,9 +1764,9 @@ export class AcDbDatabase extends AcDbObject {
       )
     }
 
-    if (!this.tables.viewportTable.has('*Active')) {
+    if (!this.tables.viewportTable.has(ACTIVE_VPORT_NAME)) {
       const viewport = new AcDbViewportTableRecord()
-      viewport.name = '*Active'
+      viewport.name = ACTIVE_VPORT_NAME
       this.tables.viewportTable.add(viewport)
     }
 

--- a/packages/data-model/src/database/AcDbViewportTable.ts
+++ b/packages/data-model/src/database/AcDbViewportTable.ts
@@ -1,3 +1,4 @@
+import { ACTIVE_VPORT_NAME } from '../misc/AcDbConstants'
 import { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSymbolTable } from './AcDbSymbolTable'
 import { AcDbViewportTableRecord } from './AcDbViewportTableRecord'
@@ -13,7 +14,7 @@ import { AcDbViewportTableRecord } from './AcDbViewportTableRecord'
  * @example
  * ```typescript
  * const viewportTable = new AcDbViewportTable(database);
- * const viewport = viewportTable.getAt('*Active');
+ * const viewport = viewportTable.getAt(ACTIVE_VPORT_NAME);
  * ```
  */
 export class AcDbViewportTable extends AcDbSymbolTable<AcDbViewportTableRecord> {
@@ -29,5 +30,22 @@ export class AcDbViewportTable extends AcDbSymbolTable<AcDbViewportTableRecord> 
    */
   constructor(db: AcDbDatabase) {
     super(db)
+  }
+
+  /**
+   * Normalizes VPORT table record names for AutoCAD-compatible lookup.
+   *
+   * The reserved active viewport name compares case-insensitively and is stored
+   * as `*Active`. All other configuration names also compare case-insensitively.
+   *
+   * @override
+   * @param name - The name of the viewport table record.
+   * @returns The normalized viewport table record name.
+   */
+  protected normalizeName(name: string) {
+    if (AcDbViewportTableRecord.isActiveVportName(name)) {
+      return ACTIVE_VPORT_NAME
+    }
+    return name.toUpperCase()
   }
 }

--- a/packages/data-model/src/database/AcDbViewportTableRecord.ts
+++ b/packages/data-model/src/database/AcDbViewportTableRecord.ts
@@ -1,6 +1,7 @@
 import { AcGePoint2d } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../base'
+import { ACTIVE_VPORT_NAME } from '../misc/AcDbConstants'
 import { AcDbAbstractViewTableRecord } from './AcDbAbstractViewTableRecord'
 
 /**
@@ -14,13 +15,24 @@ import { AcDbAbstractViewTableRecord } from './AcDbAbstractViewTableRecord'
  * @example
  * ```typescript
  * const viewportRecord = new AcDbViewportTableRecord();
- * viewportRecord.name = '*Active';
+ * viewportRecord.name = ACTIVE_VPORT_NAME;
  * viewportRecord.circleSides = 100;
  * viewportRecord.lowerLeftCorner = new AcGePoint2d(0, 0);
  * viewportRecord.upperRightCorner = new AcGePoint2d(1, 1);
  * ```
  */
 export class AcDbViewportTableRecord extends AcDbAbstractViewTableRecord {
+  /**
+   * Returns true if the specified name is the active viewport table record.
+   *
+   * AutoCAD stores the current model-space viewport configuration as `*Active`.
+   * DXF/DWG sources may emit different casing (`*ACTIVE`, `*active`, etc.), but
+   * the names compare case-insensitively.
+   */
+  static isActiveVportName(name: string) {
+    return name.toLowerCase() === ACTIVE_VPORT_NAME.toLowerCase()
+  }
+
   /** Number of sides used for circle tessellation */
   private _circleSides: number
   /** Lower left corner of the viewport window */

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -200,6 +200,7 @@ export type {
 } from './entity'
 export {
   ACAD_APPID,
+  ACTIVE_VPORT_NAME,
   AcDbAngleUnits,
   AcDbCodePage,
   AcDbDataGenerator,

--- a/packages/data-model/src/misc/AcDbConstants.ts
+++ b/packages/data-model/src/misc/AcDbConstants.ts
@@ -73,6 +73,14 @@ export const ByLayer = 'ByLayer'
 export const ByBlock = 'ByBlock'
 
 /**
+ * Name of the active viewport table record in AutoCAD.
+ *
+ * This reserved name identifies the current viewport configuration in the
+ * VPORT symbol table.
+ */
+export const ACTIVE_VPORT_NAME = '*Active'
+
+/**
  * Application ID for MLightCAD used in dictionaries and XData registration.
  */
 export const MLIGHTCAD_APPID = 'mlightcad'

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -6,6 +6,7 @@ export { AcDbRenderingCache } from './AcDbRenderingCache'
 export { AcDbCodePage, dwgCodePageToEncoding } from './AcDbCodePage'
 export {
   ACAD_APPID,
+  ACTIVE_VPORT_NAME,
   ByBlock,
   ByLayer,
   DEFAULT_GRADIENT_HATCH_NAME,

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -45,7 +45,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "^0.7.1"
+    "@mlightcad/libredwg-web": "^0.7.2"
   },
   "devDependencies": {
     "vite": "^5.2.10"

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -357,7 +357,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       if (item.viewHeight) {
         record.gsView.viewHeight = item.viewHeight
       }
-      const aspectRatio = (item as { aspectRatio?: number }).aspectRatio
+      const aspectRatio = item.aspectRatio
       if (
         aspectRatio != null &&
         Number.isFinite(aspectRatio) &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: workspace:*
         version: link:../data-model
       '@mlightcad/libredwg-web':
-        specifier: ^0.7.1
-        version: 0.7.1
+        specifier: ^0.7.2
+        version: 0.7.2
     devDependencies:
       vite:
         specifier: ^5.2.10
@@ -1395,8 +1395,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.1':
-    resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
+  '@mlightcad/libredwg-web@0.7.2':
+    resolution: {integrity: sha512-MPbVtnuUokzvCS4pdibiNw7PLdnSJo9R1pZcBnzRCyzWQqMHuZOxLVwtsV9aGk1SBmJ2186Hbu3Umt2B7hFS4Q==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6344,7 +6344,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.1': {}
+  '@mlightcad/libredwg-web@0.7.2': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `ACTIVE_VPORT_NAME` constant and case-insensitive lookup for the active viewport (`*Active` / `*ACTIVE`) and other VPORT configuration names
- Override `AcDbViewportTable.normalizeName` to match AutoCAD behavior
- Upgrade `@mlightcad/libredwg-web` to 0.7.2 and use typed `aspectRatio` field in the converter

## Test plan
- [x] `AcDbViewportTable` unit tests cover case-insensitive normalization for `*Active` and configuration names
- [x] `AcDbDxfConverter` tests updated to use `ACTIVE_VPORT_NAME` constant
- [ ] CI passes

Made with [Cursor](https://cursor.com)