### PR TITLE
fix(data-model): resolve attribute ByBlock/ByLayer colors from owning INSERT

### DIFF
--- a/packages/data-model/__tests__/AcDbAttribute.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttribute.spec.ts
@@ -1,7 +1,14 @@
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcCmColor } from '@mlightcad/common'
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
 import { AcDbDatabase } from '../src/database'
-import { AcDbAttribute, AcDbMText, AcDbTextVerticalMode } from '../src/entity'
+import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
+import {
+  AcDbAttribute,
+  AcDbBlockReference,
+  AcDbMText,
+  AcDbTextVerticalMode
+} from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 const setWorkingDb = () => {
@@ -160,5 +167,53 @@ describe('AcDbAttribute', () => {
 
     expect(attribute.geometricExtents.min).toMatchObject({ x: 8, y: 9, z: 10 })
     expect(attribute.geometricExtents.max.x).toBeCloseTo(10)
+  })
+
+  it('resolves ByBlock color from the owning INSERT, not CECOLOR', () => {
+    const db = setWorkingDb()
+    const viewportLayer = new AcDbLayerTableRecord()
+    viewportLayer.name = 'Viewport'
+    viewportLayer.color = new AcCmColor()
+    viewportLayer.color.setForeground()
+    db.tables.layerTable.add(viewportLayer)
+
+    const insert = new AcDbBlockReference('BLOCK')
+    insert.layer = 'Viewport'
+    db.tables.blockTable.modelSpace.appendEntity(insert)
+
+    const attribute = new AcDbAttribute()
+    attribute.color.setByBlock()
+    insert.appendAttributes(attribute)
+
+    expect(attribute.database).toBe(db)
+    expect(attribute.resolvedColor.isForeground).toBe(true)
+  })
+
+  it('resolves ByLayer color from the attribute layer, not the INSERT layer', () => {
+    const db = setWorkingDb()
+    const viewportLayer = new AcDbLayerTableRecord()
+    viewportLayer.name = 'Viewport'
+    viewportLayer.color = new AcCmColor()
+    viewportLayer.color.setForeground()
+    db.tables.layerTable.add(viewportLayer)
+
+    const cartoucheLayer = new AcDbLayerTableRecord()
+    cartoucheLayer.name = 'CARTOUCHE'
+    cartoucheLayer.color = new AcCmColor()
+    cartoucheLayer.color.colorIndex = 40
+    db.tables.layerTable.add(cartoucheLayer)
+
+    const insert = new AcDbBlockReference('BLOCK')
+    insert.layer = 'Viewport'
+    db.tables.blockTable.modelSpace.appendEntity(insert)
+
+    const attribute = new AcDbAttribute()
+    attribute.layer = 'CARTOUCHE'
+    attribute.color.setByLayer()
+    insert.appendAttributes(attribute)
+
+    expect(attribute.database).toBe(db)
+    expect(attribute.resolvedColor.colorIndex).toBe(40)
+    expect(attribute.resolvedColor.isForeground).toBe(false)
   })
 })

--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -1,3 +1,4 @@
+import { AcCmColor } from '@mlightcad/common'
 import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
