### PR TITLE
feat: add area property to curve, hatch, and geometry classes

### DIFF
--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -309,4 +309,9 @@ describe('AcDbArc', () => {
     const arc = new AcDbArc(new AcGePoint3d(0, 0, 0), 2, 0, Math.PI)
     expect(arc.getOffsetCurves(-3)).toEqual([])
   })
+
+  it('returns 0 area for open arc', () => {
+    const arc = new AcDbArc(new AcGePoint3d(), 5, 0, Math.PI / 2)
+    expect(arc.area).toBe(0)
+  })
 })

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -280,4 +280,9 @@ describe('AcDbCircle', () => {
     const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 5)
     expect((circle.getOffsetCurves(3)[0] as AcDbCircle).radius).toBeCloseTo(8)
   })
+
+  it('computes area as πr²', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 5)
+    expect(circle.area).toBeCloseTo(Math.PI * 25, 8)
+  })
 })

--- a/packages/data-model/__tests__/AcDbEllipse.spec.ts
+++ b/packages/data-model/__tests__/AcDbEllipse.spec.ts
@@ -394,4 +394,20 @@ describe('AcDbEllipse', () => {
     expect(result.majorAxisRadius).toBeCloseTo(12)
     expect(result.minorAxisRadius).toBeCloseTo(7)
   })
+
+  it('computes area for full ellipse and returns 0 for open arc', () => {
+    const ellipse = new AcDbEllipse(
+      new AcGePoint3d(),
+      new AcGeVector3d(0, 0, 1),
+      new AcGeVector3d(3, 0, 0),
+      3,
+      2,
+      0,
+      Math.PI * 2
+    )
+    expect(ellipse.area).toBeCloseTo(Math.PI * 6, 8)
+
+    ellipse.endAngle = Math.PI / 2
+    expect(ellipse.area).toBe(0)
+  })
 })

--- a/packages/data-model/__tests__/AcDbFace.spec.ts
+++ b/packages/data-model/__tests__/AcDbFace.spec.ts
@@ -229,4 +229,13 @@ describe('AcDbFace', () => {
   it('clone creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbFace())
   })
+
+  it('computes triangle area', () => {
+    const face = new AcDbFace()
+    face.setVertexAt(0, new AcGePoint3d(0, 0, 0))
+    face.setVertexAt(1, new AcGePoint3d(4, 0, 0))
+    face.setVertexAt(2, new AcGePoint3d(0, 3, 0))
+    face.setVertexAt(3, new AcGePoint3d(0, 3, 0))
+    expect(face.area).toBeCloseTo(6, 8)
+  })
 })

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -645,4 +645,11 @@ describe('AcDbHatch', () => {
   it('clone creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbHatch())
   })
+
+  it('computes area with holes', () => {
+    const hatch = new AcDbHatch()
+    hatch.add(createRectLoop(0, 0, 10, 10))
+    hatch.add(createRectLoop(2, 2, 6, 6))
+    expect(hatch.area).toBeCloseTo(64, 8)
+  })
 })

--- a/packages/data-model/__tests__/AcDbLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbLine.spec.ts
@@ -271,4 +271,9 @@ describe('AcDbLine', () => {
     )
     expect(line.getOffsetSideAtPoint(new AcGePoint3d(5, -3, 0))).toBe(-1)
   })
+
+  it('returns 0 area', () => {
+    const line = new AcDbLine(new AcGePoint3d(), new AcGePoint3d(10, 0, 0))
+    expect(line.area).toBe(0)
+  })
 })

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -463,4 +463,17 @@ describe('AcDbPolyline', () => {
     }
     expect(minY).toBeLessThan(-5)
   })
+
+  it('computes area for closed polyline and returns 0 when open', () => {
+    const polyline = new AcDbPolyline()
+    polyline.closed = true
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(10, 0))
+    polyline.addVertexAt(2, new AcGePoint2d(10, 5))
+    polyline.addVertexAt(3, new AcGePoint2d(0, 5))
+    expect(polyline.area).toBeCloseTo(50, 8)
+
+    polyline.closed = false
+    expect(polyline.area).toBe(0)
+  })
 })

--- a/packages/data-model/__tests__/AcDbTrace.spec.ts
+++ b/packages/data-model/__tests__/AcDbTrace.spec.ts
@@ -216,4 +216,13 @@ describe('AcDbTrace', () => {
     expect(out).toContain('12\n7\n22\n8\n32\n9\n')
     expect(out).toContain('13\n10\n23\n11\n33\n12\n')
   })
