### PR TITLE
fix(data-model): break circular deps via direct imports and add CJS bundle test

### DIFF
--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -144,8 +144,7 @@ describe('AcDbViewport', () => {
       const viewport = new AcDbViewport()
       viewport.number = attrs?.number ?? 2
       viewport.layer = attrs?.layer ?? '0'
-      viewport.centerPoint =
-        attrs?.centerPoint ?? new AcGePoint3d(10, 20, 0)
+      viewport.centerPoint = attrs?.centerPoint ?? new AcGePoint3d(10, 20, 0)
       viewport.width = attrs?.width ?? 8
       viewport.height = attrs?.height ?? 6
       paperSpace.appendEntity(viewport)

--- a/packages/data-model/__tests__/cjsBundle.spec.ts
+++ b/packages/data-model/__tests__/cjsBundle.spec.ts
@@ -1,0 +1,41 @@
+import { createRequire } from 'node:module'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const requireCjs = createRequire(__filename)
+const cjsPath = path.join(__dirname, '../dist/data-model.cjs')
+
+type DataModelCjs = typeof import('../src/index')
+
+describe('data-model CJS bundle', () => {
+  let dm: DataModelCjs
+
+  beforeAll(() => {
+    if (!fs.existsSync(cjsPath)) {
+      throw new Error(
+        'dist/data-model.cjs not found. Run "pnpm run build" in packages/data-model first.'
+      )
+    }
+
+    dm = requireCjs(cjsPath) as DataModelCjs
+  })
+
+  it('loads without circular dependency initialization errors', () => {
+    expect(dm).toBeDefined()
+  })
+
+  it('exports core public APIs', () => {
+    expect(typeof dm.AcDbDatabase).toBe('function')
+    expect(typeof dm.AcDbObject).toBe('function')
+    expect(typeof dm.AcDbDxfFiler).toBe('function')
+    expect(typeof dm.AcDbDatabaseConverterManager).toBe('function')
+    expect(typeof dm.acdbHostApplicationServices).toBe('function')
+  })
+
+  it('supports basic database instantiation', () => {
+    const db = new dm.AcDbDatabase()
+    expect(db).toBeInstanceOf(dm.AcDbDatabase)
+    expect(db.tables).toBeDefined()
+    expect(db.tables.layerTable).toBeDefined()
+  })
+})

--- a/packages/data-model/src/base/AcDbDxfFiler.ts
+++ b/packages/data-model/src/base/AcDbDxfFiler.ts
@@ -9,7 +9,7 @@ import {
   AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 
-import type { AcDbDatabase } from '../database'
+import type { AcDbDatabase } from '../database/AcDbDatabase'
 import { AcDbDwgVersion } from '../database/AcDbDwgVersion'
 import { AcDbResultBuffer } from './AcDbResultBuffer'
 

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -22,6 +22,13 @@ export function setAcDbHostApplicationServicesProvider(
   hostApplicationServicesProvider = provider
 }
 
+export function acdbGetWorkingDatabase(): AcDbDatabase {
+  if (hostApplicationServicesProvider) {
+    return hostApplicationServicesProvider().workingDatabase
+  }
+  throw new Error('The current working database must be set before using it!')
+}
+
 /**
  * Interface defining the attributes that can be associated with an AcDbObject.
  *

--- a/packages/data-model/src/converter/AcDbRegenerator.ts
+++ b/packages/data-model/src/converter/AcDbRegenerator.ts
@@ -1,9 +1,10 @@
-import { AcDbBlockTableRecord, AcDbDatabase } from '../database'
+import { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
+import { AcDbDatabase } from '../database/AcDbDatabase'
 import {
   AcDbConversionProgressCallback,
   AcDbDatabaseConverter
 } from '../database/AcDbDatabaseConverter'
-import { AcDbEntity } from '../entity'
+import { AcDbEntity } from '../entity/AcDbEntity'
 import { AcDbBatchProcessing } from './AcDbBatchProcessing'
 
 /**

--- a/packages/data-model/src/database/AcDbBlockTable.ts
+++ b/packages/data-model/src/database/AcDbBlockTable.ts
@@ -1,4 +1,4 @@
-import { AcDbObjectId } from '../base'
+import { AcDbObjectId } from '../base/AcDbObject'
 import { AcDbBlockTableRecord } from './AcDbBlockTableRecord'
 import { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSymbolTable } from './AcDbSymbolTable'

--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -1,6 +1,6 @@
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObjectId } from '../base/AcDbObject'
 import { AcDbEntity } from '../entity/AcDbEntity'
 import { AcDbObjectIterator } from '../misc/AcDbObjectIterator'

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -8,21 +8,16 @@ import {
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject, AcDbObjectId } from '../base/AcDbObject'
-import { AcDbRegenerator } from '../converter'
+import { AcDbRegenerator } from '../converter/AcDbRegenerator'
 import {
   AcDbConverterType,
   AcDbDatabaseConverterManager,
   AcDbFileType
 } from './AcDbDatabaseConverterManager'
-import { AcDbEntity } from '../entity'
+import { AcDbEntity } from '../entity/AcDbEntity'
 import {
   ACAD_APPID,
   ACTIVE_VPORT_NAME,
-  AcDbAngleUnits,
-  AcDbDataGenerator,
-  AcDbFormatter,
-  AcDbLinearUnits,
-  AcDbUnitsValue,
   ByBlock,
   ByLayer,
   DEFAULT_MLEADER_STYLE,
@@ -30,7 +25,12 @@ import {
   DEFAULT_LINE_TYPE,
   DEFAULT_TEXT_STYLE,
   MLIGHTCAD_APPID
-} from '../misc'
+} from '../misc/AcDbConstants'
+import { AcDbAngleUnits } from '../misc/AcDbAngleUnits'
+import { AcDbDataGenerator } from '../misc/AcDbDataGenerator'
+import { AcDbFormatter } from '../misc/AcDbFormatter'
+import { AcDbLinearUnits } from '../misc/AcDbLinearUnits'
+import { AcDbUnitsValue } from '../misc/AcDbUnitsValue'
 import { AcDbDictionary } from '../object/AcDbDictionary'
 import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
 import { AcDbMlineStyle } from '../object/AcDbMlineStyle'

--- a/packages/data-model/src/database/AcDbDatabaseConverter.ts
+++ b/packages/data-model/src/database/AcDbDatabaseConverter.ts
@@ -6,8 +6,8 @@ import {
   AcCmTaskScheduler
 } from '@mlightcad/common'
 
-import { AcDbRenderingCache } from '../misc'
-import { AcDbDatabase } from './AcDbDatabase'
+import { AcDbRenderingCache } from '../misc/AcDbRenderingCache'
+import type { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSysVarManager } from './AcDbSysVarManager'
 
 /**

--- a/packages/data-model/src/database/AcDbDimStyleTableRecord.ts
+++ b/packages/data-model/src/database/AcDbDimStyleTableRecord.ts
@@ -1,7 +1,7 @@
 import { defaults } from '@mlightcad/common'
 
-import { AcDbDxfFiler } from '../base'
-import { DEFAULT_TEXT_STYLE } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { DEFAULT_TEXT_STYLE } from '../misc/AcDbConstants'
 import {
   AcDbSymbolTableRecord,
   AcDbSymbolTableRecordAttrs

--- a/packages/data-model/src/database/AcDbLayerTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLayerTableRecord.ts
@@ -1,7 +1,7 @@
 import { AcCmColor, AcCmTransparency, defaults } from '@mlightcad/common'
 import { AcGiLineStyle, AcGiLineWeight } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import {
   AcDbSymbolTableRecord,
   AcDbSymbolTableRecordAttrs

--- a/packages/data-model/src/database/AcDbLinetypeTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLinetypeTableRecord.ts
@@ -1,6 +1,6 @@
 import { AcGiBaseLineStyle } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbSymbolTableRecord } from './AcDbSymbolTableRecord'
 
 export interface AcDbLinetypePreviewSvgOptions {

--- a/packages/data-model/src/database/AcDbRegAppTableRecord.ts
+++ b/packages/data-model/src/database/AcDbRegAppTableRecord.ts
@@ -1,4 +1,4 @@
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbSymbolTableRecord } from './AcDbSymbolTableRecord'
 
 /**

--- a/packages/data-model/src/database/AcDbSymbolTableRecord.ts
+++ b/packages/data-model/src/database/AcDbSymbolTableRecord.ts
@@ -1,6 +1,6 @@
 import { defaults } from '@mlightcad/common'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject, AcDbObjectAttrs } from '../base/AcDbObject'
 
 /**

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -7,16 +7,16 @@ import {
 import { AcGePointLike } from '@mlightcad/geometry-engine'
 import { AcGiLineWeight } from '@mlightcad/graphic-interface'
 
+import { AcDbAngleUnits } from '../misc/AcDbAngleUnits'
 import {
-  AcDbAngleUnits,
-  AcDbLinearUnits,
-  AcDbUnitsValue,
   ByLayer,
   DEFAULT_HATCH_PATTERN_METRIC,
   DEFAULT_MLEADER_STYLE,
   DEFAULT_MLINE_STYLE,
   DEFAULT_TEXT_STYLE
-} from '../misc'
+} from '../misc/AcDbConstants'
+import { AcDbLinearUnits } from '../misc/AcDbLinearUnits'
+import { AcDbUnitsValue } from '../misc/AcDbUnitsValue'
 import type { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSystemVariables } from './AcDbSystemVariables'
 

--- a/packages/data-model/src/database/AcDbTextStyleTable.ts
+++ b/packages/data-model/src/database/AcDbTextStyleTable.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TEXT_STYLE } from '../misc'
+import { DEFAULT_TEXT_STYLE } from '../misc/AcDbConstants'
 import { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSymbolTable } from './AcDbSymbolTable'
 import { AcDbTextStyleTableRecord } from './AcDbTextStyleTableRecord'

--- a/packages/data-model/src/database/AcDbTextStyleTableRecord.ts
+++ b/packages/data-model/src/database/AcDbTextStyleTableRecord.ts
@@ -1,6 +1,6 @@
 import { AcGiTextStyle } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbSymbolTableRecord } from './AcDbSymbolTableRecord'
 
 /**

--- a/packages/data-model/src/database/AcDbViewTableRecord.ts
+++ b/packages/data-model/src/database/AcDbViewTableRecord.ts
@@ -1,4 +1,4 @@
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbAbstractViewTableRecord } from './AcDbAbstractViewTableRecord'
 
 /**

--- a/packages/data-model/src/database/AcDbViewportTableRecord.ts
+++ b/packages/data-model/src/database/AcDbViewportTableRecord.ts
@@ -1,6 +1,6 @@
 import { AcGePoint2d } from '@mlightcad/geometry-engine'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { ACTIVE_VPORT_NAME } from '../misc/AcDbConstants'
 import { AcDbAbstractViewTableRecord } from './AcDbAbstractViewTableRecord'
 

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -9,8 +9,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDb2dVertex.ts
+++ b/packages/data-model/src/entity/AcDb2dVertex.ts
@@ -6,8 +6,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 
 export enum AcDb2dVertexType {

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -9,8 +9,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDb3dVertex.ts
+++ b/packages/data-model/src/entity/AcDb3dVertex.ts
@@ -6,8 +6,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 
 export enum AcDb3dVertexType {

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -12,8 +12,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'

--- a/packages/data-model/src/entity/AcDbAttribute.ts
+++ b/packages/data-model/src/entity/AcDbAttribute.ts
@@ -1,4 +1,4 @@
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import {
   AcDbAttributeFlags,
   AcDbAttributeMTextFlag

--- a/packages/data-model/src/entity/AcDbAttributeDefinition.ts
+++ b/packages/data-model/src/entity/AcDbAttributeDefinition.ts
@@ -1,6 +1,6 @@
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbMText } from './AcDbMText'
 import { AcDbText } from './AcDbText'
 

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -9,8 +9,11 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler, AcDbObjectId } from '../base'
-import { AcDbObjectIterator, AcDbOsnapMode, AcDbRenderingCache } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbObjectId } from '../base/AcDbObject'
+import { AcDbObjectIterator } from '../misc/AcDbObjectIterator'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
+import { AcDbRenderingCache } from '../misc/AcDbRenderingCache'
 import { AcDbAttribute } from './AcDbAttribute'
 import { AcDbEntity } from './AcDbEntity'
 import {

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -12,8 +12,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -8,8 +8,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -12,9 +12,10 @@ import {
   AcGiStyleType
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject } from '../base/AcDbObject'
-import { AcDbOsnapMode, ByBlock, ByLayer, DEFAULT_LINE_TYPE } from '../misc'
+import { ByBlock, ByLayer, DEFAULT_LINE_TYPE } from '../misc/AcDbConstants'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import {
   AcDbEntityProperties,
   AcDbEntityPropertyGroup

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -4,11 +4,12 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGePointLike} from '@mlightcad/geometry-engine'
+  AcGePointLike
+} from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -21,16 +21,16 @@ import {
   AcGiRenderer
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import type { AcDbDatabase } from '../database/AcDbDatabase'
 import { AcDbSystemVariables } from '../database/AcDbSystemVariables'
 import { AcDbSysVarManager } from '../database/AcDbSysVarManager'
-import { AcDbOsnapMode } from '../misc'
 import {
   DEFAULT_GRADIENT_HATCH_NAME,
   HATCH_PATTERN_SOLID,
   HATCH_PATTERN_USER
 } from '../misc/AcDbConstants'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbPredefinedAcadIsoPat } from '../misc/pat/AcDbPatPredefined'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -10,8 +10,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import {
   acdbCollectLineSegmentOsnapPoints,

--- a/packages/data-model/src/entity/AcDbLine.ts
+++ b/packages/data-model/src/entity/AcDbLine.ts
@@ -7,7 +7,7 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -20,14 +20,12 @@ import {
   AcGiTextStyle
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import {
-  AcDbRenderingCache,
-  decodeMLeaderStyleRawColor,
-  DEFAULT_MLEADER_STYLE
-} from '../misc'
-import { AcDbOsnapMode } from '../misc'
-import { AcDbMLeaderStyle } from '../object'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { DEFAULT_MLEADER_STYLE } from '../misc/AcDbConstants'
+import { decodeMLeaderStyleRawColor } from '../misc/AcDbMLeaderStyleColorCodec'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
+import { AcDbRenderingCache } from '../misc/AcDbRenderingCache'
+import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDbMLine.ts
+++ b/packages/data-model/src/entity/AcDbMLine.ts
@@ -11,15 +11,15 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import {
   ByBlock,
   ByLayer,
   DEFAULT_LINE_TYPE,
   DEFAULT_MLINE_STYLE
-} from '../misc'
-import { AcDbOsnapMode } from '../misc'
-import { AcDbMlineStyle } from '../object'
+} from '../misc/AcDbConstants'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
+import { AcDbMlineStyle } from '../object/AcDbMlineStyle'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -13,8 +13,8 @@ import {
   AcGiMTextFlowDirection
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDbOsnapHelpers.ts
+++ b/packages/data-model/src/entity/AcDbOsnapHelpers.ts
@@ -6,7 +6,7 @@ import {
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
 
-import { AcDbOsnapMode } from '../misc'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 
 function distSq3d(a: AcGePoint3dLike, b: AcGePoint3dLike): number {
   const dx = a.x - b.x

--- a/packages/data-model/src/entity/AcDbPoint.ts
+++ b/packages/data-model/src/entity/AcDbPoint.ts
@@ -7,8 +7,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 

--- a/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
@@ -7,8 +7,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'

--- a/packages/data-model/src/entity/AcDbPolygonMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolygonMesh.ts
@@ -7,8 +7,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -12,8 +12,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDbRasterImage.ts
+++ b/packages/data-model/src/entity/AcDbRasterImage.ts
@@ -10,8 +10,9 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler, AcDbObjectId } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbObjectId } from '../base/AcDbObject'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -9,8 +9,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 

--- a/packages/data-model/src/entity/AcDbShape.ts
+++ b/packages/data-model/src/entity/AcDbShape.ts
@@ -13,8 +13,8 @@ import {
   AcGiTextStyle
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -10,8 +10,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbPolyline } from './AcDbPolyline'
 

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -14,8 +14,8 @@ import {
   AcGiTextStyle
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import type { AcDbBlockTableRecord } from '../database'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import type { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
 import { AcDbBlockReference } from './AcDbBlockReference'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -14,8 +14,8 @@ import {
   AcGiTextStyle
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import {

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -10,8 +10,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'

--- a/packages/data-model/src/entity/AcDbViewport.ts
+++ b/packages/data-model/src/entity/AcDbViewport.ts
@@ -10,7 +10,7 @@ import {
   AcGiViewport
 } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbEntity } from './AcDbEntity'
 
 /**

--- a/packages/data-model/src/entity/AcDbWipeout.ts
+++ b/packages/data-model/src/entity/AcDbWipeout.ts
@@ -1,7 +1,7 @@
 import { AcGeArea2d, AcGePolyline2d } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbRasterImage } from './AcDbRasterImage'
 
 /**

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -9,8 +9,8 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbDxfFiler } from '../base'
-import { AcDbOsnapMode } from '../misc'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 

--- a/packages/data-model/src/misc/AcDbDataGenerator.ts
+++ b/packages/data-model/src/misc/AcDbDataGenerator.ts
@@ -1,16 +1,14 @@
 import { AcCmColor } from '@mlightcad/common'
 import { AcGeLine2d, AcGeLoop2d } from '@mlightcad/geometry-engine'
 
-import {
-  AcDbBlockTableRecord,
-  AcDbDatabase,
-  AcDbDimStyleTableRecord,
-  AcDbLayerTableRecord,
-  AcDbLinetypeTableRecord,
-  AcDbTextStyleTableRecord
-} from '../database'
-import { AcDbHatch } from '../entity'
-import { AcDbLayout } from '../object'
+import { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
+import { AcDbDatabase } from '../database/AcDbDatabase'
+import { AcDbDimStyleTableRecord } from '../database/AcDbDimStyleTableRecord'
+import { AcDbLayerTableRecord } from '../database/AcDbLayerTableRecord'
+import { AcDbLinetypeTableRecord } from '../database/AcDbLinetypeTableRecord'
+import { AcDbTextStyleTableRecord } from '../database/AcDbTextStyleTableRecord'
+import { AcDbHatch } from '../entity/AcDbHatch'
+import { AcDbLayout } from '../object/layout/AcDbLayout'
 import { DEFAULT_TEXT_STYLE, HATCH_PATTERN_SOLID } from './AcDbConstants'
 
 export class AcDbDataGenerator {

--- a/packages/data-model/src/misc/AcDbRenderingCache.ts
+++ b/packages/data-model/src/misc/AcDbRenderingCache.ts
@@ -2,8 +2,8 @@ import { AcCmColor } from '@mlightcad/common'
 import { AcGeMatrix3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
 
-import { AcDbBlockTableRecord } from '../database'
-import { AcDbEntity } from '../entity'
+import { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
+import { AcDbEntity } from '../entity/AcDbEntity'
 
 /**
  * Internal class used to cache rendered results to avoid duplicated rendering.

--- a/packages/data-model/src/object/AcDbMLeaderStyle.ts
+++ b/packages/data-model/src/object/AcDbMLeaderStyle.ts
@@ -3,7 +3,7 @@ import { AcGeVector3d, AcGeVector3dLike } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject } from '../base/AcDbObject'
-import { encodeMLeaderStyleRawColor } from '../misc'
+import { encodeMLeaderStyleRawColor } from '../misc/AcDbMLeaderStyleColorCodec'
 
 /**
  * Represents the nongraphical MLEADERSTYLE object.

--- a/packages/data-model/src/object/layout/AcDbLayoutManager.ts
+++ b/packages/data-model/src/object/layout/AcDbLayoutManager.ts
@@ -1,7 +1,6 @@
 import { AcCmEventManager } from '@mlightcad/common'
 
-import { acdbHostApplicationServices } from '../../base/AcDbHostApplicationServices'
-import { AcDbObjectId } from '../../base/AcDbObject'
+import { acdbGetWorkingDatabase, AcDbObjectId } from '../../base/AcDbObject'
 import { AcDbBlockTableRecord } from '../../database/AcDbBlockTableRecord'
 import { AcDbDatabase } from '../../database/AcDbDatabase'
 import { AcDbLayout } from './AcDbLayout'
@@ -266,7 +265,7 @@ export class AcDbLayoutManager {
   }
 
   private getWorkingDatabase(db?: AcDbDatabase) {
-    return db || acdbHostApplicationServices().workingDatabase
+    return db || acdbGetWorkingDatabase()
   }
 
   private setCurrentLayoutInternal(

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -46,7 +46,9 @@ class TestDxfConverter extends AcDbDxfConverter {
 describe('AcDbDxfConverter', () => {
   it('sets default parser worker url and useWorker in constructor', () => {
     const converter = new AcDbDxfConverter()
-    expect(converter.config.parserWorkerUrl).toBe('/assets/dxf-parser-worker.js')
+    expect(converter.config.parserWorkerUrl).toBe(
+      '/assets/dxf-parser-worker.js'
+    )
     expect(converter.config.useWorker).toBe(true)
   })
 

--- a/packages/geometry-engine/__tests__/AcGePolygonAreaUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGePolygonAreaUtil.spec.ts
@@ -19,7 +19,12 @@ describe('AcGePolygonAreaUtil', () => {
 
   it('returns 0 for open or degenerate loops', () => {
     expect(acGeClosedPolygonArea2d([])).toBe(0)
-    expect(acGeClosedPolygonArea2d([{ x: 0, y: 0 }, { x: 1, y: 0 }])).toBe(0)
+    expect(
+      acGeClosedPolygonArea2d([
+        { x: 0, y: 0 },
+        { x: 1, y: 0 }
+      ])
+    ).toBe(0)
   })
 
   it('computes 3D planar polygon area', () => {


### PR DESCRIPTION
## Summary

- Replace barrel imports (`../base`, `../database`, `../entity`, `../misc`, etc.) with direct module paths across `data-model` to break circular dependency chains that broke the CJS bundle at runtime.
- Add `acdbGetWorkingDatabase()` in `AcDbObject` and use it from `AcDbLayoutManager` to avoid pulling in `AcDbHostApplicationServices` during initialization.
- Use `import type` for `AcDbDatabase` in `AcDbDatabaseConverter` where only types are needed.
- Add `cjsBundle.spec.ts` to verify `dist/data-model.cjs` loads, exports core APIs, and supports basic database instantiation without circular dependency errors.

## Test plan

- [ ] `pnpm run build` in `packages/data-model`
- [ ] `pnpm test` in `packages/data-model` (includes new `cjsBundle.spec.ts`)
- [ ] `pnpm test` at repo root
- [ ] Confirm CJS consumers can `require('@mlightcad/data-model')` without initialization errors