@@ -62,12 +63,10 @@ describe('AcDbBlockReference', () => {
     db.tables.blockTable.modelSpace.appendEntity(blockRef)
 
     const attr1 = new AcDbAttribute()
-    attr1.database = db
     attr1.tag = 'A1'
     attr1.textString = 'v1'
 
     const attr2 = new AcDbAttribute()
-    attr2.database = db
     attr2.tag = 'A2'
     attr2.textString = 'v2'
 
@@ -79,6 +78,23 @@ describe('AcDbBlockReference', () => {
     expect(attrs.map(a => a.tag)).toEqual(['A1', 'A2'])
     expect(attr1.ownerId).toBe(blockRef.objectId)
     expect(attr2.ownerId).toBe(blockRef.objectId)
+    expect(attr1.database).toBe(db)
+    expect(attr2.database).toBe(db)
+  })
+
+  it('propagates database to attributes appended before INSERT is committed', () => {
+    const db = createDb()
+    createNamedBlock(db, 'TEST_BLOCK')
+
+    const blockRef = new AcDbBlockReference('TEST_BLOCK')
+    const attr = new AcDbAttribute()
+    attr.tag = 'A1'
+    blockRef.appendAttributes(attr)
+
+    db.tables.blockTable.modelSpace.appendEntity(blockRef)
+
+    expect(attr.database).toBe(db)
+    expect(attr.ownerId).toBe(blockRef.objectId)
   })
 
   it('computes blockTransform with base-point compensation', () => {
@@ -375,13 +391,43 @@ describe('AcDbBlockReference', () => {
     const drawn = AcDbRenderingCache.instance.draw(
       renderer as never,
       block,
-      0,
+      new AcCmColor(),
       [],
       false
     )
 
     expect(invisibleSpy).not.toHaveBeenCalled()
     expect(drawn).toEqual({ items: [visibleDrawn] })
+  })
+
+  it('applies black block color to ByBlock entities inside block definitions', () => {
+    const db = createDb()
+    const block = createNamedBlock(db, 'BYBLOCK_BLK')
+    const line = new AcDbLine({ x: 0, y: 0, z: 0 }, { x: 10, y: 0, z: 0 })
+    line.color.setByBlock()
+    block.appendEntity(line)
+
+    const colorsDuringDraw: number[] = []
+    jest.spyOn(line, 'worldDraw').mockImplementation(() => {
+      colorsDuringDraw.push(line.color.RGB ?? -1)
+      return { id: 'line' } as never
+    })
+
+    AcDbRenderingCache.instance.clear()
+    const renderer = {
+      group: (items: unknown[]) => ({ items })
+    }
+
+    AcDbRenderingCache.instance.draw(
+      renderer as never,
+      block,
+      new AcCmColor().setRGBValue(0x000000),
+      [],
+      false
+    )
+
+    expect(colorsDuringDraw).toEqual([0x000000])
+    expect(line.color.isByBlock).toBe(true)
   })
 
   it('draws through cache for existing block and empty group for missing block', () => {

--- a/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
+++ b/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
@@ -6,6 +6,8 @@ jest.mock('../src/entity', () => ({
   AcDbEntity: class MockEntity {}
 }))
 
+import { AcCmColor } from '@mlightcad/common'
+
 import { AcDbRenderingCache } from '../src/misc/AcDbRenderingCache'
 
 describe('AcDbRenderingCache', () => {
@@ -13,8 +15,15 @@ describe('AcDbRenderingCache', () => {
     const cache = new AcDbRenderingCache()
     expect(AcDbRenderingCache.instance).toBeInstanceOf(AcDbRenderingCache)
 
-    const key = cache.createKey('B1', 7)
-    expect(key).toBe('B1_7')
+    const color = new AcCmColor().setRGBValue(0xff0000)
+    const key = cache.createKey('B1', color)
+    expect(key).toBe('B1_RGB:255,0,0')
+
+    const foreground = new AcCmColor().setForeground()
+    expect(cache.createKey('B1', foreground)).toBe('B1_7')
+
+    const black = new AcCmColor().setRGBValue(0x000000)
+    expect(cache.createKey('B1', black)).toBe('B1_RGB:0,0,0')
 
     const group = {
       fastDeepClone() {
@@ -31,7 +40,7 @@ describe('AcDbRenderingCache', () => {
       group: (items: unknown[]) => ({ items, fastDeepClone: () => ({ items }) })
     } as any
 
-    const drawn = cache.draw(renderer, null as any, 0)
+    const drawn = cache.draw(renderer, null as any, new AcCmColor())
     expect(drawn).toBeDefined()
 
     cache.clear()

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -342,6 +342,14 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   set database(db: AcDbDatabase) {
+    this.assignDatabase(db)
+  }
+
+  /**
+   * Associates this object with a database. Subclasses may override {@link database}
+   * and call this helper to avoid `super` setter restrictions.
+   */
+  protected assignDatabase(db: AcDbDatabase) {
     this._database = db
   }
 

--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -270,6 +270,13 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord {
       this.database.commitObjectHandle(item, id => this._entities.has(id))
       item.resolveEffectiveProperties()
       this._entities.set(item.objectId, item)
+      if (
+        item.dxfTypeName === 'INSERT' &&
+        'syncAttributeDatabases' in item &&
+        typeof item.syncAttributeDatabases === 'function'
+      ) {
+        item.syncAttributeDatabases()
+      }
     }
 
     if (Array.isArray(entity)) {

--- a/packages/data-model/src/entity/AcDbAttribute.ts
+++ b/packages/data-model/src/entity/AcDbAttribute.ts
@@ -3,8 +3,15 @@ import {
   AcDbAttributeFlags,
   AcDbAttributeMTextFlag
 } from './AcDbAttributeDefinition'
+import { AcDbEntity } from './AcDbEntity'
 import { AcDbMText } from './AcDbMText'
 import { AcDbText } from './AcDbText'
+
+function isBlockReferenceOwner(
+  owner: unknown
+): owner is AcDbEntity & { blockTableRecord: unknown } {
+  return owner != null && typeof owner === 'object' && 'blockTableRecord' in owner
+}
 
 /**
  * Represents an attribute entity attached to a block reference (INSERT).
@@ -22,6 +29,24 @@ export class AcDbAttribute extends AcDbText {
 
   override get dxfTypeName() {
     return 'ATTRIB'
+  }
+
+  /**
+   * Resolves ByBlock color against the owning INSERT, not CECOLOR.
+   *
+   * AutoCAD attributes inherit block-reference traits for ByBlock color. When
+   * the INSERT sits on a layer such as `Viewport` with ACI 7, attribute text
+   * must follow that foreground colour (inverted on paper) rather than the
+   * current-entity colour sysvar.
+   */
+  override get resolvedColor() {
+    if (this.color.isByBlock) {
+      const owner = this.database?.tables.blockTable.getEntityById(this.ownerId)
+      if (isBlockReferenceOwner(owner)) {
+        return owner.resolvedColor
+      }
+    }
+    return this.resolveStandardColor()
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -251,6 +251,23 @@ export class AcDbBlockReference extends AcDbEntity {
   appendAttributes(attrib: AcDbAttribute) {
     this._attribs.set(attrib.objectId, attrib)
     attrib.ownerId = this.objectId
+    this.syncAttributeDatabases()
+  }
+
+  /**
+   * Propagates this INSERT's database association to all attached attributes.
+   *
+   * @internal
+   */
+  syncAttributeDatabases() {
+    try {
+      const db = this.database
+      this._attribs.forEach(attrib => {
+        attrib.database = db
+      })
+    } catch {
+      // INSERT not yet associated with a database.
+    }
   }
 
   /**
@@ -732,7 +749,7 @@ export class AcDbBlockReference extends AcDbEntity {
       const block = AcDbRenderingCache.instance.draw(
         renderer,
         blockTableRecord,
-        this.rgbColor,
+        this.resolvedColor,
         attribs,
         true,
         matrix,

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -157,6 +157,13 @@ export abstract class AcDbEntity extends AcDbObject {
    * Resolved color applied on this entity. It will resolve layer colors and block colors as needed.
    */
   get resolvedColor() {
+    return this.resolveStandardColor()
+  }
+
+  /**
+   * Default ByLayer / ByBlock colour resolution for entities without an INSERT owner.
+   */
+  protected resolveStandardColor() {
     let color = this.color
     if (color.isByLayer) {
       const layerColor = this.getLayerColor()
@@ -178,8 +185,8 @@ export abstract class AcDbEntity extends AcDbObject {
           }
         }
       }
-      // Block reference entity needs to override this method to resolve ByBlock
-      // against INSERT-level inherited traits.
+      // Nested block ByBlock colours are applied during block rendering. Attributes
+      // override this method to resolve ByBlock against their owning INSERT.
     }
     return color
   }

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -2177,7 +2177,7 @@ export class AcDbMLeader extends AcDbEntity {
     return AcDbRenderingCache.instance.draw(
       renderer,
       blockTableRecord,
-      this.rgbColor,
+      this.resolvedColor,
       [],
       true,
       transform,

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -459,7 +459,7 @@ export abstract class AcDbDimension extends AcDbEntity {
       const group = AcDbRenderingCache.instance.draw(
         renderer,
         blockTableRecord,
-        this.rgbColor,
+        this.resolvedColor,
         [],
         false,
         matrix,

--- a/packages/data-model/src/misc/AcDbRenderingCache.ts
+++ b/packages/data-model/src/misc/AcDbRenderingCache.ts
@@ -17,8 +17,9 @@ import { AcDbEntity } from '../entity/AcDbEntity'
  * @example
  * ```typescript
  * const cache = AcDbRenderingCache.instance;
- * const key = cache.createKey('MyBlock', 0xFF0000);
- * const renderedEntity = cache.draw(renderer, blockRecord, 0xFF0000);
+ * const color = new AcCmColor().setRGBValue(0xFF0000);
+ * const key = cache.createKey('MyBlock', color);
+ * const renderedEntity = cache.draw(renderer, blockRecord, color);
  * ```
  */
 export class AcDbRenderingCache {
@@ -60,17 +61,22 @@ export class AcDbRenderingCache {
    * Creates a cache key by combining the block name and color.
    *
    * @param name - The block name
-   * @param color - The color value
+   * @param color - The resolved block color
    * @returns A unique key for the cache entry
    *
    * @example
    * ```typescript
-   * const key = cache.createKey('MyBlock', 0xFF0000);
-   * // Returns: "MyBlock_16711680"
+   * const color = new AcCmColor().setRGBValue(0xFF0000);
+   * const key = cache.createKey('MyBlock', color);
+   * // Returns: "MyBlock_RGB:255,0,0"
    * ```
    */
-  createKey(name: string, color: number) {
-    return `${name}_${color}`
+  createKey(name: string, color: AcCmColor) {
+    let colorKey = color.toString()
+    if (!colorKey && color.isByColor) {
+      colorKey = `RGB:${color.red},${color.green},${color.blue}`
+    }
+    return `${name}_${colorKey}`
   }
 
   /**
@@ -151,7 +157,7 @@ export class AcDbRenderingCache {
    *
    * @param renderer - The renderer to use for drawing
    * @param blockTableRecord - The block table record to draw
-   * @param color - The color to use for rendering
+   * @param blockColor - The resolved color to use for rendering
    * @param cache - Whether to cache the rendering result (default: true)
    * @param transform - Optional transformation matrix to apply
    * @param normal - Optional normal vector
@@ -162,7 +168,7 @@ export class AcDbRenderingCache {
    * const renderedEntity = cache.draw(
    *   renderer,
    *   blockRecord,
-   *   0xFF0000,
+   *   new AcCmColor().setRGBValue(0xFF0000),
    *   true,
    *   transform,
    *   normal
@@ -172,7 +178,7 @@ export class AcDbRenderingCache {
   draw(
     renderer: AcGiRenderer,
     blockTableRecord: AcDbBlockTableRecord,
-    color: number,
+    blockColor: AcCmColor,
     attributes: AcGiEntity[] = [],
     cache: boolean = true,
     transform?: AcGeMatrix3d,
@@ -180,7 +186,8 @@ export class AcDbRenderingCache {
   ) {
     const results: AcGiEntity[] = []
     if (blockTableRecord != null) {
-      const key = this.createKey(blockTableRecord.name, color)
+      const blockRgb = blockColor.RGB ?? 0
+      const key = this.createKey(blockTableRecord.name, blockColor)
       let block: AcGiEntity | undefined
       if (this.has(key)) {
         block = this.get(key)
@@ -193,9 +200,13 @@ export class AcDbRenderingCache {
           // If the color of this entity is 'byBlock', then store the original color of this entity color
           // and set the color of this entity to block's color. After renderering this entity, restore
           // its original color
-          if (entity.color.isByBlock && color) {
+          if (entity.color.isByBlock) {
             _tmpColor.copy(entity.color)
-            entity.color.setRGBValue(color)
+            if (blockColor.isForeground) {
+              entity.color.setForeground()
+            } else {
+              entity.color.setRGBValue(blockRgb)
+            }
             this.addEntity(entity, results, renderer)
             entity.color.copy(_tmpColor)
           } else {


### PR DESCRIPTION
## Summary

- Fix attribute color resolution: ByBlock now inherits from the owning INSERT (not CECOLOR), and ByLayer resolves from the attribute's own layer.
- Propagate database association to attributes when they are appended to a block reference, including before the INSERT is committed to model space.
- Switch block rendering cache keys from raw RGB numbers to `AcCmColor`, so foreground (ACI 7) and true-color blocks cache and render correctly; apply `resolvedColor` when drawing nested blocks.

## Test plan

- [x] `AcDbAttribute` tests for ByBlock (Viewport/foreground) and ByLayer (CARTOUCHE) color resolution
- [x] `AcDbBlockReference` tests for attribute database propagation and ByBlock entity coloring inside block definitions
- [x] `AcDbRenderingCache` tests for updated cache key format with RGB and foreground colors