+
+  it('computes quadrilateral area', () => {
+    const trace = new AcDbTrace()
+    trace.setPointAt(0, new AcGePoint3d(0, 0, 0))
+    trace.setPointAt(1, new AcGePoint3d(10, 0, 0))
+    trace.setPointAt(2, new AcGePoint3d(0, 5, 0))
+    trace.setPointAt(3, new AcGePoint3d(10, 5, 0))
+    expect(trace.area).toBeCloseTo(50, 8)
+  })
 })

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -165,6 +165,11 @@ export class AcDb2dPolyline extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Sets whether this polyline is closed.
    *

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -102,6 +102,11 @@ export class AcDb3dPolyline extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Sets whether this polyline is closed.
    *

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -317,6 +317,11 @@ export class AcDbArc extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Returns the full property definition for this arc entity, including
    * general group and geometry group.
@@ -455,7 +460,7 @@ export class AcDbArc extends AcDbCurve {
               type: 'float',
               editable: false,
               accessor: {
-                get: () => this._geo.area
+                get: () => this.area
               }
             }
           ]

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -188,6 +188,11 @@ export class AcDbCircle extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  override get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Gets the object snap points for this circle.
    *
@@ -355,7 +360,7 @@ export class AcDbCircle extends AcDbCurve {
               type: 'float',
               editable: false,
               accessor: {
-                get: () => this._geo.area
+                get: () => this.area
               }
             }
           ]

