### PR TITLE
refactor(graphic-interface): resolve sub-entity RGB at draw time via AcGiContext

### DIFF
--- a/packages/data-model/__tests__/AcDbEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntity.spec.ts
@@ -181,7 +181,6 @@ describe('AcDbEntity.color resolution', () => {
 
     expect(line.color.isByBlock).toBe(true)
     expect(line.resolvedColor.RGB).toBe(0x336699)
-    expect(line.rgbColor).toBe(0x336699)
   })
 
   it('resolves ByBlock through current layer when CECOLOR is ByLayer', () => {
@@ -198,7 +197,6 @@ describe('AcDbEntity.color resolution', () => {
     line.color.setByBlock()
 
     expect(line.resolvedColor.RGB).toBe(0x112233)
-    expect(line.rgbColor).toBe(0x112233)
   })
 
   it('resolves ByLayer against the entity layer color', () => {
@@ -215,7 +213,6 @@ describe('AcDbEntity.color resolution', () => {
     line.color.setByLayer()
 
     expect(line.resolvedColor.RGB).toBe(0xaa5500)
-    expect(line.rgbColor).toBe(0xaa5500)
   })
 })
 

--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -1,6 +1,6 @@
 import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
-import { AcGiLineWeight } from '@mlightcad/graphic-interface'
+import { AcGiLineWeight, AcGiSubEntityTraits, DEFAULT_ACGI_CONTEXT, acgiResolveSubEntityTraitsRgb } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices } from '../src/base'
 import {
@@ -21,9 +21,9 @@ const createWorkingDb = () => {
 
 const createRenderer = () => {
   const renderer = {
+    context: DEFAULT_ACGI_CONTEXT,
     subEntityTraits: {
-      color: undefined,
-      rgbColor: 0,
+      color: new AcCmColor(),
       lineType: {
         type: 'UserSpecified',
         name: 'CONTINUOUS',
@@ -201,11 +201,19 @@ describe('AcDbMLeader arrowhead rendering', () => {
     const lineRgbLog: number[] = []
     let mtextRgb = -1
     renderer.lines.mockImplementation((points: unknown[]) => {
-      lineRgbLog.push(renderer.subEntityTraits.rgbColor)
+      lineRgbLog.push(
+        acgiResolveSubEntityTraitsRgb(
+          renderer.subEntityTraits as unknown as AcGiSubEntityTraits,
+          renderer.context
+        )
+      )
       return { kind: 'lines', points }
     })
     renderer.mtext.mockImplementation(() => {
-      mtextRgb = renderer.subEntityTraits.rgbColor
+      mtextRgb = acgiResolveSubEntityTraitsRgb(
+        renderer.subEntityTraits as unknown as AcGiSubEntityTraits,
+        renderer.context
+      )
       return { kind: 'mtext' }
     })
 

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -178,7 +178,6 @@ describe('AcDbMLine', () => {
     baseColor.colorIndex = 2
     const traits = {
       color: baseColor,
-      rgbColor: 0x123456,
       fillType: {
         solidFill: false,
         patternAngle: 0,
@@ -225,7 +224,6 @@ describe('AcDbMLine', () => {
       }
     ])
     expect(traits.color).toBe(baseColor)
-    expect(traits.rgbColor).toBe(0x123456)
     expect(traits.fillType).toMatchObject({
       solidFill: false,
       patternAngle: 0
@@ -252,7 +250,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         fillType: {
           solidFill: false,
           patternAngle: 0,
@@ -313,7 +310,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         lineType: originalLineType,
         fillType: {
           solidFill: false,
@@ -363,7 +359,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         lineType: {
           type: 'UserSpecified' as const,
           name: 'Continuous',
@@ -456,7 +451,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         lineType: {
           type: 'UserSpecified' as const,
           name: 'Continuous',
@@ -515,7 +509,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         lineType: {
           type: 'UserSpecified' as const,
           name: 'Continuous',
@@ -576,7 +569,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         fillType: {
           solidFill: false,
           patternAngle: 0,
@@ -637,7 +629,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         fillType: {
           solidFill: false,
           patternAngle: 0,
@@ -697,7 +688,6 @@ describe('AcDbMLine', () => {
     const renderer = {
       subEntityTraits: {
         color: new AcCmColor(),
-        rgbColor: 0xffffff,
         fillType: {
           solidFill: false,
           patternAngle: 0,

--- a/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
@@ -66,7 +66,6 @@ describe('AcDbProxyGraphic', () => {
     const renderer = {
       subEntityTraits: {
         color: { clone: () => ({}) },
-        rgbColor: 0xffffff,
         lineType: { name: 'Continuous', definitionLines: [] },
         lineTypeScale: 1,
         lineWeight: -3,
@@ -120,7 +119,6 @@ describe('AcDbProxyEntity', () => {
     const renderer = {
       subEntityTraits: {
         color: { clone: () => ({}) },
-        rgbColor: 0xffffff,
         lineType: { name: 'Continuous', definitionLines: [] },
         lineTypeScale: 1,
         lineWeight: -3,

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -192,26 +192,6 @@ export abstract class AcDbEntity extends AcDbObject {
   }
 
   /**
-   * Gets the RGB color of this entity.
-   *
-   * This method handles the conversion of color indices (including ByLayer and ByBlock)
-   * to actual RGB colors. It resolves layer colors and block colors as needed.
-   *
-   * @returns The RGB color value as a number
-   *
-   * @example
-   * ```typescript
-   * const rgbColor = entity.rgbColor;
-   * console.log(`RGB: ${rgbColor.toString(16)}`);
-   * ```
-   */
-  get rgbColor() {
-    const color = this.resolvedColor
-    const rgb = color.RGB
-    return rgb != null ? rgb : 0xffffff
-  }
-
-  /**
    * Gets the name of the line type referenced by this entity.
    *
    * @returns The linetype name
@@ -671,7 +651,6 @@ export abstract class AcDbEntity extends AcDbObject {
 
     const traits = renderer.subEntityTraits
     traits.color = this.resolvedColor
-    traits.rgbColor = this.rgbColor
     traits.lineType = this.lineStyle
     traits.lineTypeScale = this.linetypeScale
     traits.lineWeight = this.lineWeight

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -1701,7 +1701,6 @@ export class AcDbMLeader extends AcDbEntity {
     const entities: AcGiEntity[] = []
     const traits = renderer.subEntityTraits
     const originalColor = traits.color
-    const originalRgbColor = traits.rgbColor
     const originalLineType = traits.lineType
     const originalLineWeight = traits.lineWeight
     const leaderLineColor = this.getResolvedLeaderLineColor()
@@ -1715,8 +1714,7 @@ export class AcDbMLeader extends AcDbEntity {
       this.applyColorTraits(
         traits,
         leaderLineColor,
-        originalColor,
-        originalRgbColor
+        originalColor
       )
       this.applyLineTraits(traits, leaderLineStyle, leaderLineWeight)
       this._leaders.forEach(leader => {
@@ -1739,7 +1737,7 @@ export class AcDbMLeader extends AcDbEntity {
       this.contentType === AcDbMLeaderContentType.MTextContent &&
       mtextContent
     ) {
-      this.applyColorTraits(traits, textColor, originalColor, originalRgbColor)
+      this.applyColorTraits(traits, textColor, originalColor)
       const textHeight = this.getResolvedTextHeight()
       const mtextData: AcGiMTextData = {
         text: mtextContent.text,
@@ -1758,7 +1756,6 @@ export class AcDbMLeader extends AcDbEntity {
     }
 
     traits.color = originalColor
-    traits.rgbColor = originalRgbColor
     traits.lineType = originalLineType
     traits.lineWeight = originalLineWeight
     if (entities.length === 0) return undefined
@@ -2618,15 +2615,12 @@ export class AcDbMLeader extends AcDbEntity {
   private applyColorTraits(
     traits: AcGiRenderer['subEntityTraits'],
     color: AcCmColor | undefined,
-    originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number
+    originalColor: AcGiRenderer['subEntityTraits']['color']
   ) {
     traits.color = originalColor
-    traits.rgbColor = originalRgbColor
     if (!color) return
 
     traits.color = color
-    traits.rgbColor = this.resolveColorToRgb(color)
   }
 
   /**
@@ -2648,21 +2642,5 @@ export class AcDbMLeader extends AcDbEntity {
     if (lineWeight != null) {
       traits.lineWeight = lineWeight
     }
-  }
-
-  /**
-   * Converts an `AcCmColor` to resolved RGB for rendering.
-   *
-   * @param color Source color definition.
-   * @returns Resolved RGB integer color.
-   */
-  private resolveColorToRgb(color: AcCmColor) {
-    if (color.isByLayer) {
-      const layerColor = this.getLayerColor()
-      if (layerColor?.RGB != null) return layerColor.RGB
-      return this.rgbColor
-    }
-    if (color.isByBlock) return this.rgbColor
-    return color.RGB ?? this.rgbColor
   }
 }

--- a/packages/data-model/src/entity/AcDbMLine.ts
+++ b/packages/data-model/src/entity/AcDbMLine.ts
@@ -636,7 +636,6 @@ export class AcDbMLine extends AcDbEntity {
     const elementCount = this.getRenderableElementCount(mlineStyle)
     const traits = renderer.subEntityTraits
     const originalColor = traits.color
-    const originalRgbColor = traits.rgbColor
     const originalLineType = traits.lineType
     const originalFillType = traits.fillType
     const originalDrawOrder = traits.drawOrder
@@ -644,7 +643,6 @@ export class AcDbMLine extends AcDbEntity {
     const fillArea = this.createFillArea(mlineStyle, elementCount)
     if (fillArea) {
       traits.color = originalColor
-      traits.rgbColor = originalRgbColor
       this.applyFillTraits(mlineStyle, traits)
       traits.fillType = {
         solidFill: true,
@@ -663,7 +661,6 @@ export class AcDbMLine extends AcDbEntity {
     } else {
       for (let elementIndex = 0; elementIndex < elementCount; elementIndex++) {
         traits.color = originalColor
-        traits.rgbColor = originalRgbColor
         traits.lineType = originalLineType
         this.applyStyleElementTraits(mlineStyle, elementIndex, traits)
         const points = this.getElementPath(elementIndex, mlineStyle)
@@ -677,12 +674,10 @@ export class AcDbMLine extends AcDbEntity {
         mlineStyle,
         elementCount,
         originalColor,
-        originalRgbColor,
         originalLineType
       )
     }
     traits.color = originalColor
-    traits.rgbColor = originalRgbColor
     traits.lineType = originalLineType
     traits.fillType = originalFillType
     traits.drawOrder = originalDrawOrder
@@ -1294,7 +1289,6 @@ export class AcDbMLine extends AcDbEntity {
    * @param mlineStyle Resolved style object, if available.
    * @param elementCount Renderable style element count.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    */
   private appendStyleDrivenJointAndCapEntities(
@@ -1303,7 +1297,6 @@ export class AcDbMLine extends AcDbEntity {
     mlineStyle: AcDbMlineStyle | undefined,
     elementCount: number,
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType']
   ) {
     if (!mlineStyle || elementCount < 2) return
@@ -1314,7 +1307,6 @@ export class AcDbMLine extends AcDbEntity {
         mlineStyle,
         elementCount,
         originalColor,
-        originalRgbColor,
         originalLineType
       )
     )
@@ -1324,7 +1316,6 @@ export class AcDbMLine extends AcDbEntity {
         mlineStyle,
         elementCount,
         originalColor,
-        originalRgbColor,
         originalLineType
       )
     )
@@ -1337,7 +1328,6 @@ export class AcDbMLine extends AcDbEntity {
    * @param mlineStyle Resolved style object.
    * @param elementCount Renderable style element count.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    * @returns Drawn joint entities.
    */
@@ -1346,7 +1336,6 @@ export class AcDbMLine extends AcDbEntity {
     mlineStyle: AcDbMlineStyle,
     elementCount: number,
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType']
   ) {
     if (
@@ -1387,7 +1376,6 @@ export class AcDbMLine extends AcDbEntity {
         this.applyElementDrawTraits(
           traits,
           originalColor,
-          originalRgbColor,
           originalLineType,
           mlineStyle,
           points[i].elementIndex
@@ -1406,7 +1394,6 @@ export class AcDbMLine extends AcDbEntity {
    * @param mlineStyle Resolved style object.
    * @param elementCount Renderable style element count.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    * @returns Drawn cap entities.
    */
@@ -1415,7 +1402,6 @@ export class AcDbMLine extends AcDbEntity {
     mlineStyle: AcDbMlineStyle,
     elementCount: number,
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType']
   ) {
     if (this.closed || this._segments.length <= 0) return []
@@ -1428,7 +1414,6 @@ export class AcDbMLine extends AcDbEntity {
         mlineStyle,
         elementCount,
         originalColor,
-        originalRgbColor,
         originalLineType
       )
     )
@@ -1439,7 +1424,6 @@ export class AcDbMLine extends AcDbEntity {
         mlineStyle,
         elementCount,
         originalColor,
-        originalRgbColor,
         originalLineType
       )
     )
@@ -1454,7 +1438,6 @@ export class AcDbMLine extends AcDbEntity {
    * @param mlineStyle Resolved style object.
    * @param elementCount Renderable style element count.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    * @returns Drawn one-side cap entities.
    */
@@ -1464,7 +1447,6 @@ export class AcDbMLine extends AcDbEntity {
     mlineStyle: AcDbMlineStyle,
     elementCount: number,
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType']
   ) {
     if (side === 'start' && this.suppressStartCaps) return []
@@ -1494,7 +1476,6 @@ export class AcDbMLine extends AcDbEntity {
         this.applyElementDrawTraits(
           traits,
           originalColor,
-          originalRgbColor,
           originalLineType,
           mlineStyle,
           points[i].elementIndex
@@ -1516,7 +1497,6 @@ export class AcDbMLine extends AcDbEntity {
         capDirection,
         traits,
         originalColor,
-        originalRgbColor,
         originalLineType,
         mlineStyle
       )
@@ -1536,7 +1516,6 @@ export class AcDbMLine extends AcDbEntity {
           capDirection,
           traits,
           originalColor,
-          originalRgbColor,
           originalLineType,
           mlineStyle
         )
@@ -1587,7 +1566,6 @@ export class AcDbMLine extends AcDbEntity {
    * @param capDirection Outward cap direction.
    * @param traits Mutable renderer traits.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    * @param mlineStyle Resolved style object.
    * @returns Arc entity, or `undefined` when arc cannot be constructed.
@@ -1600,7 +1578,6 @@ export class AcDbMLine extends AcDbEntity {
     capDirection: AcGeVector3d,
     traits: AcGiRenderer['subEntityTraits'],
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType'],
     mlineStyle: AcDbMlineStyle
   ) {
@@ -1636,7 +1613,6 @@ export class AcDbMLine extends AcDbEntity {
     this.applyElementDrawTraits(
       traits,
       originalColor,
-      originalRgbColor,
       originalLineType,
       mlineStyle,
       side === 'end' ? endPointPair.elementIndex : startPointPair.elementIndex
@@ -1649,7 +1625,6 @@ export class AcDbMLine extends AcDbEntity {
    *
    * @param traits Mutable renderer traits.
    * @param originalColor Original trait color.
-   * @param originalRgbColor Original trait RGB.
    * @param originalLineType Original trait linetype.
    * @param mlineStyle Resolved style object.
    * @param elementIndex Style element index.
@@ -1657,13 +1632,11 @@ export class AcDbMLine extends AcDbEntity {
   private applyElementDrawTraits(
     traits: AcGiRenderer['subEntityTraits'],
     originalColor: AcGiRenderer['subEntityTraits']['color'],
-    originalRgbColor: number,
     originalLineType: AcGiRenderer['subEntityTraits']['lineType'],
     mlineStyle: AcDbMlineStyle,
     elementIndex: number
   ) {
     traits.color = originalColor
-    traits.rgbColor = originalRgbColor
     traits.lineType = originalLineType
     this.applyStyleElementTraits(mlineStyle, elementIndex, traits)
   }
@@ -1744,7 +1717,6 @@ export class AcDbMLine extends AcDbEntity {
     if (styleElement.color.isByBlock || styleElement.color.isByLayer) return
 
     traits.color = styleElement.color.clone()
-    traits.rgbColor = styleElement.color.RGB ?? this.rgbColor
   }
 
   /**
@@ -1762,7 +1734,6 @@ export class AcDbMLine extends AcDbEntity {
     if (!fillColor || fillColor.isByBlock || fillColor.isByLayer) return
 
     traits.color = fillColor.clone()
-    traits.rgbColor = fillColor.RGB ?? this.rgbColor
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -667,9 +667,14 @@ export class AcDbTable extends AcDbBlockReference {
     const entities = blockTableRecord.newIterator()
     for (const entity of entities) {
       let object: AcGiEntity | undefined
-      if (entity.color.isByBlock && this.rgbColor) {
+      if (entity.color.isByBlock) {
         _tmpColor.copy(entity.color)
-        entity.color.setRGBValue(this.rgbColor)
+        const tableColor = this.resolvedColor
+        if (tableColor.isForeground) {
+          entity.color.setForeground()
+        } else if (tableColor.RGB != null) {
+          entity.color.setRGBValue(tableColor.RGB)
+        }
         object = entity.worldDraw(renderer)
         entity.color.copy(_tmpColor)
       } else {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -436,16 +436,25 @@ export type {
 export {
   AcGiArrowType,
   AcGiDefaultLightingType,
+  ACGI_DARK_THEME_FOREGROUND,
+  ACGI_LIGHT_THEME_FOREGROUND,
+  ACGI_MODEL_SPACE_BACKGROUND,
+  DEFAULT_ACGI_CONTEXT,
   AcGiLineWeight,
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection,
   AcGiOrthographicType,
   AcGiRenderMode,
-  AcGiViewport
+  AcGiViewport,
+  acgiBuildContext,
+  acgiIsLightBackground,
+  acgiResolveSubEntityTraitsRgb,
+  acgiResolveSubEntityTraitsRgbFromBackground
 } from '@mlightcad/graphic-interface'
 export type {
   AcGiArrowStyle,
   AcGiBaseLineStyle,
+  AcGiContext,
   AcGiEntity,
   AcGiFontMapping,
   AcGiHatchGradientStyle,

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -439,6 +439,7 @@ export {
   ACGI_DARK_THEME_FOREGROUND,
   ACGI_LIGHT_THEME_FOREGROUND,
   ACGI_MODEL_SPACE_BACKGROUND,
+  ACGI_PAPER_SPACE_BACKGROUND,
   DEFAULT_ACGI_CONTEXT,
   AcGiLineWeight,
   AcGiMTextAttachmentPoint,
@@ -447,6 +448,8 @@ export {
   AcGiRenderMode,
   AcGiViewport,
   acgiBuildContext,
+  acgiContrastingForegroundColor,
+  acgiForegroundColorForBackground,
   acgiIsLightBackground,
   acgiResolveSubEntityTraitsRgb,
   acgiResolveSubEntityTraitsRgbFromBackground

--- a/packages/data-model/src/misc/proxyGraphic/AcDbProxyGraphic.ts
+++ b/packages/data-model/src/misc/proxyGraphic/AcDbProxyGraphic.ts
@@ -1,4 +1,4 @@
-import { AcCmColor, AcCmColorMethod, AcCmColorUtil } from '@mlightcad/common'
+import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 import {
   AcGeArea2d,
   AcGeCircArc3d,
@@ -359,7 +359,6 @@ export class AcDbProxyGraphic {
     const traits = renderer.subEntityTraits
     const previousTraits = {
       color: traits.color.clone(),
-      rgbColor: traits.rgbColor,
       lineType: traits.lineType,
       lineTypeScale: traits.lineTypeScale,
       lineWeight: traits.lineWeight,
@@ -390,7 +389,6 @@ export class AcDbProxyGraphic {
     }
 
     traits.color = previousTraits.color
-    traits.rgbColor = previousTraits.rgbColor
     traits.lineType = previousTraits.lineType
     traits.lineTypeScale = previousTraits.lineTypeScale
     traits.lineWeight = previousTraits.lineWeight
@@ -518,21 +516,15 @@ export class AcDbProxyGraphic {
     traits.lineWeight = this._lineweight
 
     if (this._rgbColor != null) {
-      traits.rgbColor = this._rgbColor
       traits.color = new AcCmColor(AcCmColorMethod.ByColor, this._rgbColor)
     } else if (this._colorIndex === 256) {
       traits.color = new AcCmColor(AcCmColorMethod.ByLayer)
-      traits.rgbColor =
-        AcCmColorUtil.getColorByIndex(7) ??
-        traits.rgbColor
     } else if (this._colorIndex === 0) {
       traits.color = new AcCmColor(AcCmColorMethod.ByBlock)
+    } else if (this._colorIndex === 7) {
+      traits.color = new AcCmColor(AcCmColorMethod.ByACI, 7)
     } else {
-      const rgb = AcCmColorUtil.getColorByIndex(this._colorIndex)
       traits.color = new AcCmColor(AcCmColorMethod.ByACI, this._colorIndex)
-      if (rgb != null) {
-        traits.rgbColor = rgb
-      }
     }
 
     traits.lineType = {

--- a/packages/graphic-interface/src/AcGiContext.ts
+++ b/packages/graphic-interface/src/AcGiContext.ts
@@ -26,6 +26,9 @@ export const ACGI_DARK_THEME_FOREGROUND = 0xffffff
 /** ACI-7 foreground on a light canvas background. */
 export const ACGI_LIGHT_THEME_FOREGROUND = 0x000000
 
+/** AutoCAD paper-space default background: RGB(255, 255, 255). */
+export const ACGI_PAPER_SPACE_BACKGROUND = 0xffffff
+
 /** ITU-R BT.601 luma threshold used by {@link acgiIsLightBackground}. */
 const ACGI_LIGHT_BACKGROUND_LUMA_THRESHOLD = 128
 
@@ -61,6 +64,25 @@ export function acgiBuildContext(
     backgroundIsDark: !acgiIsLightBackground(backgroundColor),
     fallbackRgb: 0xffffff
   }
+}
+
+/**
+ * ACI-7 foreground that contrasts with a light or dark UI theme flag.
+ */
+export function acgiContrastingForegroundColor(isLight: boolean): number {
+  return isLight ? ACGI_LIGHT_THEME_FOREGROUND : ACGI_DARK_THEME_FOREGROUND
+}
+
+/**
+ * ACI-7 foreground that contrasts with the canvas background.
+ */
+export function acgiForegroundColorForBackground(
+  backgroundColor: number
+): number {
+  const context = acgiBuildContext(backgroundColor)
+  return context.backgroundIsDark
+    ? context.foregroundOnDark
+    : context.foregroundOnLight
 }
 
 /**

--- a/packages/graphic-interface/src/AcGiContext.ts
+++ b/packages/graphic-interface/src/AcGiContext.ts
@@ -1,0 +1,96 @@
+import { AcGiSubEntityTraits } from './AcGiSubEntityTraits'
+
+/**
+ * Draw-time context used to resolve semantic entity colors into pixel RGB values.
+ *
+ * ACI 7 (foreground / contrast color) depends on the current background, so RGB
+ * resolution must happen in the renderer with this context rather than on traits.
+ */
+export interface AcGiContext {
+  /** RGB used when the resolved color is foreground (ACI 7) on a dark background. */
+  foregroundOnDark: number
+  /** RGB used when the resolved color is foreground (ACI 7) on a light background. */
+  foregroundOnLight: number
+  /** Whether the current draw background is dark. */
+  backgroundIsDark: boolean
+  /** Fallback RGB when the resolved color has no concrete RGB value. */
+  fallbackRgb?: number
+}
+
+/** AutoCAD model-space default background: RGB(0, 0, 0). */
+export const ACGI_MODEL_SPACE_BACKGROUND = 0x000000
+
+/** ACI-7 foreground on a dark canvas background. */
+export const ACGI_DARK_THEME_FOREGROUND = 0xffffff
+
+/** ACI-7 foreground on a light canvas background. */
+export const ACGI_LIGHT_THEME_FOREGROUND = 0x000000
+
+/** ITU-R BT.601 luma threshold used by {@link acgiIsLightBackground}. */
+const ACGI_LIGHT_BACKGROUND_LUMA_THRESHOLD = 128
+
+/** Default draw context matching a dark AutoCAD model-space background. */
+export const DEFAULT_ACGI_CONTEXT: AcGiContext = {
+  foregroundOnDark: ACGI_DARK_THEME_FOREGROUND,
+  foregroundOnLight: ACGI_LIGHT_THEME_FOREGROUND,
+  backgroundIsDark: true,
+  fallbackRgb: 0xffffff
+}
+
+/**
+ * Whether a packed RGB colour is perceptually light (paper-like).
+ */
+export function acgiIsLightBackground(color: number): boolean {
+  const r = (color >> 16) & 0xff
+  const g = (color >> 8) & 0xff
+  const b = color & 0xff
+  return (
+    0.299 * r + 0.587 * g + 0.114 * b > ACGI_LIGHT_BACKGROUND_LUMA_THRESHOLD
+  )
+}
+
+/**
+ * Builds draw-time {@link AcGiContext} from the current canvas background.
+ */
+export function acgiBuildContext(
+  backgroundColor: number = ACGI_MODEL_SPACE_BACKGROUND
+): AcGiContext {
+  return {
+    foregroundOnDark: ACGI_DARK_THEME_FOREGROUND,
+    foregroundOnLight: ACGI_LIGHT_THEME_FOREGROUND,
+    backgroundIsDark: !acgiIsLightBackground(backgroundColor),
+    fallbackRgb: 0xffffff
+  }
+}
+
+/**
+ * Resolves {@link AcGiSubEntityTraits.color} to a pixel RGB value.
+ */
+export function acgiResolveSubEntityTraitsRgb(
+  traits: AcGiSubEntityTraits,
+  context: AcGiContext
+): number {
+  const color = traits.color
+  if (color.isForeground) {
+    return context.backgroundIsDark
+      ? context.foregroundOnDark
+      : context.foregroundOnLight
+  }
+  if (color.isByLayer || color.isByBlock) {
+    return context.fallbackRgb ?? 0xffffff
+  }
+  return color.RGB ?? context.fallbackRgb ?? 0xffffff
+}
+
+/**
+ * Convenience wrapper when only the canvas background is available.
+ */
+export function acgiResolveSubEntityTraitsRgbFromBackground(
+  traits: AcGiSubEntityTraits,
+  backgroundColor: number
+): number {
+  return acgiResolveSubEntityTraitsRgb(
+    traits,
+    acgiBuildContext(backgroundColor)
+  )
+}

--- a/packages/graphic-interface/src/AcGiRenderer.ts
+++ b/packages/graphic-interface/src/AcGiRenderer.ts
@@ -6,6 +6,7 @@ import {
   AcGePoint3dLike
 } from '@mlightcad/geometry-engine'
 
+import { AcGiContext } from './AcGiContext'
 import { AcGiEntity } from './AcGiEntity'
 import { AcGiImageStyle } from './AcGiImageStyle'
 import { AcGiPointStyle } from './AcGiPointStyle'
@@ -26,6 +27,12 @@ export interface AcGiRenderer<T extends AcGiEntity = AcGiEntity> {
    * (color, layer, linetype, etc.) settings of the current geometry.
    */
   get subEntityTraits(): AcGiSubEntityTraits
+
+  /**
+   * Draw-time context for resolving semantic trait colors (for example ACI 7
+   * foreground) into pixel RGB values.
+   */
+  get context(): AcGiContext
 
   /**
    * Create one group

--- a/packages/graphic-interface/src/AcGiSubEntityTraits.ts
+++ b/packages/graphic-interface/src/AcGiSubEntityTraits.ts
@@ -10,14 +10,10 @@ import { AcGiLineWeight } from './AcGiLineWeight'
  */
 export interface AcGiSubEntityTraits {
   /**
-   * The RGB color.
-   * It resolves layer colors and block colors as needed and converts color index
-   * to actual RGB color.
-   */
-  rgbColor: number
-
-  /**
-   * Color of the entity.
+   * Resolved semantic color of the sub-entity.
+   *
+   * Use {@link acgiResolveSubEntityTraitsRgb} with {@link AcGiRenderer.context} to obtain
+   * the pixel RGB value at draw time (including ACI 7 foreground handling).
    */
   color: AcCmColor
 

--- a/packages/graphic-interface/src/index.ts
+++ b/packages/graphic-interface/src/index.ts
@@ -18,8 +18,11 @@ export {
   ACGI_DARK_THEME_FOREGROUND,
   ACGI_LIGHT_THEME_FOREGROUND,
   ACGI_MODEL_SPACE_BACKGROUND,
+  ACGI_PAPER_SPACE_BACKGROUND,
   DEFAULT_ACGI_CONTEXT,
   acgiBuildContext,
+  acgiContrastingForegroundColor,
+  acgiForegroundColorForBackground,
   acgiIsLightBackground,
   acgiResolveSubEntityTraitsRgb,
   acgiResolveSubEntityTraitsRgbFromBackground

--- a/packages/graphic-interface/src/index.ts
+++ b/packages/graphic-interface/src/index.ts
@@ -14,6 +14,17 @@ export type {
 } from './AcGiLineStyle'
 export { AcGiLineWeight } from './AcGiLineWeight'
 export type { AcGiPointStyle } from './AcGiPointStyle'
+export {
+  ACGI_DARK_THEME_FOREGROUND,
+  ACGI_LIGHT_THEME_FOREGROUND,
+  ACGI_MODEL_SPACE_BACKGROUND,
+  DEFAULT_ACGI_CONTEXT,
+  acgiBuildContext,
+  acgiIsLightBackground,
+  acgiResolveSubEntityTraitsRgb,
+  acgiResolveSubEntityTraitsRgbFromBackground
+} from './AcGiContext'
+export type { AcGiContext } from './AcGiContext'
 export type { AcGiFontMapping, AcGiRenderer } from './AcGiRenderer'
 export type { AcGiShapeData } from './AcGiShapeData'
 export type { AcGiStyleType } from './AcGiStyleType'


### PR DESCRIPTION
## Summary
- Remove `gbColor` from `AcGiSubEntityTraits` and `AcDbEntity`; traits now carry only semantic `AcCmColor` values.
- Add `AcGiContext` and `acgiResolveSubEntityTraitsRgb` so renderers resolve pixel RGB at draw time, including ACI 7 foreground based on canvas background.
- Update `AcDbMLeader`, `AcDbMLine`, `AcDbTable`, and `AcDbProxyGraphic` to stop writing `traits.rgbColor`; re-export new helpers from `@mlightcad/graphic-interface` and `@mlightcad/data-model`.

## Test plan
- [ ] Update renderer implementations to expose `context` and call `acgiResolveSubEntityTraitsRgb` when reading trait colors
- [ ] Verify ACI 7 (foreground) renders white on dark backgrounds and black on light backgrounds
- [ ] Run data-model unit tests for entity color resolution, MLeader, MLine, and proxy graphic rendering
- [ ] Smoke-test example app drawing with ByLayer / ByBlock / foreground colors