### PR TITLE
refactor(graphic-interface): convert AcGiContext to class and fix SHAPE font resolution

### DIFF
--- a/packages/data-model/__tests__/AcDbEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntity.spec.ts
@@ -1,5 +1,5 @@
 import { AcCmColor } from '@mlightcad/common'
-import { DEFAULT_ACGI_CONTEXT } from '@mlightcad/graphic-interface'
+import { DEFAULT_ACGI_CONTEXT, AcGiContext } from '@mlightcad/graphic-interface'
 import {
   AcGeBox3d,
   AcGeMatrix3d,
@@ -130,7 +130,7 @@ describe('AcDbEntity.worldDraw layer policy', () => {
     const subWorldDraw = jest.spyOn(entity, 'subWorldDraw')
     const renderer = {
       subEntityTraits: {},
-      context: { ...DEFAULT_ACGI_CONTEXT }
+      context: new AcGiContext({ ...DEFAULT_ACGI_CONTEXT })
     } as never
 
     expect(entity.worldDraw(renderer)).toBeUndefined()
@@ -148,7 +148,7 @@ describe('AcDbEntity.worldDraw layer policy', () => {
 
     const renderer = {
       subEntityTraits: {},
-      context: { ...DEFAULT_ACGI_CONTEXT }
+      context: new AcGiContext({ ...DEFAULT_ACGI_CONTEXT })
     }
     const subWorldDraw = jest.spyOn(entity, 'subWorldDraw')
 

--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -3,8 +3,7 @@ import { AcGePoint3d } from '@mlightcad/geometry-engine'
 import {
   AcGiLineWeight,
   AcGiSubEntityTraits,
-  DEFAULT_ACGI_CONTEXT,
-  acgiResolveSubEntityTraitsRgb
+  DEFAULT_ACGI_CONTEXT
 } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices } from '../src/base'
@@ -207,17 +206,15 @@ describe('AcDbMLeader arrowhead rendering', () => {
     let mtextRgb = -1
     renderer.lines.mockImplementation((points: unknown[]) => {
       lineRgbLog.push(
-        acgiResolveSubEntityTraitsRgb(
-          renderer.subEntityTraits as unknown as AcGiSubEntityTraits,
-          renderer.context
+        renderer.context.resolveSubEntityTraitsRgb(
+          renderer.subEntityTraits as unknown as AcGiSubEntityTraits
         )
       )
       return { kind: 'lines', points }
     })
     renderer.mtext.mockImplementation(() => {
-      mtextRgb = acgiResolveSubEntityTraitsRgb(
-        renderer.subEntityTraits as unknown as AcGiSubEntityTraits,
-        renderer.context
+      mtextRgb = renderer.context.resolveSubEntityTraitsRgb(
+        renderer.subEntityTraits as unknown as AcGiSubEntityTraits
       )
       return { kind: 'mtext' }
     })

--- a/packages/data-model/__tests__/AcDbShape.spec.ts
+++ b/packages/data-model/__tests__/AcDbShape.spec.ts
@@ -139,6 +139,28 @@ describe('AcDbShape', () => {
     expectDetachedClone(() => new AcDbShape())
   })
 
+  it('passes undefined text style when styleName is empty', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    db.textstyle = 'pipe'
+    acdbHostApplicationServices().workingDatabase = db
+
+    const shape = new AcDbShape()
+    shape.database = db
+    shape.name = '_GV_'
+    shape.size = 0.01
+    shape.position = new AcGePoint3d(100, 200, 0)
+
+    const renderer = {
+      shape: jest.fn(() => ({ objectId: 'S1' }))
+    } as unknown as { shape: jest.Mock }
+
+    shape.subWorldDraw(renderer as never)
+
+    const [, textStyle] = renderer.shape.mock.calls[0]
+    expect(textStyle).toBeUndefined()
+  })
+
   it('renders via renderer.shape with shape glyph metadata', () => {
     const db = new AcDbDatabase()
     db.createDefaultData()

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -1,6 +1,7 @@
 import { AcGeBox3d, AcGePoint3d } from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
+  AcGiContext,
   AcGiMTextAttachmentPoint,
   AcGiRenderer,
   DEFAULT_ACGI_CONTEXT
@@ -30,7 +31,7 @@ const createGiEntity = () => {
 const createRenderer = () => {
   const traits: Record<string, unknown> = {}
   return {
-    context: { ...DEFAULT_ACGI_CONTEXT },
+    context: new AcGiContext({ ...DEFAULT_ACGI_CONTEXT }),
     subEntityTraits: traits,
     lines: jest.fn(() => createGiEntity()),
     circularArc: jest.fn(() => createGiEntity()),

--- a/packages/data-model/src/entity/AcDbShape.ts
+++ b/packages/data-model/src/entity/AcDbShape.ts
@@ -477,12 +477,12 @@ export class AcDbShape extends AcDbEntity {
     delay?: boolean
   ): AcGiEntity | undefined {
     const textStyle = this.getTextStyle()
-    const style: AcGiTextStyle = {
+    const style: AcGiTextStyle | undefined = textStyle ? {
       ...textStyle,
       widthFactor: this.widthFactor,
       // MText renderer stores oblique in degrees on the text style.
       obliqueAngle: (this.oblique * 180) / Math.PI
-    }
+    } : undefined
 
     const shapeData: AcGiShapeData = {
       name: this._name.trim() || undefined,
@@ -499,13 +499,18 @@ export class AcDbShape extends AcDbEntity {
 
   /**
    * Gets the text style that references the SHX font for this shape.
+   *
+   * When {@link styleName} is empty, returns `undefined` so renderers search
+   * shape-file definition entries in the STYLE table instead of falling back to
+   * `$TEXTSTYLE` (which is for TEXT/MTEXT, not SHAPE entities).
    */
-  protected getTextStyle(): AcGiTextStyle {
-    const style = this.database.tables.textStyleTable.resolveAt(this.styleName)
-    if (!style) {
-      throw new Error('No valid text style found in text style table.')
+  protected getTextStyle(): AcGiTextStyle | undefined {
+    const trimmed = this.styleName.trim()
+    if (!trimmed) {
+      return undefined
     }
-    return style.textStyle
+    const style = this.database.tables.textStyleTable.resolveAt(trimmed)
+    return style?.textStyle
   }
 
   override dxfOutFields(filer: AcDbDxfFiler) {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -440,6 +440,7 @@ export {
   ACGI_LIGHT_THEME_FOREGROUND,
   ACGI_MODEL_SPACE_BACKGROUND,
   ACGI_PAPER_SPACE_BACKGROUND,
+  AcGiContext,
   DEFAULT_ACGI_CONTEXT,
   AcGiLineWeight,
   AcGiMTextAttachmentPoint,
@@ -447,17 +448,14 @@ export {
   AcGiOrthographicType,
   AcGiRenderMode,
   AcGiViewport,
-  acgiBuildContext,
   acgiContrastingForegroundColor,
   acgiForegroundColorForBackground,
   acgiIsLightBackground,
-  acgiResolveSubEntityTraitsRgb,
   acgiResolveSubEntityTraitsRgbFromBackground
 } from '@mlightcad/graphic-interface'
 export type {
   AcGiArrowStyle,
   AcGiBaseLineStyle,
-  AcGiContext,
   AcGiEntity,
   AcGiFontMapping,
   AcGiHatchGradientStyle,

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -92,6 +92,33 @@ describe('AcDbDxfConverter', () => {
     )
   })
 
+  it('collects shape-definition fonts from the style table', () => {
+    const converter = new TestDxfConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      tables: {
+        STYLE: {
+          entries: [
+            {
+              name: '',
+              font: 'tecosymbol.shx',
+              standardFlag: 1
+            },
+            {
+              name: 'pipe',
+              font: 'romans.shx',
+              bigFont: 'hztxt.shx',
+              standardFlag: 0
+            }
+          ]
+        }
+      },
+      entities: [{ type: 'SHAPE', shapeName: '_GV_', insertionPoint: { x: 0, y: 0, z: 0 }, size: 0.01 }],
+      blocks: {}
+    })
+
+    expect(fonts).toEqual(expect.arrayContaining(['tecosymbol']))
+  })
+
   it('preserves default table ownership when DXF table metadata omits owner ids', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -171,6 +171,19 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
     })
 
     const fonts: Set<string> = new Set<string>()
+    // Collect shape file definitions from the TEXT STYLE TABLE (standardFlag bit 0 = isShapeFile).
+    // SHAPE entities render glyph codes from these .shx shape fonts, so they must be included
+    // in the font list even when no text entity references the style directly.
+    dxf.tables.STYLE?.entries.forEach(style => {
+      if (style.standardFlag & 1) {
+        if (style.font) {
+          const fontName = getFontName(style.font)
+          if (fontName) {
+            fonts.add(fontName)
+          }
+        }
+      }
+    })
     this.getFontsInBlock(dxf.entities, dxf.blocks, styleMap, fonts)
     return Array.from(fonts)
   }

--- a/packages/graphic-interface/src/AcGiContext.ts
+++ b/packages/graphic-interface/src/AcGiContext.ts
@@ -1,12 +1,28 @@
 import { AcGiSubEntityTraits } from './AcGiSubEntityTraits'
 
+export interface AcGiContextOptions {
+  /**
+   * Database being drawn. Runtime type is `AcDbDatabase` (data-model); typed as
+   * `unknown` here so graphic-interface does not depend on data-model.
+   */
+  database?: unknown
+  /** RGB used when the resolved color is foreground (ACI 7) on a dark background. */
+  foregroundOnDark?: number
+  /** RGB used when the resolved color is foreground (ACI 7) on a light background. */
+  foregroundOnLight?: number
+  /** Whether the current draw background is dark. */
+  backgroundIsDark?: boolean
+  /** Fallback RGB when the resolved color has no concrete RGB value. */
+  fallbackRgb?: number
+}
+
 /**
  * Draw-time context used to resolve semantic entity colors into pixel RGB values.
  *
  * ACI 7 (foreground / contrast color) depends on the current background, so RGB
  * resolution must happen in the renderer with this context rather than on traits.
  */
-export interface AcGiContext {
+export class AcGiContext {
   /**
    * Database being drawn. Runtime type is `AcDbDatabase` (data-model); typed as
    * `unknown` here so graphic-interface does not depend on data-model.
@@ -20,6 +36,48 @@ export interface AcGiContext {
   backgroundIsDark: boolean
   /** Fallback RGB when the resolved color has no concrete RGB value. */
   fallbackRgb?: number
+
+  constructor(options: AcGiContextOptions = {}) {
+    this.database = options.database
+    this.foregroundOnDark =
+      options.foregroundOnDark ?? ACGI_DARK_THEME_FOREGROUND
+    this.foregroundOnLight =
+      options.foregroundOnLight ?? ACGI_LIGHT_THEME_FOREGROUND
+    this.backgroundIsDark = options.backgroundIsDark ?? true
+    this.fallbackRgb = options.fallbackRgb ?? 0xffffff
+  }
+
+  /**
+   * Resolves {@link AcGiSubEntityTraits.color} to a pixel RGB value.
+   */
+  resolveSubEntityTraitsRgb(traits: AcGiSubEntityTraits): number {
+    const color = traits.color
+    if (color.isForeground) {
+      return this.backgroundIsDark
+        ? this.foregroundOnDark
+        : this.foregroundOnLight
+    }
+    if (color.isByLayer || color.isByBlock) {
+      return this.fallbackRgb ?? 0xffffff
+    }
+    return color.RGB ?? this.fallbackRgb ?? 0xffffff
+  }
+
+  /**
+   * Creates a draw-time context from the current canvas background colour.
+   */
+  static fromBackgroundColor(
+    backgroundColor: number = ACGI_MODEL_SPACE_BACKGROUND,
+    database?: unknown
+  ): AcGiContext {
+    return new AcGiContext({
+      database,
+      foregroundOnDark: ACGI_DARK_THEME_FOREGROUND,
+      foregroundOnLight: ACGI_LIGHT_THEME_FOREGROUND,
+      backgroundIsDark: !acgiIsLightBackground(backgroundColor),
+      fallbackRgb: 0xffffff
+    })
+  }
 }
 
 /** AutoCAD model-space default background: RGB(0, 0, 0). */
@@ -38,13 +96,13 @@ export const ACGI_PAPER_SPACE_BACKGROUND = 0xffffff
 const ACGI_LIGHT_BACKGROUND_LUMA_THRESHOLD = 128
 
 /** Default draw context matching a dark AutoCAD model-space background. */
-export const DEFAULT_ACGI_CONTEXT: AcGiContext = {
+export const DEFAULT_ACGI_CONTEXT = new AcGiContext({
   database: undefined,
   foregroundOnDark: ACGI_DARK_THEME_FOREGROUND,
   foregroundOnLight: ACGI_LIGHT_THEME_FOREGROUND,
   backgroundIsDark: true,
   fallbackRgb: 0xffffff
-}
+})
 
 /**
  * Whether a packed RGB colour is perceptually light (paper-like).
@@ -59,19 +117,15 @@ export function acgiIsLightBackground(color: number): boolean {
 }
 
 /**
- * Builds draw-time {@link AcGiContext} from the current canvas background.
+ * ACI-7 foreground that contrasts with the canvas background.
  */
-export function acgiBuildContext(
-  backgroundColor: number = ACGI_MODEL_SPACE_BACKGROUND,
-  database?: unknown
-): AcGiContext {
-  return {
-    database,
-    foregroundOnDark: ACGI_DARK_THEME_FOREGROUND,
-    foregroundOnLight: ACGI_LIGHT_THEME_FOREGROUND,
-    backgroundIsDark: !acgiIsLightBackground(backgroundColor),
-    fallbackRgb: 0xffffff
-  }
+export function acgiForegroundColorForBackground(
+  backgroundColor: number
+): number {
+  const context = AcGiContext.fromBackgroundColor(backgroundColor)
+  return context.backgroundIsDark
+    ? context.foregroundOnDark
+    : context.foregroundOnLight
 }
 
 /**
@@ -82,45 +136,13 @@ export function acgiContrastingForegroundColor(isLight: boolean): number {
 }
 
 /**
- * ACI-7 foreground that contrasts with the canvas background.
- */
-export function acgiForegroundColorForBackground(
-  backgroundColor: number
-): number {
-  const context = acgiBuildContext(backgroundColor)
-  return context.backgroundIsDark
-    ? context.foregroundOnDark
-    : context.foregroundOnLight
-}
-
-/**
- * Resolves {@link AcGiSubEntityTraits.color} to a pixel RGB value.
- */
-export function acgiResolveSubEntityTraitsRgb(
-  traits: AcGiSubEntityTraits,
-  context: AcGiContext
-): number {
-  const color = traits.color
-  if (color.isForeground) {
-    return context.backgroundIsDark
-      ? context.foregroundOnDark
-      : context.foregroundOnLight
-  }
-  if (color.isByLayer || color.isByBlock) {
-    return context.fallbackRgb ?? 0xffffff
-  }
-  return color.RGB ?? context.fallbackRgb ?? 0xffffff
-}
-
-/**
  * Convenience wrapper when only the canvas background is available.
  */
 export function acgiResolveSubEntityTraitsRgbFromBackground(
   traits: AcGiSubEntityTraits,
   backgroundColor: number
 ): number {
-  return acgiResolveSubEntityTraitsRgb(
-    traits,
-    acgiBuildContext(backgroundColor)
-  )
+  return AcGiContext.fromBackgroundColor(
+    backgroundColor
+  ).resolveSubEntityTraitsRgb(traits)
 }

--- a/packages/graphic-interface/src/AcGiSubEntityTraits.ts
+++ b/packages/graphic-interface/src/AcGiSubEntityTraits.ts
@@ -12,8 +12,8 @@ export interface AcGiSubEntityTraits {
   /**
    * Resolved semantic color of the sub-entity.
    *
-   * Use {@link acgiResolveSubEntityTraitsRgb} with {@link AcGiRenderer.context} to obtain
-   * the pixel RGB value at draw time (including ACI 7 foreground handling).
+   * Use {@link AcGiContext.resolveSubEntityTraitsRgb} with {@link AcGiRenderer.context}
+   * to obtain the pixel RGB value at draw time (including ACI 7 foreground handling).
    */
   color: AcCmColor
 

--- a/packages/graphic-interface/src/index.ts
+++ b/packages/graphic-interface/src/index.ts
@@ -19,15 +19,14 @@ export {
   ACGI_LIGHT_THEME_FOREGROUND,
   ACGI_MODEL_SPACE_BACKGROUND,
   ACGI_PAPER_SPACE_BACKGROUND,
+  AcGiContext,
   DEFAULT_ACGI_CONTEXT,
-  acgiBuildContext,
   acgiContrastingForegroundColor,
   acgiForegroundColorForBackground,
   acgiIsLightBackground,
-  acgiResolveSubEntityTraitsRgb,
   acgiResolveSubEntityTraitsRgbFromBackground
 } from './AcGiContext'
-export type { AcGiContext } from './AcGiContext'
+export type { AcGiContextOptions } from './AcGiContext'
 export type { AcGiFontMapping, AcGiRenderer } from './AcGiRenderer'
 export type { AcGiShapeData } from './AcGiShapeData'
 export type { AcGiStyleType } from './AcGiStyleType'


### PR DESCRIPTION
## Summary

- Convert `AcGiContext` from a plain interface plus standalone helpers (`acgiBuildContext`, `acgiResolveSubEntityTraitsRgb`) into a class with `resolveSubEntityTraitsRgb()` and `fromBackgroundColor()` factory methods.
- Fix `AcDbShape` so entities with an empty `styleName` pass `undefined` text style to the renderer, allowing shape-file definitions in the STYLE table to be used instead of falling back to `$TEXTSTYLE`.
- Collect shape-definition fonts (STYLE entries with `standardFlag & 1`) during DXF import so SHAPE entities load the correct `.shx` shape files.

## Test plan

- [ ] Run data-model tests: `AcDbShape`, `AcDbEntity`, `AcDbMLeader`, `AcDbTable`
- [ ] Run dxf-json-converter test: `AcDbDxfConverter` shape-definition font collection
- [ ] Load a DXF with SHAPE entities that rely on anonymous shape-file STYLE entries and verify glyphs render correctly
- [ ] Verify sub-entity RGB resolution still works for MLeader and table rendering after the AcGiContext API change
