### PR TITLE
feat(libredwg-converter): convert ACAD_PROXY_ENTITY to AcDbProxyEntity

### DIFF
--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -5,6 +5,7 @@ import {
   AcDbCircle,
   AcDbDatabase,
   AcDbHatch,
+  AcDbProxyEntity,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
 
@@ -71,6 +72,34 @@ describe('libredwg AcDbEntityConverter', () => {
     expect(dbArc.startPoint).toMatchObject({ x: -2, y: 2, z: 0 })
     expect(dbArc.endPoint).toMatchObject({ x: -1, y: 3, z: 0 })
     expect(dbCircle.center).toMatchObject({ x: -1, y: 2, z: 0 })
+  })
+
+  it('converts ACAD_PROXY_ENTITY with graphics data to AcDbProxyEntity', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'ACAD_PROXY_ENTITY',
+      subclassMarker: 'AcDbProxyEntity',
+      originalDxfName: 'AECC_TIN_SURFACE',
+      proxyEntityClassId: 498,
+      applicationEntityClassId: 500,
+      graphicsDataSize: 4,
+      graphicsData: '01020304',
+      entityDataSize: 0,
+      objectDrawingFormat: 29,
+      originalDataFormat: 0,
+      layer: '0',
+      handle: 'A1'
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbProxyEntity)
+    const proxy = result as AcDbProxyEntity
+    expect(proxy.type).toBe('ProxyEntity')
+    expect(proxy.originalDxfName).toBe('AECC_TIN_SURFACE')
+    expect(proxy.proxyEntityClassId).toBe(498)
+    expect(proxy.graphicsMetafileType).toBe(29)
+    expect(proxy.originalClassName).toBe('500')
+    expect(proxy.proxyGraphic).toEqual(new Uint8Array([0x01, 0x02, 0x03, 0x04]))
   })
 
   describe('ATTRIB common attribute propagation (issue #183 follow-up)', () => {

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "^0.7.2"
+    "@mlightcad/libredwg-web": "^0.7.3"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -38,6 +38,7 @@ import {
   AcDbPolyFaceMesh,
   AcDbPolygonMesh,
   AcDbPolyline,
+  AcDbProxyEntity,
   AcDbRadialDimension,
   AcDbRasterImage,
   AcDbRasterImageClipBoundaryType,
@@ -67,8 +68,8 @@ import {
   AcGeVector3d,
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection,
-  transformOcsPointToWcs
-} from '@mlightcad/data-model'
+  hexStringsToBytes,
+  transformOcsPointToWcs} from '@mlightcad/data-model'
 import type {
   Dwg3dFaceEntity,
   DwgAlignedDimensionEntity,
@@ -99,6 +100,7 @@ import type {
   DwgPolyline2dEntity,
   DwgPolyline3dEntity,
   DwgPolylineBoundaryPath,
+  DwgProxyEntity,
   DwgRadialDiameterDimensionEntity,
   DwgRayEntity,
   DwgSolidEntity,
@@ -232,8 +234,33 @@ export class AcDbEntityConverter {
       return this.convertXline(entity as DwgXlineEntity)
     } else if (entity.type == 'INSERT') {
       return this.convertBlockReference(entity as DwgInsertEntity)
+    } else if (entity.type == 'ACAD_PROXY_ENTITY') {
+      return this.convertProxyEntity(entity as DwgProxyEntity)
     }
     return null
+  }
+
+  /**
+   * Converts a DWG ACAD_PROXY_ENTITY to an AcDbProxyEntity.
+   */
+  private convertProxyEntity(entity: DwgProxyEntity): AcDbProxyEntity {
+    const proxy = new AcDbProxyEntity()
+    proxy.proxyEntityClassId = entity.proxyEntityClassId
+    if (entity.originalDxfName) {
+      proxy.originalDxfName = entity.originalDxfName
+    }
+    if (entity.objectDrawingFormat != null) {
+      proxy.graphicsMetafileType = entity.objectDrawingFormat
+    }
+    if (entity.applicationEntityClassId != null) {
+      proxy.originalClassName = String(entity.applicationEntityClassId)
+    }
+    if (entity.graphicsData) {
+      const bytes = hexStringsToBytes([entity.graphicsData])
+      const size = entity.graphicsDataSize ?? bytes.length
+      proxy.setProxyGraphic(bytes.subarray(0, size))
+    }
+    return proxy
   }
 
   private convertFace(face: Dwg3dFaceEntity) {

--- a/packages/libredwg-converter/vite.config.worker.ts
+++ b/packages/libredwg-converter/vite.config.worker.ts
@@ -1,9 +1,24 @@
 import strip from 'vite-plugin-strip-comments'
 import { visualizer } from 'rollup-plugin-visualizer'
-import { defineConfig, PluginOption } from 'vite'
+import { defineConfig, PluginOption, Plugin } from 'vite'
+
+/** Linked packages resolve outside node_modules; strip-comments breaks Emscripten glue (`"file://"`). */
+function stripCommentsSafe(...args: Parameters<typeof strip>): Plugin {
+  const plugin = strip(...args)
+  const transform = plugin.transform
+  if (transform) {
+    plugin.transform = function (code, id, options) {
+      if (id?.includes('libredwg-web')) {
+        return { code, map: null }
+      }
+      return transform.call(this, code, id, options)
+    }
+  }
+  return plugin
+}
 
 export default defineConfig(({ mode }) => {
-  const plugins: PluginOption[] = [strip({ type: 'none' })]
+  const plugins: PluginOption[] = [stripCommentsSafe({ type: 'none' })]
 
   if (mode === 'analyze') {
     plugins.push(visualizer())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/libredwg-converter:
     dependencies:
       '@mlightcad/libredwg-web':
-        specifier: ^0.7.2
-        version: 0.7.2
+        specifier: ^0.7.3
+        version: 0.7.3
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1409,8 +1409,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.2':
-    resolution: {integrity: sha512-MPbVtnuUokzvCS4pdibiNw7PLdnSJo9R1pZcBnzRCyzWQqMHuZOxLVwtsV9aGk1SBmJ2186Hbu3Umt2B7hFS4Q==}
+  '@mlightcad/libredwg-web@0.7.3':
+    resolution: {integrity: sha512-r0/TVhD6PoQInkcpiJyAx2GNG3VfFcgmBvDHjhAduIj+5F/uGtIcxP80uFcLKsV2yYbGPYElor2NsyKLRRpR4g==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6358,7 +6358,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.2': {}
+  '@mlightcad/libredwg-web@0.7.3': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `ACAD_PROXY_ENTITY` conversion in libredwg-converter, mapping DWG proxy entities to `AcDbProxyEntity` (original DXF name, class IDs, graphics metafile type, and proxy graphic bytes).
- Bump `@mlightcad/libredwg-web` to `^0.7.3` for updated proxy entity DWG typings/parsing.
- Fix worker build by skipping `vite-plugin-strip-comments` for `libredwg-web` Emscripten glue (avoids breaking "file://"` strings).

## Test plan
- [ ] Run libredwg-converter unit tests (`pnpm --filter @mlightcad/libredwg-converter test`)
- [ ] Verify worker bundle builds successfully
- [ ] Load a DWG containing proxy entities (e.g. Civil 3D surfaces) and confirm they render as proxy graphics