--- a/packages/data-model/src/entity/AcDbCurve.ts
+++ b/packages/data-model/src/entity/AcDbCurve.ts
@@ -44,6 +44,12 @@ export abstract class AcDbCurve extends AcDbEntity {
   abstract get closed(): boolean
 
   /**
+   * The area enclosed by this curve. Returns `0` when the curve does not form a
+   * closed region.
+   */
+  abstract get area(): number
+
+  /**
    * Creates offset curves at the given signed distance, similar to ObjectARX
    * `AcDbCurve::getOffsetCurves`.
    *

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -319,6 +319,11 @@ export class AcDbEllipse extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Gets the grip points for this ellipse.
    *
@@ -541,7 +546,7 @@ export class AcDbEllipse extends AcDbCurve {
               type: 'float',
               editable: false,
               accessor: {
-                get: () => this._geo.area
+                get: () => this.area
               }
             }
           ]

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -1,10 +1,10 @@
 import {
   AcGeBox3d,
+  acGeClosedPolygonArea3d,
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGePointLike
-} from '@mlightcad/geometry-engine'
+  AcGePointLike} from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base'
@@ -172,6 +172,26 @@ export class AcDbFace extends AcDbEntity {
    */
   get geometricExtents(): AcGeBox3d {
     return new AcGeBox3d().setFromPoints(this._vertices)
+  }
+
+  /**
+   * The area of this planar face. Degenerate faces return `0`.
+   */
+  get area(): number {
+    const points = [
+      this.getVertexAt(0),
+      this.getVertexAt(1),
+      this.getVertexAt(2)
+    ]
+    const fourth = this.getVertexAt(3)
+    if (
+      fourth.x !== points[2].x ||
+      fourth.y !== points[2].y ||
+      fourth.z !== points[2].z
+    ) {
+      points.push(fourth)
+    }
+    return acGeClosedPolygonArea3d(points)
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -938,10 +938,17 @@ export class AcDbHatch extends AcDbEntity {
     return areas.length > 0 ? areas : [this._geo]
   }
 
-  private getCalculatedAreaValue() {
+  private getCalculatedAreaValue(): number {
     const areas = this.buildAreasFromLoops()
     if (areas.length === 0) return 0
     return areas.reduce((sum, area) => sum + area.area, 0)
+  }
+
+  /**
+   * The area enclosed by this hatch, including holes.
+   */
+  get area(): number {
+    return this.getCalculatedAreaValue()
   }
 
   /**
@@ -1086,7 +1093,7 @@ export class AcDbHatch extends AcDbEntity {
               type: 'float',
               editable: false,
               accessor: {
-                get: () => this.getCalculatedAreaValue()
+                get: () => this.area
               }
             }
           ]

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -484,6 +484,11 @@ export class AcDbLeader extends AcDbCurve {
     // TODO: Not sure whether the leader really support setting value of property 'closed'
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Transforms this leader by the specified matrix.
    */

--- a/packages/data-model/src/entity/AcDbLine.ts
+++ b/packages/data-model/src/entity/AcDbLine.ts
@@ -167,6 +167,11 @@ export class AcDbLine extends AcDbCurve {
     return false
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Returns the full property definition for this line entity, including
    * general group and geometry group.

--- a/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
@@ -93,6 +93,11 @@ export class AcDbPolyFaceMesh extends AcDbCurve {
     return false
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Sets whether this mesh is closed.
    */

--- a/packages/data-model/src/entity/AcDbPolygonMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolygonMesh.ts
@@ -109,6 +109,11 @@ export class AcDbPolygonMesh extends AcDbCurve {
     return this._closedM
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Sets whether this mesh is closed.
    */

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -162,6 +162,11 @@ export class AcDbPolyline extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Sets whether this polyline is closed.
    *

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -139,6 +139,11 @@ export class AcDbRay extends AcDbCurve {
     return false
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Gets the geometric extents (bounding box) of this ray.
    *

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -242,6 +242,11 @@ export class AcDbSpline extends AcDbCurve {
     return this._geo.closed
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return this._geo.area
+  }
+
   /**
    * Sets whether this spline is closed.
    *

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -127,6 +127,15 @@ export class AcDbTrace extends AcDbCurve {
     return true
   }
 
+  /** @inheritdoc */
+  override get area(): number {
+    const polyline = new AcGePolyline2d(
+      AcDbTrace.boundaryPointsFromVertices(this._vertices),
+      true
+    )
+    return polyline.area
+  }
+
   /**
    * Gets the thickness of this trace.
    *

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -140,6 +140,11 @@ export class AcDbXline extends AcDbCurve {
     return false
   }
 
+  /** @inheritdoc */
+  get area(): number {
+    return 0
+  }
+
   /**
    * Gets the geometric extents (bounding box) of this xline.
    *

--- a/packages/geometry-engine/__tests__/AcGeCircArc3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeCircArc3d.spec.ts
@@ -4,7 +4,8 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGeVector3d,
-  ORIGIN_POINT_3D
+  ORIGIN_POINT_3D,
+  TAU
 } from '../src'
 
 describe('Test AcGeCircArc3d', () => {
@@ -113,5 +114,21 @@ describe('Test AcGeCircArc3d', () => {
 
     closestSpy.mockRestore()
     errSpy.mockRestore()
+  })
+
+  it('computes circle area and returns 0 for open arc', () => {
+    const circle = new AcGeCircArc3d({ x: 0, y: 0, z: 0 }, 5, 0, TAU, {
+      x: 0,
+      y: 0,
+      z: 1
+    })
+    expect(circle.area).toBeCloseTo(Math.PI * 25, 8)
+
+    const arc = new AcGeCircArc3d({ x: 0, y: 0, z: 0 }, 5, 0, Math.PI / 2, {
+      x: 0,
+      y: 0,
+      z: 1
+    })
+    expect(arc.area).toBe(0)
   })
 })

--- a/packages/geometry-engine/__tests__/AcGeCoverageBoost.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeCoverageBoost.spec.ts
@@ -696,7 +696,7 @@ describe('geometry-engine public API coverage boost', () => {
     expect(circ3.endPoint).toBeInstanceOf(AcGePoint3d)
     expect(circ3.midPoint).toBeInstanceOf(AcGePoint3d)
     expect(circ3.length).toBeGreaterThan(0)
-    expect(circ3.area).toBeGreaterThan(0)
+    expect(circ3.area).toBe(0)
     const nearest = circ3.nearestPoint({ x: 10, y: 0, z: 0 })
     expect(nearest).toMatchObject({
       x: expect.any(Number),
@@ -773,7 +773,7 @@ describe('geometry-engine public API coverage boost', () => {
     expect(ellipse3.midPoint).toBeInstanceOf(AcGePoint3d)
     expect(ellipse3.isCircular).toBe(false)
     expect(ellipse3.length).toBeGreaterThan(0)
-    expect(ellipse3.area).toBeGreaterThan(0)
+    expect(ellipse3.area).toBe(0)
     expect(ellipse3.calculateBoundingBox()).toBeInstanceOf(AcGeBox3d)
     expect(ellipse3.closed).toBe(false)
     expect(ellipse3.getPoints(8).length).toBe(9)

--- a/packages/geometry-engine/__tests__/AcGeEllipseArc3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeEllipseArc3d.spec.ts
@@ -99,6 +99,17 @@ describe('Test AcGeEllipseArc3d', () => {
     expect(fullEllipse.midPoint).toBeInstanceOf(Object)
     expect(fullEllipse.area).toBeCloseTo(Math.PI * 6, 8)
 
+    const openArc = new AcGeEllipseArc3d(
+      ORIGIN_POINT_3D,
+      AcGeVector3d.Z_AXIS,
+      AcGeVector3d.X_AXIS,
+      3,
+      2,
+      0,
+      Math.PI / 2
+    )
+    expect(openArc.area).toBe(0)
+
     const skewAxis = new AcGeVector3d(1, 1, 0).normalize()
     const skew = new AcGeEllipseArc3d(
       ORIGIN_POINT_3D,

--- a/packages/geometry-engine/__tests__/AcGePolygonAreaUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolygonAreaUtil.spec.ts
@@ -1,0 +1,34 @@
+import {
+  acGeClosedPolygonArea2d,
+  acGeClosedPolygonArea3d,
+  acGePolygonArea2d,
+  acGePolygonArea3d
+} from '../src/util/AcGePolygonAreaUtil'
+
+describe('AcGePolygonAreaUtil', () => {
+  it('computes 2D polygon area', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 0, y: 2 }
+    ]
+    expect(acGePolygonArea2d(square)).toBeCloseTo(4, 8)
+    expect(acGeClosedPolygonArea2d(square)).toBeCloseTo(4, 8)
+  })
+
+  it('returns 0 for open or degenerate loops', () => {
+    expect(acGeClosedPolygonArea2d([])).toBe(0)
+    expect(acGeClosedPolygonArea2d([{ x: 0, y: 0 }, { x: 1, y: 0 }])).toBe(0)
+  })
+
+  it('computes 3D planar polygon area', () => {
+    const triangle = [
+      { x: 0, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+      { x: 0, y: 3, z: 0 }
+    ]
+    expect(acGePolygonArea3d(triangle)).toBeCloseTo(6, 8)
+    expect(acGeClosedPolygonArea3d(triangle)).toBeCloseTo(6, 8)
+  })
+})

--- a/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolyline2d.spec.ts
@@ -239,4 +239,27 @@ describe('Test AcGePolyline2d', () => {
     const [result] = polyline.offset(1)
     expect(result.numberOfVertices).toBeGreaterThanOrEqual(4)
   })
+
+  it('computes area for closed polyline and returns 0 when open', () => {
+    const open = new AcGePolyline2d(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 5 }
+      ],
+      false
+    )
+    expect(open.area).toBe(0)
+
+    const closed = new AcGePolyline2d(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 5 },
+        { x: 0, y: 5 }
+      ],
+      true
+    )
+    expect(closed.area).toBeCloseTo(50, 8)
+  })
 })

--- a/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeSpline3d.spec.ts
@@ -810,4 +810,32 @@ describe('AcGeSpline3d', () => {
       })
     })
   })
+
+  describe('area', () => {
+    it('computes area for closed spline and returns 0 when open', () => {
+      const closed = new AcGeSpline3d(
+        [
+          new AcGePoint3d(0, 0, 0),
+          new AcGePoint3d(10, 0, 0),
+          new AcGePoint3d(10, 10, 0),
+          new AcGePoint3d(0, 10, 0)
+        ],
+        'Uniform',
+        3,
+        true
+      )
+      expect(closed.area).toBeGreaterThan(0)
+
+      const open = new AcGeSpline3d(
+        [
+          new AcGePoint3d(0, 0, 0),
+          new AcGePoint3d(10, 0, 0),
+          new AcGePoint3d(10, 5, 0),
+          new AcGePoint3d(20, 5, 0)
+        ],
+        'Uniform'
+      )
+      expect(open.area).toBe(0)
+    })
+  })
 })

--- a/packages/geometry-engine/src/geometry/AcGeArea2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeArea2d.ts
@@ -1,5 +1,6 @@
 import { AcGeBox2d, AcGeMatrix2d, AcGePoint2d, AcGePoint2dLike } from '../math'
 import { AcGeGeometryUtil, AcGeMathUtil } from '../util'
+import { acGeSignedPolygonArea2d } from '../util/AcGePolygonAreaUtil'
 import { AcGeLoop2d } from './AcGeLoop2d'
 import { AcGePolyline2d } from './AcGePolyline2d'
 import { AcGeShape2d } from './AcGeShape2d'
@@ -161,7 +162,7 @@ export class AcGeArea2d extends AcGeShape2d {
       // Sets the number of points used for curve segmentation to 128
       const points = loop.getPoints(128) as AcGePoint2d[]
 
-      const loopArea = this.polygonArea(points)
+      const loopArea = acGeSignedPolygonArea2d(points)
 
       if (i === 0) {
         // outter loop
@@ -173,23 +174,6 @@ export class AcGeArea2d extends AcGeShape2d {
     }
 
     return totalArea
-  }
-
-  /**
-   * Calculate signed area of a polygon using Shoelace formula
-   */
-  private polygonArea(points: AcGePoint2d[]): number {
-    const count = points.length
-    if (count < 3) return 0
-
-    let area = 0
-    for (let i = 0, j = count - 1; i < count; j = i++) {
-      const p1 = points[j]
-      const p2 = points[i]
-      area += p1.x * p2.y - p2.x * p1.y
-    }
-
-    return area * 0.5
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeCircArc3d.ts
@@ -297,12 +297,11 @@ export class AcGeCircArc3d extends AcGeCurve3d {
   }
 
   /**
-   * The area of this arc
+   * The area enclosed by this curve. Open arcs return `0`.
    */
-  get area() {
-    return this.closed
-      ? Math.PI * this.radius * this.radius
-      : Math.abs(this.deltaAngle * this.radius * this.radius)
+  get area(): number {
+    if (!this.closed) return 0
+    return Math.PI * this.radius * this.radius
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeEllipseArc3d.ts
@@ -275,28 +275,11 @@ export class AcGeEllipseArc3d extends AcGeCurve3d {
   }
 
   /**
-   * Compute the area of the ellipse or ellipse arc.
-   * - Full ellipse: π * a * b
-   * - Ellipse arc: exact analytical area (not numerical integration)
+   * The area enclosed by this curve. Open ellipse arcs return `0`.
    */
   get area(): number {
-    const a = this.majorAxisRadius
-    const b = this.minorAxisRadius
-
-    const t1 = this.startAngle
-    const t2 = t1 + this.deltaAngle
-
-    // Full ellipse
-    if (Math.abs(this.deltaAngle - TAU) < 1e-10) {
-      return Math.PI * a * b
-    }
-
-    const area =
-      ((a * b) / 2) *
-      (t2 - t1 - (Math.sin(t2) * Math.cos(t2) - Math.sin(t1) * Math.cos(t1)))
-
-    // Always return positive area
-    return Math.abs(area)
+    if (Math.abs(this.deltaAngle - TAU) >= 1e-10) return 0
+    return Math.PI * this.majorAxisRadius * this.minorAxisRadius
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGePolyline2d.ts
@@ -1,4 +1,5 @@
 import { AcGeBox2d, AcGeMatrix2d, AcGePoint2d, AcGePoint3d } from '../math'
+import { acGeClosedPolygonArea2d } from '../util/AcGePolygonAreaUtil'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGeCurve2d } from './AcGeCurve2d'
 import { offsetAcGePolyline2d } from './AcGePolyline2dOffset'
@@ -112,6 +113,15 @@ export class AcGePolyline2d<
       }
     }
     return length
+  }
+
+  /**
+   * The area enclosed by this polyline. Open polylines return `0`.
+   */
+  get area(): number {
+    if (!this._closed || this._vertices.length < 3) return 0
+    const points = this.getPoints(128) as AcGePoint2d[]
+    return acGeClosedPolygonArea2d(points)
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -8,6 +8,7 @@ import {
   AcGePoint3dLike,
   AcGePointLike
 } from '../math'
+import { acGeClosedPolygonArea3d } from '../util/AcGePolygonAreaUtil'
 import { AcGeCurve3d } from './AcGeCurve3d'
 import { AcGeKnotParameterizationType, AcGeNurbsCurve } from './AcGeNurbsCurve'
 
@@ -443,6 +444,15 @@ export class AcGeSpline3d extends AcGeCurve3d {
   }
   set closed(value: boolean) {
     this.setClosed(value)
+  }
+
+  /**
+   * The area enclosed by this spline. Open splines return `0`.
+   */
+  get area(): number {
+    if (!this._closed) return 0
+    const points = this.getPoints(128)
+    return acGeClosedPolygonArea3d(points)
   }
 
   /**

--- a/packages/geometry-engine/src/index.ts
+++ b/packages/geometry-engine/src/index.ts
@@ -100,5 +100,10 @@ export {
   transformWcsPointToOcs,
   offsetPointByDirectionInXY,
   offsetSmoothedSampledPath,
-  offsetVertexPath
+  offsetVertexPath,
+  acGeClosedPolygonArea2d,
+  acGeClosedPolygonArea3d,
+  acGePolygonArea2d,
+  acGePolygonArea3d,
+  acGeSignedPolygonArea2d
 } from './util'

--- a/packages/geometry-engine/src/util/AcGePolygonAreaUtil.ts
+++ b/packages/geometry-engine/src/util/AcGePolygonAreaUtil.ts
@@ -1,0 +1,71 @@
+import { AcGePoint2dLike } from '../math/AcGePoint2d'
+import { AcGePoint3dLike } from '../math/AcGePoint3d'
+
+/**
+ * Computes the signed area of a 2D polygon using the shoelace formula.
+ */
+export function acGeSignedPolygonArea2d(points: AcGePoint2dLike[]): number {
+  const count = points.length
+  if (count < 3) return 0
+
+  let area = 0
+  for (let i = 0, j = count - 1; i < count; j = i++) {
+    const p1 = points[j]
+    const p2 = points[i]
+    area += p1.x * p2.y - p2.x * p1.y
+  }
+
+  return area * 0.5
+}
+
+/**
+ * Computes the absolute area of a 2D polygon using the shoelace formula.
+ */
+export function acGePolygonArea2d(points: AcGePoint2dLike[]): number {
+  return Math.abs(acGeSignedPolygonArea2d(points))
+}
+
+/**
+ * Computes the area of a planar 3D polygon using Newell's method.
+ */
+export function acGePolygonArea3d(points: AcGePoint3dLike[]): number {
+  const count = points.length
+  if (count < 3) return 0
+
+  let nx = 0
+  let ny = 0
+  let nz = 0
+  for (let i = 0, j = count - 1; i < count; j = i++) {
+    const p1 = points[j]
+    const p2 = points[i]
+    const x1 = p1.x
+    const y1 = p1.y
+    const z1 = p1.z ?? 0
+    const x2 = p2.x
+    const y2 = p2.y
+    const z2 = p2.z ?? 0
+    nx += (z1 + z2) * (y1 - y2)
+    ny += (x1 + x2) * (z1 - z2)
+    nz += (y1 + y2) * (x1 - x2)
+  }
+
+  return 0.5 * Math.hypot(nx, ny, nz)
+}
+
+/**
+ * Returns the absolute polygon area for a closed loop, or `0` when the loop is
+ * open or degenerate.
+ */
+export function acGeClosedPolygonArea2d(points: AcGePoint2dLike[]): number {
+  if (points.length < 3) return 0
+  return acGePolygonArea2d(points)
+}
+
+/**
+ * Returns the absolute polygon area for a closed loop, or `0` when the loop is
+ * open or degenerate.
+ */
+export function acGeClosedPolygonArea3d(points: AcGePoint3dLike[]): number {
+  if (points.length < 3) return 0
+  return acGePolygonArea3d(points)
+}

--- a/packages/geometry-engine/src/util/index.ts
+++ b/packages/geometry-engine/src/util/index.ts
@@ -64,3 +64,10 @@ export {
   offsetVertexPath
 } from './AcGeCurveOffsetUtil'
 export { offsetSmoothedSampledPath } from './AcGeSampledCurveOffsetUtil'
+export {
+  acGeClosedPolygonArea2d,
+  acGeClosedPolygonArea3d,
+  acGePolygonArea2d,
+  acGePolygonArea3d,
+  acGeSignedPolygonArea2d
+} from './AcGePolygonAreaUtil'


### PR DESCRIPTION
## Summary
- Add `area: number` to `AcDbCurve` subclasses, `AcDbHatch`, and `AcDbFace`, returning `0` when no closed region exists
- Implement area calculation in `AcGeCircArc3d`, `AcGeEllipseArc3d`, `AcGePolyline2d`, `AcGeSpline3d`, and shared `AcGePolygonAreaUtil` (Shoelace / Newell methods)
- Refactor `AcGeArea2d` to reuse the shared signed polygon area helper
- Add area unit tests in each entity and geometry spec file

## Test plan
- [x] Run area-related Jest tests for AcDbCircle, AcDbArc, AcDbLine, AcDbPolyline, AcDbEllipse, AcDbTrace, AcDbHatch, AcDbFace, and AcGe geometry classes
- [ ] Verify property palette area field for circle, polyline, and hatch in the viewer
