### PR TITLE
feat(data-model): add drawNoPlotLayers policy for no-plot layer visibility

### DIFF
--- a/packages/data-model/__tests__/AcDbEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntity.spec.ts
@@ -107,6 +107,49 @@ describe('AcDbEntity.dxfTypeName', () => {
   })
 })
 
+describe('AcDbEntity.worldDraw layer policy', () => {
+  let db: AcDbDatabase
+
+  beforeEach(() => {
+    db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+  })
+
+  it('skips subWorldDraw when drawNoPlotLayers is false and layer is non-plottable', () => {
+    ;(db as unknown as { _drawNoPlotLayers: boolean })._drawNoPlotLayers = false
+    db.tables.layerTable.add(
+      new AcDbLayerTableRecord({ name: 'NPLT', isPlottable: false })
+    )
+
+    const entity = new DummyEntity()
+    entity.layer = 'NPLT'
+    db.tables.blockTable.modelSpace.appendEntity(entity)
+
+    const subWorldDraw = jest.spyOn(entity, 'subWorldDraw')
+    const renderer = { subEntityTraits: {} } as never
+
+    expect(entity.worldDraw(renderer)).toBeUndefined()
+    expect(subWorldDraw).not.toHaveBeenCalled()
+  })
+
+  it('calls subWorldDraw when drawNoPlotLayers is true on a non-plottable layer', () => {
+    db.tables.layerTable.add(
+      new AcDbLayerTableRecord({ name: 'NPLT', isPlottable: false })
+    )
+
+    const entity = new DummyEntity()
+    entity.layer = 'NPLT'
+    db.tables.blockTable.modelSpace.appendEntity(entity)
+
+    const subWorldDraw = jest.spyOn(entity, 'subWorldDraw')
+    const renderer = { subEntityTraits: {} } as never
+
+    entity.worldDraw(renderer)
+    expect(subWorldDraw).toHaveBeenCalled()
+  })
+})
+
 describe('AcDbEntity.color resolution', () => {
   let db: AcDbDatabase
 

--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -5,7 +5,11 @@ import {
 } from '@mlightcad/geometry-engine'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
-import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
+import {
+  AcDbBlockTableRecord,
+  AcDbDatabase,
+  AcDbLayerTableRecord
+} from '../src/database'
 import { AcDbViewport } from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
@@ -117,43 +121,120 @@ describe('AcDbViewport', () => {
     expect(viewport.viewHeight).toBe(7)
   })
 
-  it('draws rectangle in paper space for active viewport only', () => {
-    const db = createDb()
-
-    const paperSpace = new AcDbBlockTableRecord()
-    paperSpace.name = '*Paper_Space0'
-    db.tables.blockTable.add(paperSpace)
-
-    const viewport = new AcDbViewport()
-    viewport.number = 2
-    viewport.centerPoint = new AcGePoint3d(10, 20, 0)
-    viewport.width = 8
-    viewport.height = 6
-    paperSpace.appendEntity(viewport)
-
-    const renderer = {
+  describe('subWorldDraw', () => {
+    const createRenderer = () => ({
       lines: jest.fn((points: AcGePoint3d[]) => ({ points })),
       group: jest.fn((children: unknown[]) => ({ children }))
+    })
+
+    const appendPaperSpaceViewport = (
+      db: AcDbDatabase,
+      attrs?: Partial<{
+        number: number
+        layer: string
+        centerPoint: AcGePoint3d
+        width: number
+        height: number
+      }>
+    ) => {
+      const paperSpace = new AcDbBlockTableRecord()
+      paperSpace.name = '*Paper_Space0'
+      db.tables.blockTable.add(paperSpace)
+
+      const viewport = new AcDbViewport()
+      viewport.number = attrs?.number ?? 2
+      viewport.layer = attrs?.layer ?? '0'
+      viewport.centerPoint =
+        attrs?.centerPoint ?? new AcGePoint3d(10, 20, 0)
+      viewport.width = attrs?.width ?? 8
+      viewport.height = attrs?.height ?? 6
+      paperSpace.appendEntity(viewport)
+      return viewport
     }
 
-    const drawn = viewport.subWorldDraw(renderer as never)
-    expect(renderer.lines).toHaveBeenCalledTimes(4)
-    expect(renderer.group).toHaveBeenCalledTimes(1)
-    expect(drawn).toBeDefined()
+    it('draws rectangle in paper space for active viewport only', () => {
+      const db = createDb()
+      const paperSpace = new AcDbBlockTableRecord()
+      paperSpace.name = '*Paper_Space0'
+      db.tables.blockTable.add(paperSpace)
 
-    const firstEdge = renderer.lines.mock.calls[0][0] as AcGePoint3d[]
-    expect(firstEdge[0]).toMatchObject({ x: 6, y: 17, z: 0 })
-    expect(firstEdge[1]).toMatchObject({ x: 14, y: 17, z: 0 })
+      const viewport = new AcDbViewport()
+      viewport.number = 2
+      viewport.centerPoint = new AcGePoint3d(10, 20, 0)
+      viewport.width = 8
+      viewport.height = 6
+      paperSpace.appendEntity(viewport)
 
-    const inactive = new AcDbViewport()
-    inactive.number = 1
-    paperSpace.appendEntity(inactive)
-    expect(inactive.subWorldDraw(renderer as never)).toBeUndefined()
+      const renderer = createRenderer()
 
-    const inModelSpace = new AcDbViewport()
-    inModelSpace.number = 2
-    db.tables.blockTable.modelSpace.appendEntity(inModelSpace)
-    expect(inModelSpace.subWorldDraw(renderer as never)).toBeUndefined()
+      const drawn = viewport.subWorldDraw(renderer as never)
+      expect(renderer.lines).toHaveBeenCalledTimes(4)
+      expect(renderer.group).toHaveBeenCalledTimes(1)
+      expect(drawn).toBeDefined()
+
+      const firstEdge = renderer.lines.mock.calls[0][0] as AcGePoint3d[]
+      expect(firstEdge[0]).toMatchObject({ x: 6, y: 17, z: 0 })
+      expect(firstEdge[1]).toMatchObject({ x: 14, y: 17, z: 0 })
+
+      const inactive = new AcDbViewport()
+      inactive.number = 1
+      paperSpace.appendEntity(inactive)
+      expect(inactive.subWorldDraw(renderer as never)).toBeUndefined()
+
+      const inModelSpace = new AcDbViewport()
+      inModelSpace.number = 2
+      db.tables.blockTable.modelSpace.appendEntity(inModelSpace)
+      expect(inModelSpace.subWorldDraw(renderer as never)).toBeUndefined()
+    })
+
+    it('still draws border on a non-plottable layer when called directly', () => {
+      const db = createDb()
+      ;(db as unknown as { _drawNoPlotLayers: boolean })._drawNoPlotLayers =
+        false
+      db.tables.layerTable.add(
+        new AcDbLayerTableRecord({ name: 'NPLT', isPlottable: false })
+      )
+
+      const viewport = appendPaperSpaceViewport(db, { layer: 'NPLT' })
+      const renderer = createRenderer()
+
+      expect(viewport.subWorldDraw(renderer as never)).toBeDefined()
+      expect(renderer.lines).toHaveBeenCalledTimes(4)
+      expect(renderer.group).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('worldDraw', () => {
+    it('delegates no-plot suppression to AcDbEntity.worldDraw', () => {
+      const db = createDb()
+      ;(db as unknown as { _drawNoPlotLayers: boolean })._drawNoPlotLayers =
+        false
+      db.tables.layerTable.add(
+        new AcDbLayerTableRecord({ name: 'NPLT', isPlottable: false })
+      )
+
+      const paperSpace = new AcDbBlockTableRecord()
+      paperSpace.name = '*Paper_Space0'
+      db.tables.blockTable.add(paperSpace)
+
+      const viewport = new AcDbViewport()
+      viewport.number = 2
+      viewport.layer = 'NPLT'
+      viewport.centerPoint = new AcGePoint3d(10, 20, 0)
+      viewport.width = 8
+      viewport.height = 6
+      paperSpace.appendEntity(viewport)
+
+      const subWorldDraw = jest.spyOn(viewport, 'subWorldDraw')
+      const renderer = {
+        subEntityTraits: {},
+        lines: jest.fn((points: AcGePoint3d[]) => ({ points })),
+        group: jest.fn((children: unknown[]) => ({ children }))
+      }
+
+      expect(viewport.worldDraw(renderer as never)).toBeUndefined()
+      expect(subWorldDraw).not.toHaveBeenCalled()
+    })
   })
 
   it('writes viewport DXF fields and returns self', () => {

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -246,6 +246,16 @@ export interface AcDbOpenDatabaseOptions {
    * number, boolean, or string types.
    */
   sysVars?: Record<string, number | boolean | string>
+
+  /**
+   * Whether entities on non-plottable ("no-plot") layers are drawn.
+   *
+   * - `true` (default): desktop AutoCAD editor semantics — no-plot layers remain
+   *   visible on screen (Defpoints, viewport frames on `*-NPLT`, etc.).
+   * - `false`: web/publish viewer semantics (e.g. BIM 360 / ACC) — entities on
+   *   no-plot layers are omitted from display.
+   */
+  drawNoPlotLayers?: boolean
 }
 
 /**
@@ -381,6 +391,11 @@ export class AcDbDatabase extends AcDbObject {
   private _maxHandle: number
   /** Lazily created formatter for lengths, angles, and coordinates */
   private _formatter?: AcDbFormatter
+  /**
+   * When false, entities on non-plottable layers are not drawn (viewer semantics).
+   * Set from {@link AcDbOpenDatabaseOptions.drawNoPlotLayers} when opening a database.
+   */
+  private _drawNoPlotLayers = true
 
   /**
    * Events that can be triggered by the database.
@@ -925,6 +940,31 @@ export class AcDbDatabase extends AcDbObject {
    * database.lwdisplay = true;
    * ```
    */
+  /**
+   * Whether entities on non-plottable layers should be drawn.
+   *
+   * Configured via {@link AcDbOpenDatabaseOptions.drawNoPlotLayers} when the
+   * database is opened. Defaults to `true`.
+   */
+  get drawNoPlotLayers() {
+    return this._drawNoPlotLayers
+  }
+
+  /**
+   * Returns whether entities on the given layer should be drawn under the
+   * current {@link drawNoPlotLayers} setting.
+   *
+   * Layer off/freeze visibility is handled separately by the viewer; this only
+   * reflects the no-plot policy.
+   */
+  isLayerDrawable(layerName: string): boolean {
+    if (this._drawNoPlotLayers) {
+      return true
+    }
+    const layer = this.tables.layerTable.getAt(layerName)
+    return layer == null || layer.isPlottable
+  }
+
   set lwdisplay(value: boolean) {
     this.updateSysVar(
       AcDbSystemVariables.LWDISPLAY,
@@ -1388,6 +1428,7 @@ export class AcDbDatabase extends AcDbObject {
       )
 
     this.clear()
+    this._drawNoPlotLayers = options?.drawNoPlotLayers ?? true
 
     await converter.read(
       data,

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -644,6 +644,8 @@ export abstract class AcDbEntity extends AcDbObject {
    * never overidde this method.
    *
    * It executes the following logic:
+   * - Skips drawing when the entity's layer is not drawable under the database
+   *   {@link AcDbDatabase.drawNoPlotLayers} policy
    * - Handles traits (color, linetype, lineweight, transparency, etc.)
    * - Calls subWorldDraw() to do the actual geometry output
    *
@@ -655,6 +657,10 @@ export abstract class AcDbEntity extends AcDbObject {
    * @returns The rendered entity, or undefined if drawing failed
    */
   worldDraw(renderer: AcGiRenderer, delay?: boolean): AcGiEntity | undefined {
+    if (!this.database.isLayerDrawable(this.layer)) {
+      return undefined
+    }
+
     const traits = renderer.subEntityTraits
     traits.color = this.resolvedColor
     traits.rgbColor = this.rgbColor


### PR DESCRIPTION
## Summary
- Add `drawNoPlotLayers` option to `AcDbOpenDatabaseOptions` (default `true` for AutoCAD editor semantics; `false` for web/publish viewer semantics like BIM 360 / ACC).
- Centralize no-plot layer filtering in `AcDbDatabase.isLayerDrawable()` and apply it in `AcDbEntity.worldDraw()` so all entities, including viewports, respect the policy consistently.
- Expand unit tests for `AcDbEntity.worldDraw` and `AcDbViewport` to cover no-plot suppression and direct `subWorldDraw` behavior.

## Test plan
- [x] Run `AcDbEntity.spec.ts` worldDraw layer policy tests
- [x] Run `AcDbViewport.spec.ts` subWorldDraw and worldDraw tests
- [ ] Verify viewer with `drawNoPlotLayers: false` hides entities on non-plottable layers (e.g. Defpoints)
- [ ] Verify editor/default behavior still draws no-plot layers on screen

Made with [Cursor](https://cursor.com)