### PR TITLE
feat: enforce worker-only parsing and verify GPL parser isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To support reading both DXF and DWG files (and potentially other formats in the 
 - The `AcDbDatabaseConverterManager` maintains a registry of these converters, allowing you to register or unregister converters for specific file types at runtime.
 - No converters are registered by default. Register the DXF and DWG converters from their respective packages before calling `AcDbDatabase.read()`.
 
+Both `@mlightcad/dxf-json-converter` and `@mlightcad/libredwg-converter` are designed to run their parsers in a Web Worker only. This is not a technical or architectural limitation of the converters themselves; it is a deliberate licensing choice. The upstream parsers are copyleft (GPL/LGPL), so keeping them in a separate worker bundle helps isolate that code from the main application and makes license compliance easier for MIT-licensed apps built on RealDWG-Web.
+
 ### Registering Converters
 
 Register DXF and DWG converters before reading files:
@@ -33,7 +35,7 @@ import {
 import { AcDbDxfConverter } from '@mlightcad/dxf-json-converter'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
 
-// DXF converter (GPL parser runs in a separate Web Worker)
+// DXF converter (GPL parser is loaded in a separate Web Worker for license isolation)
 const dxfConverter = new AcDbDxfConverter({
   convertByEntityType: false,
   useWorker: true,
@@ -44,7 +46,7 @@ AcDbDatabaseConverterManager.instance.register(
   dxfConverter
 )
 
-// DWG converter
+// DWG converter (copyleft parser is loaded in a separate Web Worker for license isolation)
 const dwgConverter = new AcDbLibreDwgConverter({
   convertByEntityType: false,
   useWorker: true,
@@ -122,11 +124,13 @@ This module provides a DWG file converter for the RealDWG-Web ecosystem, enablin
 
 This module provides a DWG file converter for the RealDWG-Web ecosystem, enabling reading and conversion of DWG files into the drawing database. It is powered by the LibreDWG library compiled to WebAssembly and is designed to be registered with the converter manager for DWG file support.
 
+DWG parsing is provided through a dedicated Web Worker bundle (`libredwg-parser-worker.js`). Worker-only usage is a licensing choice, not a platform constraint: it keeps the copyleft LibreDWG parser separate from the main application bundle so that MIT-licensed apps can integrate DWG support more safely.
+
 ### dxf-json-converter (DXF file support)
 
 This module provides a DXF file converter for the RealDWG-Web ecosystem. It is based on [@mlightcad/dxf-json](https://www.npmjs.com/package/@mlightcad/dxf-json) and is designed to be registered with the converter manager for DXF file support.
 
-DXF parsing runs in a dedicated Web Worker bundle (`dxf-parser-worker.js`) so that the GPL-licensed parser can be loaded on demand and kept separate from the main application bundle. The main `@mlightcad/data-model` package does not depend on `dxf-json`.
+DXF parsing is provided through a dedicated Web Worker bundle (`dxf-parser-worker.js`). Worker-only usage is a licensing choice, not a platform constraint: it keeps the GPL-licensed `@mlightcad/dxf-json` parser separate from the main application bundle. The main `@mlightcad/data-model` package does not depend on `dxf-json`.
 
 ## geometry-engine (AcGe classes in AutoCAD ObjectARX)
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,8 +10,14 @@ const config: Config = {
     "^@mlightcad/graphic-interface$": "<rootDir>/packages/graphic-interface/src/index.ts",
     "^@mlightcad/data-model$": "<rootDir>/packages/data-model/src/index.ts",
     "^@mlightcad/dxf-json-converter$": "<rootDir>/packages/dxf-json-converter/src/index.ts",
+    "^@mlightcad/dxf-json/types$":
+      "<rootDir>/packages/dxf-json-converter/node_modules/@mlightcad/dxf-json/dist/cjs/types-bundle.cjs",
   },
   transform: {
+    ".*packages[\\\\/]dxf-json-converter[\\\\/].+\\.tsx?$": [
+      "ts-jest",
+      { tsconfig: "<rootDir>/packages/dxf-json-converter/tsconfig.json" }
+    ],
     "^.+\\.(ts|tsx)$": "ts-jest",
   },
   testPathIgnorePatterns: ["packages/dxf-json/"]

--- a/package.json
+++ b/package.json
@@ -24,21 +24,13 @@
     "lint:fix": "nx run-many -t lint:fix",
     "publish:package": "pnpm -r publish --access public --no-git-checks",
     "release": "node tools/release.mjs",
+    "sync:versions": "node tools/sync-versions.mjs",
+    "sync:versions:check": "node tools/sync-versions.mjs --check",
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
   "engines": {
     "pnpm": ">=10"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "nx"
-    ],
-    "overrides": {
-      "@mlightcad/dxf-json": "^1.2.0"
-    }
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",

--- a/packages/data-model/src/database/AcDbDatabaseConverter.ts
+++ b/packages/data-model/src/database/AcDbDatabaseConverter.ts
@@ -280,21 +280,21 @@ export interface AcDbDatabaseConverterConfig {
    */
   timeout?: number
   /**
-   * Whether to use web workers for computationally intensive tasks.
+   * Whether to use web workers for parser execution.
    *
-   * When set to `true`, the converter will attempt to use web workers
-   * for computationally intensive tasks, which can improve performance
-   * by offloading work to background threads and preventing UI blocking.
+   * When set to `true`, the converter uses a web worker for parsing, which
+   * keeps copyleft parser code out of the main bundle and avoids blocking
+   * the UI thread.
    *
-   * When set to `false`, all computationally intensive operations will be
-   * performed on the main thread.
+   * Copyleft converters (DXF/DWG) require worker parsing. Setting this to
+   * `false` is only meaningful for converters that still support main-thread
+   * parsing.
    *
-   * @default false
+   * @default true
    *
    * @example
    * ```typescript
    * const config: AcDbDatabaseConverterConfig = {
-   *   useWorker: true,
    *   parserWorkerUrl: '/assets/dxf-parser-worker.js'
    * };
    * ```
@@ -373,7 +373,10 @@ export abstract class AcDbDatabaseConverter<TModel = unknown> {
    * ```
    */
   constructor(config: AcDbDatabaseConverterConfig = {}) {
-    this.config = config
+    this.config = {
+      useWorker: config.useWorker ?? true,
+      ...config
+    }
   }
 
   /**

--- a/packages/dxf-json-converter/README.md
+++ b/packages/dxf-json-converter/README.md
@@ -6,12 +6,12 @@ The `dxf-json-converter` package provides a DXF file converter for the RealDWG-W
 
 This package implements a DXF file converter compatible with the RealDWG-Web data model. It allows you to register DXF file support in your application and convert DXF files into the in-memory drawing database.
 
-DXF parsing runs in a dedicated Web Worker bundle so that GPL-licensed parser code can be loaded on demand and kept separate from the main application bundle.
+DXF parsing is provided through a dedicated Web Worker bundle (`dxf-parser-worker.js`). **This converter is intended for Web Worker use only.** That restriction is not because parsing cannot run on the main thread in principle; it is a deliberate licensing choice. `@mlightcad/dxf-json` is GPL-3.0, and loading it in a separate worker bundle helps keep copyleft parser code apart from the main MIT-licensed application so license obligations are easier to manage.
 
 ## Key Features
 
 - **DXF File Support**: Read and convert DXF files to the drawing database
-- **Worker-based Parsing**: Optional Web Worker parsing for better UI responsiveness
+- **Worker-based Parsing**: Required by design for GPL license isolation
 - **Integration**: Designed to work with the RealDWG-Web data model and converter manager
 
 ## Installation
@@ -45,7 +45,7 @@ Deploy `dxf-parser-worker.js` from this package's `dist/` folder to a public URL
 ## Dependencies
 
 - **@mlightcad/data-model**: Drawing database and entity definitions
-- **@mlightcad/dxf-json**: DXF file parser (GPL-3.0)
+- **@mlightcad/dxf-json**: DXF file parser (GPL-3.0), loaded in the worker bundle by design for license isolation
 
 ## API Documentation
 

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -7,7 +7,6 @@ import {
   ACTIVE_VPORT_NAME,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
-import { AcDbDxfParser } from '../src/AcDbDxfParser'
 import { AcDbDxfConverter } from '../src/AcDbDxfConverter'
 
 class TestDxfConverter extends AcDbDxfConverter {
@@ -51,19 +50,12 @@ describe('AcDbDxfConverter', () => {
     expect(config.parserWorkerUrl).toBe('/assets/dxf-parser-worker.js')
   })
 
-  it('parses through AcDbDxfParser when worker disabled', async () => {
-    const parseSpy = jest
-      .spyOn(AcDbDxfParser.prototype, 'parse')
-      .mockReturnValue({ entities: [] } as any)
-
+  it('throws when worker parsing is not configured', async () => {
     const converter = new TestDxfConverter({ useWorker: false })
-    const result = await converter.parsePublic(new ArrayBuffer(0))
 
-    expect(result.model).toEqual({ entities: [] })
-    expect(result.data.unknownEntityCount).toBe(0)
-    expect(parseSpy).toHaveBeenCalled()
-
-    parseSpy.mockRestore()
+    await expect(converter.parsePublic(new ArrayBuffer(0))).rejects.toThrow(
+      'dxf converter can run in web worker only!'
+    )
   })
 
   it('collects fonts from style table, mtext and nested inserts', () => {

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -44,10 +44,10 @@ class TestDxfConverter extends AcDbDxfConverter {
 }
 
 describe('AcDbDxfConverter', () => {
-  it('sets default parser worker url in constructor', () => {
-    const config: Record<string, unknown> = {}
-    new AcDbDxfConverter(config as any)
-    expect(config.parserWorkerUrl).toBe('/assets/dxf-parser-worker.js')
+  it('sets default parser worker url and useWorker in constructor', () => {
+    const converter = new AcDbDxfConverter()
+    expect(converter.config.parserWorkerUrl).toBe('/assets/dxf-parser-worker.js')
+    expect(converter.config.useWorker).toBe(true)
   })
 
   it('throws when worker parsing is not configured', async () => {

--- a/packages/dxf-json-converter/__tests__/AcDbDxfRead.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfRead.spec.ts
@@ -19,10 +19,28 @@ import {
 import { AcDbDxfConverter } from '../src/AcDbDxfConverter'
 import { AcDbDxfParser } from '../src/AcDbDxfParser'
 
+jest.mock('@mlightcad/data-model', () => {
+  const actual = jest.requireActual('@mlightcad/data-model')
+  const { AcDbDxfParser: Parser } = jest.requireActual('../src/AcDbDxfParser')
+  return {
+    ...actual,
+    createWorkerApi: () => ({
+      execute: async (data: ArrayBuffer) => ({
+        success: true,
+        data: new Parser().parse(data)
+      }),
+      destroy: () => {}
+    })
+  }
+})
+
 function registerDxfConverter() {
   AcDbDatabaseConverterManager.instance.register(
     AcDbFileType.DXF,
-    new AcDbDxfConverter({ useWorker: false })
+    new AcDbDxfConverter({
+      useWorker: true,
+      parserWorkerUrl: '/assets/dxf-parser-worker.js'
+    })
   )
 }
 

--- a/packages/dxf-json-converter/package.json
+++ b/packages/dxf-json-converter/package.json
@@ -38,14 +38,15 @@
     "analyze:lib": "vite build --mode analyze --config vite.config.main.ts",
     "analyze:worker": "vite build --mode analyze --config vite.config.worker.ts",
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",
-    "build": "tsc && vite build -c vite.config.main.ts && vite build -c vite.config.worker.ts",
-    "build:main": "vite build -c vite.config.main.ts",
+    "build": "tsc && vite build -c vite.config.main.ts && vite build -c vite.config.worker.ts && node ../../tools/verify-build.mjs verify-build.profile.json",
+    "build:main": "vite build -c vite.config.main.ts && node ../../tools/verify-build.mjs verify-build.profile.json --main-only",
     "build:worker": "vite build -c vite.config.worker.ts",
+    "verify:build": "node ../../tools/verify-build.mjs verify-build.profile.json",
     "lint": "eslint src/",
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/dxf-json": "^1.2.2"
+    "@mlightcad/dxf-json": "^1.2.3"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -82,8 +82,8 @@ import { AcDbObjectConverter } from './AcDbObjectConverter'
 export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
   constructor(config: AcDbDatabaseConverterConfig = {}) {
     super(config)
-    if (!config.parserWorkerUrl) {
-      config.parserWorkerUrl = '/assets/dxf-parser-worker.js'
+    if (!this.config.parserWorkerUrl) {
+      this.config.parserWorkerUrl = '/assets/dxf-parser-worker.js'
     }
   }
 

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -60,9 +60,8 @@ import {
   StyleTableEntry,
   TextEntity,
   VPortTableEntry
-} from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
 
-import { AcDbDxfParser } from './AcDbDxfParser'
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
 import { AcDbObjectConverter } from './AcDbObjectConverter'
 
@@ -122,14 +121,7 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         )
       }
     } else {
-      const parser = new AcDbDxfParser()
-      const result = parser.parse(data)
-      return {
-        model: result,
-        data: {
-          unknownEntityCount: 0
-        }
-      }
+      throw new Error('dxf converter can run in web worker only!')
     }
   }
 

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -81,8 +81,8 @@ import {
   HatchSolidFill,
   SmoothType,
   VertexFlag
-} from '@mlightcad/dxf-json'
-import { CircleEntity } from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
+import { CircleEntity } from '@mlightcad/dxf-json/types'
 import {
   ArcEdge,
   BoundaryPathEdge,
@@ -92,7 +92,7 @@ import {
   LineEdge,
   PolylineBoundaryPath,
   SplineEdge
-} from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
 import {
   CommonDxfEntity,
   EllipseEntity,
@@ -115,14 +115,14 @@ import {
   ViewportEntity,
   WipeoutEntity,
   XLineEntity
-} from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
 import {
   AlignedDimensionEntity,
   AngularDimensionEntity,
   DimensionEntityCommon,
   OrdinateDimensionEntity,
   RadialDiameterDimensionEntity
-} from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
 
 type ParsedMLeaderBreak = {
   index?: number

--- a/packages/dxf-json-converter/src/AcDbObjectConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbObjectConverter.ts
@@ -21,7 +21,7 @@ import {
   MLeaderStyleDXFObject,
   MLineStyleDXFObject,
   ParsedDxf
-} from '@mlightcad/dxf-json'
+} from '@mlightcad/dxf-json/types'
 
 /**
  * Converts DXF objects to AcDbObject instances.

--- a/packages/dxf-json-converter/tsconfig.json
+++ b/packages/dxf-json-converter/tsconfig.json
@@ -4,7 +4,12 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "baseUrl": "./src",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "paths": {
+      "@mlightcad/dxf-json/types": [
+        "../node_modules/@mlightcad/dxf-json/dist/esm/types/types-entry.d.ts"
+      ]
+    }
   },
   "include": [
     "src"

--- a/packages/dxf-json-converter/tsconfig.json
+++ b/packages/dxf-json-converter/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "moduleResolution": "bundler"
   },
   "include": [
     "src"

--- a/packages/dxf-json-converter/verify-build.profile.json
+++ b/packages/dxf-json-converter/verify-build.profile.json
@@ -1,0 +1,17 @@
+{
+  "main": "dist/dxf-json-converter.umd.cjs",
+  "worker": "dist/dxf-parser-worker.js",
+  "forbiddenInMain": [
+    "encodingFailureFatal",
+    "thumbnailImageFormat",
+    "parseStream",
+    "parseSync",
+    "CommonEntitySnippets",
+    "DxfArrayScanner"
+  ],
+  "requiredInWorker": [
+    "encodingFailureFatal",
+    "thumbnailImageFormat",
+    "parseSync"
+  ]
+}

--- a/packages/dxf-json-converter/vite.config.main.ts
+++ b/packages/dxf-json-converter/vite.config.main.ts
@@ -27,6 +27,7 @@ export default defineConfig(({ mode }) => {
       },
       minify: 'esbuild',
       rollupOptions: {
+        external: ['@mlightcad/dxf-json'],
         output: {
           compact: true
         }

--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -8,11 +8,6 @@
   <h2>DWG / DXF Parse Demo</h2>
   <div>
     <input type="file" id="fileInput" accept=".dwg,.dxf" />
-    <select id="modeSelect">
-      <option value="compare" selected>Compare main thread vs worker</option>
-      <option value="main">Main thread only</option>
-      <option value="worker">Web worker only</option>
-    </select>
     <button id="runButton" type="button">Run parse</button>
   </div>
   <div id="status"></div>

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,8 +1,8 @@
 /**
  * @fileoverview Example web application entry point for DWG/DXF parsing and PAT preview.
  *
- * This module wires up the demo UI: file selection, main-thread vs web-worker parsing
- * benchmarks, layer/linetype inspection, DXF export, and hatch pattern (PAT) parsing
+ * This module wires up the demo UI: file selection, web-worker parsing,
+ * layer/linetype inspection, DXF export, and hatch pattern (PAT) parsing
  * with SVG previews.
  *
  * @module example/main
@@ -24,7 +24,6 @@ import { AcDbDxfConverter } from '@mlightcad/dxf-json-converter'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
 
 const fileInput = document.getElementById('fileInput') as HTMLInputElement
-const modeSelect = document.getElementById('modeSelect') as HTMLSelectElement
 const runButton = document.getElementById('runButton') as HTMLButtonElement
 const status = document.getElementById('status') as HTMLDivElement
 const output = document.getElementById('output') as HTMLPreElement
@@ -53,15 +52,6 @@ output.insertAdjacentElement('afterend', linetypePreviewPanel)
 linetypePreviewPanel.style.marginTop = '16px'
 linetypePreviewPanel.style.display = 'none'
 
-/**
- * Parsing execution mode selected in the demo UI.
- *
- * - `compare` — Parse the same file on the main thread and in a web worker, then report timings.
- * - `main` — Parse only on the main thread (DXF only; UI may freeze during parsing).
- * - `worker` — Parse only inside a dedicated web worker (required for DWG).
- */
-type ParseMode = 'compare' | 'main' | 'worker'
-
 let lastFile: File | null = null
 let lastBuffer: ArrayBuffer | null = null
 let lastParsedDatabase: AcDbDatabase | null = null
@@ -72,20 +62,16 @@ const patParser = new AcDbPatParser()
 /**
  * Registers DXF and DWG database converters with the global converter manager.
  *
- * Both converters share the same worker configuration. DXF supports main-thread parsing;
- * DWG parsing is worker-only and relies on the LibreDWG parser worker script.
- *
+ * Both converters run parsing in dedicated web workers for copyleft license isolation.
  * Registration failures are logged to the console but do not throw, so the demo can
  * continue with whichever converters succeeded.
- *
- * @param useWorker - When `true`, parsing runs in a web worker; when `false`, on the main thread.
  */
-const registerConverters = (useWorker: boolean) => {
+const registerConverters = () => {
   // Register DXF converter
   try {
     const converter = new AcDbDxfConverter({
       convertByEntityType: false,
-      useWorker,
+      useWorker: true,
       parserWorkerUrl: './assets/dxf-parser-worker.js'
     })
     AcDbDatabaseConverterManager.instance.register(AcDbFileType.DXF, converter)
@@ -93,11 +79,11 @@ const registerConverters = (useWorker: boolean) => {
     console.error('Failed to register dxf converter: ', error)
   }
 
-  // Register DWG converter (worker-only)
+  // Register DWG converter
   try {
     const converter = new AcDbLibreDwgConverter({
       convertByEntityType: false,
-      useWorker,
+      useWorker: true,
       parserWorkerUrl: './assets/libredwg-parser-worker.js'
     })
     AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
@@ -163,20 +149,18 @@ type ParseResult =
  * Parses a drawing buffer once using the configured converters and open options.
  *
  * Creates a fresh {@link AcDbDatabase}, assigns it as the host working database, and
- * measures wall-clock time for {@link AcDbDatabase.read}. Converters are (re)registered
- * on each call so worker vs main-thread mode can differ between invocations.
+ * measures wall-clock time for {@link AcDbDatabase.read}. Converters are registered
+ * on each call before parsing.
  *
  * @param buffer - Raw file bytes (DXF or DWG).
  * @param fileType - Format hint passed to the database reader.
- * @param useWorker - Whether to register and use worker-based converters.
  * @returns Parsed database with timing and layer info, or a skipped result if parsing is not attempted.
  */
 const parseOnce = async (
   buffer: ArrayBuffer,
-  fileType: AcDbFileType,
-  useWorker: boolean
+  fileType: AcDbFileType
 ): Promise<ParseResult> => {
-  registerConverters(useWorker)
+  registerConverters()
 
   const database = new AcDbDatabase()
   acdbHostApplicationServices().workingDatabase = database
@@ -195,23 +179,6 @@ const parseOnce = async (
     durationMs: end - start,
     layers: collectLayers(database)
   }
-}
-
-/**
- * Builds a short comparison message between main-thread and worker parse durations.
- *
- * @param mainMs - Elapsed time for main-thread parsing in milliseconds.
- * @param workerMs - Elapsed time for worker parsing in milliseconds.
- * @returns Sentence describing which side was faster and by what relative percentage.
- */
-const compareTimes = (mainMs: number, workerMs: number) => {
-  const diff = workerMs - mainMs
-  const percent = (Math.abs(diff) / Math.max(mainMs, 1)) * 100
-  if (diff === 0) return 'Worker and main thread are the same speed.'
-  if (diff < 0) {
-    return `Worker is ${percent.toFixed(1)}% faster than main thread.`
-  }
-  return `Worker is ${percent.toFixed(1)}% slower than main thread.`
 }
 
 /**
@@ -529,37 +496,11 @@ const applyPatSource = () => {
 }
 
 /**
- * Adjusts parse mode dropdown options for DWG vs DXF constraints.
- *
- * DWG parsing requires a web worker, so `compare` and `main` modes are disabled for DWG
- * files and the selection is forced to `worker` when necessary.
- *
- * @param fileType - Detected format of the currently selected file.
- */
-const updateModeOptions = (fileType: AcDbFileType) => {
-  const compareOption = modeSelect.querySelector(
-    'option[value="compare"]'
-  ) as HTMLOptionElement | null
-  const mainOption = modeSelect.querySelector(
-    'option[value="main"]'
-  ) as HTMLOptionElement | null
-
-  const disableMainThreadModes = fileType === AcDbFileType.DWG
-  if (compareOption) compareOption.disabled = disableMainThreadModes
-  if (mainOption) mainOption.disabled = disableMainThreadModes
-
-  if (disableMainThreadModes && modeSelect.value !== 'worker') {
-    modeSelect.value = 'worker'
-  }
-}
-
-/**
  * Main parse workflow triggered by file selection or the Run button.
  *
- * Validates that a file buffer is loaded, enforces worker mode for DWG, runs parsing
- * according to {@link ParseMode}, writes timing and layer output, refreshes linetype
- * previews, and updates export button state. UI controls are disabled for the duration
- * of parsing to prevent concurrent runs.
+ * Validates that a file buffer is loaded, parses via web worker, writes timing
+ * and layer output, refreshes linetype previews, and updates export button state.
+ * UI controls are disabled for the duration of parsing to prevent concurrent runs.
  */
 const runParse = async () => {
   if (!lastFile || !lastBuffer) {
@@ -568,7 +509,6 @@ const runParse = async () => {
     return
   }
 
-  let mode = modeSelect.value as ParseMode
   const fileType = getFileType(lastFile.name)
   const lines: string[] = []
   let parsedDatabase: AcDbDatabase | null = null
@@ -576,88 +516,25 @@ const runParse = async () => {
   lastParsedDatabase = null
   updateExportButton()
 
-  if (fileType === AcDbFileType.DWG && mode !== 'worker') {
-    mode = 'worker'
-    modeSelect.value = 'worker'
-    lines.push(
-      'Mode forced to worker because DWG parsing cannot run on main thread.'
-    )
-    lines.push('')
-  }
-
   runButton.disabled = true
-  modeSelect.disabled = true
   fileInput.disabled = true
   exportButton.disabled = true
 
   try {
-    setStatus('')
+    setStatus('Parsing in web worker.')
     lines.push(`File: ${lastFile.name}`)
-    lines.push(`Mode: ${mode}`)
+    lines.push('Mode: web worker')
     lines.push('')
 
-    if (mode === 'compare') {
-      setStatus('Parsing on main thread. The UI may freeze during this step.')
-      const mainResult = await parseOnce(lastBuffer.slice(0), fileType, false)
-      setStatus('Parsing in web worker.')
-      if (mainResult.skipped) {
-        lines.push(`Main thread: skipped (${mainResult.reason})`)
-      } else {
-        lines.push(`Main thread: ${formatMs(mainResult.durationMs)}`)
-      }
-
-      const workerResult = await parseOnce(lastBuffer.slice(0), fileType, true)
-      setStatus('')
-      if (workerResult.skipped) {
-        lines.push(`Worker: skipped (${workerResult.reason})`)
-      } else {
-        lines.push(`Worker: ${formatMs(workerResult.durationMs)}`)
-      }
-
-      if (
-        !mainResult.skipped &&
-        !workerResult.skipped &&
-        mainResult.durationMs != null &&
-        workerResult.durationMs != null
-      ) {
-        lines.push('')
-        lines.push(compareTimes(mainResult.durationMs, workerResult.durationMs))
-      }
-
-      lines.push('')
-      let layerSource: { count: number; names: string[] } | undefined
-      if (!workerResult.skipped) {
-        layerSource = workerResult.layers
-        parsedDatabase = workerResult.database
-      } else if (!mainResult.skipped) {
-        layerSource = mainResult.layers
-        parsedDatabase = mainResult.database
-      }
-      lines.push(...renderLayers(layerSource))
-    } else if (mode === 'main') {
-      setStatus('Parsing on main thread. The UI may freeze during this step.')
-      const result = await parseOnce(lastBuffer.slice(0), fileType, false)
-      setStatus('')
-      if (result.skipped) {
-        lines.push(`Main thread: skipped (${result.reason})`)
-      } else {
-        parsedDatabase = result.database
-        lines.push(`Main thread: ${formatMs(result.durationMs)}`)
-        lines.push('')
-        lines.push(...renderLayers(result.layers))
-      }
+    const result = await parseOnce(lastBuffer.slice(0), fileType)
+    setStatus('')
+    if (result.skipped) {
+      lines.push(`Worker: skipped (${result.reason})`)
     } else {
-      setStatus('Parsing in web worker.')
-      const result = await parseOnce(lastBuffer.slice(0), fileType, true)
-      setStatus('')
-      if (result.skipped) {
-        lines.push(`Worker: skipped (${result.reason})`)
-      } else {
-        parsedDatabase = result.database
-        lines.push(`Worker: ${formatMs(result.durationMs)}`)
-        lines.push('')
-        lines.push(...renderLayers(result.layers))
-      }
+      parsedDatabase = result.database
+      lines.push(`Worker: ${formatMs(result.durationMs)}`)
+      lines.push('')
+      lines.push(...renderLayers(result.layers))
     }
   } catch (error) {
     console.error(error)
@@ -668,7 +545,6 @@ const runParse = async () => {
     output.textContent = lines.join('\n')
     renderLinetypePreviews(lastParsedDatabase)
     runButton.disabled = false
-    modeSelect.disabled = false
     fileInput.disabled = false
     updateExportButton()
   }
@@ -680,7 +556,6 @@ fileInput.addEventListener('change', async () => {
   lastFile = file
   lastParsedDatabase = null
   renderLinetypePreviews(null)
-  updateModeOptions(getFileType(file.name))
   updateExportButton()
   output.textContent = 'Loading file...\n'
   lastBuffer = await file.arrayBuffer()

--- a/packages/libredwg-converter/README.md
+++ b/packages/libredwg-converter/README.md
@@ -6,11 +6,13 @@ The `libredwg-converter` package provides a DWG file converter for the RealDWG-W
 
 This package implements a DWG file converter compatible with the RealDWG-Web data model. It allows you to register DWG file support in your application and convert DWG files into the in-memory drawing database.
 
+DWG parsing is provided through a dedicated Web Worker bundle (`libredwg-parser-worker.js`). **This converter is intended for Web Worker use only.** That restriction is not because parsing cannot run on the main thread in principle; it is a deliberate licensing choice. LibreDWG and its WebAssembly wrapper are copyleft (GPL), and loading them in a separate worker bundle helps keep that parser code apart from the main MIT-licensed application so license obligations are easier to manage.
+
 ## Key Features
 
 - **DWG File Support**: Read and convert DWG files to the drawing database
 - **Integration**: Designed to work with the RealDWG-Web data model and converter manager
-- **WebAssembly Powered**: Uses LibreDWG compiled to WASM for fast, browser-compatible parsing
+- **WebAssembly Powered**: Uses LibreDWG compiled to WASM, loaded in a Web Worker for license isolation
 
 ## Installation
 
@@ -20,7 +22,6 @@ npm install @mlightcad/libredwg-converter
 
 > **Peer dependencies:**
 > - `@mlightcad/data-model`
-> - `@mlightcad/libredwg-web`
 
 ## Usage Example
 
@@ -28,12 +29,14 @@ npm install @mlightcad/libredwg-converter
 import { AcDbDatabaseConverterManager, AcDbFileType } from '@mlightcad/data-model';
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter';
 
-// WASM module loading (async)
-import('@mlightcad/libredwg-web/wasm/libredwg-web').then(libredwgModule => {
-  const dwgConverter = new AcDbLibreDwgConverter(libredwgModule);
-  AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, dwgConverter);
+const dwgConverter = new AcDbLibreDwgConverter({
+  useWorker: true,
+  parserWorkerUrl: './assets/libredwg-parser-worker.js'
 });
+AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, dwgConverter);
 ```
+
+Deploy `libredwg-parser-worker.js` from this package's `dist/` folder to a public URL accessible by your application.
 
 ## API
 
@@ -42,7 +45,7 @@ import('@mlightcad/libredwg-web/wasm/libredwg-web').then(libredwgModule => {
 ## Dependencies
 
 - **@mlightcad/data-model**: Drawing database and entity definitions
-- **@mlightcad/libredwg-web**: WASM wrapper for LibreDWG
+- **@mlightcad/libredwg-web**: WASM wrapper for LibreDWG, loaded in the worker bundle by design for license isolation
 
 ## API Documentation
 
@@ -50,4 +53,4 @@ For detailed API documentation, visit the [RealDWG-Web documentation](https://ml
 
 ## Contributing
 
-This package is part of the RealDWG-Web monorepo. Please refer to the main project README for contribution guidelines. 
+This package is part of the RealDWG-Web monorepo. Please refer to the main project README for contribution guidelines.

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -39,9 +39,10 @@
     "analyze:lib": "vite build --mode analyze --config vite.config.main.ts",
     "analyze:worker": "vite build --mode analyze --config vite.config.worker.ts",
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",
-    "build": "tsc && vite build -c vite.config.main.ts && vite build -c vite.config.worker.ts",
-    "build:main": "vite build -c vite.config.main.ts",
+    "build": "tsc && vite build -c vite.config.main.ts && vite build -c vite.config.worker.ts && node ../../tools/verify-build.mjs verify-build.profile.json",
+    "build:main": "vite build -c vite.config.main.ts && node ../../tools/verify-build.mjs verify-build.profile.json --main-only",
     "build:worker": "vite build -c vite.config.worker.ts",
+    "verify:build": "node ../../tools/verify-build.mjs verify-build.profile.json",
     "lint": "eslint src/",
     "lint:fix": "eslint --fix --quiet src/"
   },

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -58,9 +58,9 @@ const MODEL_SPACE = '*MODEL_SPACE'
 export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   constructor(config: AcDbDatabaseConverterConfig = {}) {
     super(config)
-    config.useWorker = true
-    if (!config.parserWorkerUrl) {
-      config.parserWorkerUrl = '/assets/libredwg-parser-worker.js'
+    this.config.useWorker = true
+    if (!this.config.parserWorkerUrl) {
+      this.config.parserWorkerUrl = '/assets/libredwg-parser-worker.js'
     }
   }
 

--- a/packages/libredwg-converter/verify-build.profile.json
+++ b/packages/libredwg-converter/verify-build.profile.json
@@ -1,0 +1,10 @@
+{
+  "main": "dist/libredwg-converter.umd.cjs",
+  "worker": "dist/libredwg-parser-worker.js",
+  "forbiddenInMain": [
+    "WebAssembly",
+    "wasmBinary",
+    "__wasm_call_ctors",
+    "HEAP8"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@mlightcad/dxf-json': ^1.2.0
-
 importers:
 
   .:
@@ -123,8 +120,8 @@ importers:
   packages/dxf-json-converter:
     dependencies:
       '@mlightcad/dxf-json':
-        specifier: ^1.2.0
-        version: 1.2.2
+        specifier: ^1.2.3
+        version: 1.2.3
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1406,8 +1403,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.2.2':
-    resolution: {integrity: sha512-ASvN/DuaO/jBR2rxbgQy4d5oOseVIZIOFYtsgoWu8XNmNWtg9EyMXoVMamJdIp0aRxtP5bMBtrgfQ7A+wSqNzQ==}
+  '@mlightcad/dxf-json@1.2.3':
+    resolution: {integrity: sha512-xnCXpt6xerJJKEt9YBPWo2V6rDMeVDULoRY5eAi6PnmuGFBEtu0tgj8PVa56PxO9FqIN1Ngtw5mdsZAvH1JX/A==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -6355,7 +6352,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.2.2':
+  '@mlightcad/dxf-json@1.2.3':
     dependencies:
       '@fxts/core': 1.26.0
 

--- a/tools/sync-versions.mjs
+++ b/tools/sync-versions.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const toolsDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(toolsDir, '..');
+const packagesDir = path.join(rootDir, 'packages');
+const rootPackageJsonPath = path.join(rootDir, 'package.json');
+const pnpmWorkspaceYamlPath = path.join(rootDir, 'pnpm-workspace.yaml');
+
+function isWorkspaceVersion(value) {
+  return typeof value === 'string' && value.startsWith('workspace:');
+}
+
+function parseOverridesFromWorkspaceYaml(content) {
+  const overrides = {};
+  const lines = content.split(/\r?\n/);
+  let inOverrides = false;
+
+  for (const line of lines) {
+    if (!inOverrides) {
+      if (/^overrides:\s*$/.test(line)) {
+        inOverrides = true;
+      }
+      continue;
+    }
+
+    if (/^[^\s#]/.test(line)) {
+      break;
+    }
+
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const entryMatch = trimmed.match(
+      /^(?:'([^']+)'|"([^"]+)"|([^:\s]+))\s*:\s*(.+)$/
+    );
+    if (!entryMatch) continue;
+
+    const key = entryMatch[1] ?? entryMatch[2] ?? entryMatch[3];
+    let value = entryMatch[4].trim();
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
+      value = value.slice(1, -1);
+    }
+    overrides[key] = value;
+  }
+
+  return overrides;
+}
+
+async function readPnpmOverrides() {
+  try {
+    const content = await readFile(pnpmWorkspaceYamlPath, { encoding: 'utf8' });
+    const fromYaml = parseOverridesFromWorkspaceYaml(content);
+    if (Object.keys(fromYaml).length > 0) {
+      return fromYaml;
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+
+  const rootPkg = await readJson(rootPackageJsonPath);
+  return rootPkg.pnpm?.overrides ?? {};
+}
+
+function buildRootVersionMap(rootPkg, overrides) {
+  return {
+    ...(rootPkg.dependencies ?? {}),
+    ...(rootPkg.devDependencies ?? {}),
+    ...(rootPkg.peerDependencies ?? {}),
+    ...overrides,
+  };
+}
+
+async function readJson(filePath) {
+  const content = await readFile(filePath, { encoding: 'utf8' });
+  return JSON.parse(content);
+}
+
+async function writeJson(filePath, data) {
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  await writeFile(filePath, content, { encoding: 'utf8' });
+}
+
+async function findWorkspacePackageNames(rootPkg) {
+  const packageNames = new Set();
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgPath = path.join(packagesDir, entry.name, 'package.json');
+    try {
+      const pkg = await readJson(pkgPath);
+      if (pkg.name) {
+        packageNames.add(pkg.name);
+      }
+    } catch {
+      // ignore packages without package.json
+    }
+  }
+
+  for (const item of rootPkg.workspaces ?? []) {
+    if (item.endsWith('/*')) continue;
+    if (item.endsWith('.json')) continue;
+  }
+
+  return packageNames;
+}
+
+async function syncPackage(
+  packageFilePath,
+  rootVersionMap,
+  workspacePackageNames,
+  overrides = {},
+  { write = true } = {}
+) {
+  const pkg = await readJson(packageFilePath);
+  const dependencyKeys = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ];
+  let changed = false;
+  const drifts = [];
+
+  for (const depKey of dependencyKeys) {
+    const deps = pkg[depKey];
+    if (!deps || typeof deps !== 'object') continue;
+
+    for (const [name, value] of Object.entries(deps)) {
+      let newVersion = null;
+
+      // Priority 1: handle workspace:* versions
+      if (isWorkspaceVersion(value)) {
+        if (workspacePackageNames.has(name)) continue;
+
+        const rootVersion = rootVersionMap[name];
+        if (!rootVersion) {
+          console.warn(`⚠️  ${pkg.name || packageFilePath}: no root version found for ${name} in ${depKey}`);
+          continue;
+        }
+        newVersion = rootVersion;
+      }
+      // Priority 2: check versions in pnpm-workspace.yaml overrides
+      else if (overrides[name] && value !== overrides[name]) {
+        newVersion = overrides[name];
+      }
+
+      if (newVersion && deps[name] !== newVersion) {
+        drifts.push({ depKey, name, from: deps[name], to: newVersion });
+        deps[name] = newVersion;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed && write) {
+    await writeJson(packageFilePath, pkg);
+  }
+
+  return { changed, drifts, pkgName: pkg.name };
+}
+
+(async () => {
+  const checkOnly = process.argv.includes('--check');
+
+  try {
+    const rootPkg = await readJson(rootPackageJsonPath);
+    const overrides = await readPnpmOverrides();
+    const rootVersionMap = buildRootVersionMap(rootPkg, overrides);
+    const workspacePackageNames = await findWorkspacePackageNames(rootPkg);
+
+    const packageDirs = await readdir(packagesDir, { withFileTypes: true });
+    const changedFiles = [];
+
+    let hadProcessingErrors = false;
+
+    for (const entry of packageDirs) {
+      if (!entry.isDirectory()) continue;
+      const packageFilePath = path.join(packagesDir, entry.name, 'package.json');
+      try {
+        const { changed, drifts, pkgName } = await syncPackage(
+          packageFilePath,
+          rootVersionMap,
+          workspacePackageNames,
+          overrides,
+          { write: !checkOnly }
+        );
+        if (changed) {
+          changedFiles.push({ packageFilePath, drifts, pkgName });
+        }
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          console.warn(
+            `⚠️  Skipping ${path.relative(rootDir, path.join(packagesDir, entry.name))}: package.json not found`
+          );
+          continue;
+        }
+        hadProcessingErrors = true;
+        console.error(`❌ Failed to process ${packageFilePath}:`, error.message);
+      }
+    }
+
+    if (hadProcessingErrors) {
+      process.exit(1);
+    }
+
+    if (changedFiles.length === 0) {
+      console.log('✅ Package dependency versions are in sync with pnpm-workspace.yaml overrides.');
+      return;
+    }
+
+    if (checkOnly) {
+      console.error('❌ package.json dependency versions are out of sync with pnpm-workspace.yaml overrides:');
+      for (const { packageFilePath, drifts, pkgName } of changedFiles) {
+        console.error(`  ${pkgName || path.relative(rootDir, packageFilePath)}:`);
+        for (const { depKey, name, from, to } of drifts) {
+          console.error(`    ${depKey}.${name}: ${from} → ${to}`);
+        }
+      }
+      console.error('\nRun "pnpm sync:versions", commit the changes, then retry the release.');
+      process.exit(1);
+    }
+
+    console.log('✅ Synced versions in the following package.json files:');
+    for (const { packageFilePath } of changedFiles) {
+      console.log(`  - ${path.relative(rootDir, packageFilePath)}`);
+    }
+  } catch (error) {
+    console.error('❌ sync-workspace-versions failed:', error.message);
+    process.exit(1);
+  }
+})();

--- a/tools/verify-build.mjs
+++ b/tools/verify-build.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
+import { readFileSync, statSync } from 'node:fs'
+
+const DEFAULT_MAX_MAIN_BYTES = 512 * 1024
+
+const args = process.argv.slice(2)
+const mainOnly = args.includes('--main-only')
+const profileArg = args.find(arg => !arg.startsWith('--'))
+
+if (!profileArg) {
+  console.error(
+    'usage: node tools/verify-build.mjs <verify-build.profile.json> [--main-only]'
+  )
+  process.exit(1)
+}
+
+const profilePath = isAbsolute(profileArg)
+  ? profileArg
+  : resolve(process.cwd(), profileArg)
+const packageDir = dirname(profilePath)
+
+let profile
+try {
+  profile = JSON.parse(readFileSync(profilePath, 'utf8'))
+} catch {
+  console.error(`verify-build: failed to read profile: ${profilePath}`)
+  process.exit(1)
+}
+
+if (!profile.main || !profile.worker || !profile.forbiddenInMain?.length) {
+  console.error(
+    'verify-build: profile must define "main", "worker", and non-empty "forbiddenInMain"'
+  )
+  process.exit(1)
+}
+
+const profileName = basename(packageDir)
+const mainBundle = join(packageDir, profile.main)
+const workerBundle = join(packageDir, profile.worker)
+const mainLabel = basename(profile.main)
+const workerLabel = basename(profile.worker)
+const maxMainBytes = profile.maxMainBytes ?? DEFAULT_MAX_MAIN_BYTES
+const requiredInWorker = profile.requiredInWorker ?? profile.forbiddenInMain
+
+function fail(message) {
+  console.error(`verify-build (${profileName}): ${message}`)
+  process.exit(1)
+}
+
+function readBundle(path) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    fail(`missing build output: ${path}`)
+  }
+}
+
+function assertMainBundle() {
+  let size
+  try {
+    size = statSync(mainBundle).size
+  } catch {
+    fail(`missing main bundle: ${mainBundle}`)
+  }
+
+  if (size > maxMainBytes) {
+    fail(
+      `${mainLabel} is too large (${size} bytes > ${maxMainBytes} bytes); parser code may have been bundled into the main bundle`
+    )
+  }
+
+  const content = readBundle(mainBundle)
+  for (const marker of profile.forbiddenInMain) {
+    if (content.includes(marker)) {
+      fail(
+        `${mainLabel} contains forbidden marker "${marker}"; parser code must stay in ${workerLabel}`
+      )
+    }
+  }
+
+  console.log(
+    `verify-build (${profileName}): ${mainLabel} ok (${size} bytes, forbidden markers absent)`
+  )
+}
+
+function assertWorkerBundle() {
+  let size
+  try {
+    size = statSync(workerBundle).size
+  } catch {
+    fail(`missing worker bundle: ${workerBundle}`)
+  }
+
+  const content = readBundle(workerBundle)
+  const hasRequiredMarker = requiredInWorker.some(marker =>
+    content.includes(marker)
+  )
+  if (!hasRequiredMarker) {
+    fail(
+      `${workerLabel} is missing expected parser markers; the worker bundle may be broken`
+    )
+  }
+
+  console.log(
+    `verify-build (${profileName}): ${workerLabel} ok (${size} bytes, parser present)`
+  )
+}
+
+assertMainBundle()
+if (!mainOnly) {
+  assertWorkerBundle()
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,13 @@
     "skipLibCheck": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@mlightcad/dxf-json/types": [
+        "packages/dxf-json-converter/node_modules/@mlightcad/dxf-json/dist/esm/types/types-entry.d.ts"
+      ]
+    }
   },
   "ts-node": {
     "esm": true,


### PR DESCRIPTION
## Summary
- Require DXF and DWG converters to run in Web Workers only, documenting this as a deliberate copyleft license isolation choice rather than a platform limitation.
- Import DXF types from `@mlightcad/dxf-json/types` and externalize the GPL parser from the main Vite bundle; add `verify-build.mjs` checks to ensure parser/WASM code stays in worker bundles.
- Add `sync-versions.mjs` tooling, bump `@mlightcad/dxf-json` to ^1.2.3, simplify the example app to worker-only parsing, and update Jest config/tests for the new import path.