### PR TITLE
feat(data-model): restore initial view from VPORT *ACTIVE with sanity checks

### DIFF
--- a/packages/data-model/__tests__/AcDbActiveModelView.spec.ts
+++ b/packages/data-model/__tests__/AcDbActiveModelView.spec.ts
@@ -1,0 +1,233 @@
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/geometry-engine'
+
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
+
+function setVportAspectRatio(
+  record: AcDbViewportTableRecord,
+  aspectRatio: number
+) {
+  ;(record.gsView as { aspectRatio?: number }).aspectRatio = aspectRatio
+}
+
+function createDatabaseWithActiveVport(
+  name: string,
+  options: {
+    centerX: number
+    centerY: number
+    viewHeight: number
+    aspectRatio?: number
+  }
+) {
+  const database = new AcDbDatabase()
+  const record = new AcDbViewportTableRecord()
+  record.name = name
+  record.centerPoint = new AcGePoint2d(options.centerX, options.centerY)
+  record.viewHeight = options.viewHeight
+  if (options.aspectRatio != null) {
+    setVportAspectRatio(record, options.aspectRatio)
+  }
+  database.tables.viewportTable.add(record)
+  return database
+}
+
+describe('AcDbActiveModelView', () => {
+  it('resolves *ACTIVE case-insensitively', () => {
+    const database = createDatabaseWithActiveVport('*Active', {
+      centerX: 10,
+      centerY: 20,
+      viewHeight: 100
+    })
+
+    expect(
+      database.tables.viewportTable.getActiveVport()?.centerPoint
+    ).toEqual({
+      x: 10,
+      y: 20
+    })
+  })
+
+  it('builds the view box from center, height, and canvas aspect ratio', () => {
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(100, 50)
+    record.viewHeight = 40
+    setVportAspectRatio(record, 2)
+
+    const box = record.modelViewBox(1.5)
+    expect(box).toBeInstanceOf(AcGeBox2d)
+    expect(box!.min).toEqual({ x: 70, y: 30 })
+    expect(box!.max).toEqual({ x: 130, y: 70 })
+  })
+
+  it('falls back to stored VPORT aspect ratio when canvas aspect is invalid', () => {
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(100, 50)
+    record.viewHeight = 40
+    setVportAspectRatio(record, 2)
+
+    const box = record.modelViewBox(0)
+    expect(box!.min).toEqual({ x: 60, y: 30 })
+    expect(box!.max).toEqual({ x: 140, y: 70 })
+  })
+
+  it('uses canvas aspect ratio when VPORT aspect ratio is missing', () => {
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(0, 0)
+    record.viewHeight = 10
+
+    const box = record.modelViewBox(2)
+    expect(box!.min).toEqual({ x: -10, y: -5 })
+    expect(box!.max).toEqual({ x: 10, y: 5 })
+  })
+
+  it('returns undefined when view height is invalid', () => {
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(0, 0)
+    record.viewHeight = 0
+
+    expect(record.modelViewBox(1)).toBeUndefined()
+  })
+
+  it('resolves the saved model view box from the database', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 200,
+      centerY: 100,
+      viewHeight: 50,
+      aspectRatio: 1.5
+    })
+
+    const box = database.tables.viewportTable.getActiveVportBox(1)
+    expect(box!.min).toEqual({ x: 175, y: 75 })
+    expect(box!.max).toEqual({ x: 225, y: 125 })
+  })
+
+  it('rejects a saved view zoomed far beyond drawing extents', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 58782,
+      centerY: 8501,
+      viewHeight: 62111,
+      aspectRatio: 2.315
+    })
+    const drawingExtents = new AcGeBox2d(
+      { x: -3500, y: -11024 },
+      { x: 60760, y: 34416 }
+    )
+    const viewBox = database.tables.viewportTable.getActiveVportBox(
+      1.778,
+      drawingExtents
+    )
+    expect(viewBox).toBeUndefined()
+  })
+
+  it('uses the same view box for DWG and DXF aspect ratios at equal canvas size', () => {
+    const drawingExtents = new AcGeBox2d(
+      { x: -3500, y: -11024 },
+      { x: 60760, y: 34416 }
+    )
+    const canvasAspect = 1.778
+    const shared = {
+      centerX: 58782.02699488195,
+      centerY: 8501.312323181883,
+      viewHeight: 62111.14484121096
+    }
+
+    for (const aspectRatio of [2.31511839708561, 1.7690802348336594]) {
+      const database = createDatabaseWithActiveVport('*ACTIVE', {
+        ...shared,
+        aspectRatio
+      })
+      expect(
+        database.tables.viewportTable.getActiveVportBox(
+          canvasAspect,
+          drawingExtents
+        )
+      ).toBeUndefined()
+    }
+
+    const dxfBox = createDatabaseWithActiveVport('*ACTIVE', {
+      ...shared,
+      aspectRatio: 2.31511839708561
+    })
+      .tables.viewportTable.getAt('*ACTIVE')!
+      .modelViewBox(canvasAspect)
+    const dwgBox = createDatabaseWithActiveVport('*ACTIVE', {
+      ...shared,
+      aspectRatio: 1.7690802348336594
+    })
+      .tables.viewportTable.getAt('*ACTIVE')!
+      .modelViewBox(canvasAspect)
+
+    expect(dxfBox!.min).toEqual(dwgBox!.min)
+    expect(dxfBox!.max).toEqual(dwgBox!.max)
+  })
+
+  it('rejects a saved view panned away from the drawing', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 58782,
+      centerY: 8501,
+      viewHeight: 1000,
+      aspectRatio: 1.778
+    })
+    const drawingExtents = new AcGeBox2d(
+      { x: -3500, y: -11024 },
+      { x: 60760, y: 34416 }
+    )
+    const viewBox = database.tables.viewportTable.getActiveVportBox(
+      1.778,
+      drawingExtents
+    )
+    expect(viewBox).toBeUndefined()
+  })
+
+  it('accepts a saved view that reasonably frames the drawing', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 23000,
+      centerY: 24000,
+      viewHeight: 9000,
+      aspectRatio: 1.778
+    })
+    const drawingExtents = new AcGeBox2d(
+      { x: -3500, y: -11024 },
+      { x: 60760, y: 34416 }
+    )
+    const viewBox = database.tables.viewportTable.getActiveVportBox(
+      1.778,
+      drawingExtents
+    )
+    expect(viewBox).toBeDefined()
+    expect(
+      AcDbViewportTableRecord.isModelViewBoxUsable(viewBox!, drawingExtents)
+    ).toBe(true)
+  })
+
+  it('rejects an oversized saved view when drawing extents are unavailable', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 58782,
+      centerY: 8501,
+      viewHeight: 62111,
+      aspectRatio: 2.315
+    })
+
+    expect(
+      database.tables.viewportTable.getActiveVportBox(1.778)
+    ).toBeUndefined()
+  })
+
+  it('accepts a saved view when EXTMIN/EXTMAX are degenerate', () => {
+    const database = createDatabaseWithActiveVport('*ACTIVE', {
+      centerX: 38429942.5,
+      centerY: 4067599.5,
+      viewHeight: 3199,
+      aspectRatio: 3647 / 3199
+    })
+    database.extmin = { x: 0, y: 0, z: 0 }
+    database.extmax = { x: 0, y: 0, z: 0 }
+
+    const viewBox = database.tables.viewportTable.getActiveVportBox(0)
+    expect(viewBox).toBeDefined()
+    expect(viewBox!.min.x).toBeCloseTo(38428119, 0)
+    expect(viewBox!.max.x).toBeCloseTo(38431766, 0)
+    expect(viewBox!.min.y).toBeCloseTo(4066000, 0)
+    expect(viewBox!.max.y).toBeCloseTo(4069199, 0)
+  })
+})

--- a/packages/data-model/src/database/AcDbViewportTable.ts
+++ b/packages/data-model/src/database/AcDbViewportTable.ts
@@ -1,3 +1,5 @@
+import { AcGeBox2d } from '@mlightcad/geometry-engine'
+
 import { ACTIVE_VPORT_NAME } from '../misc/AcDbConstants'
 import { AcDbDatabase } from './AcDbDatabase'
 import { AcDbSymbolTable } from './AcDbSymbolTable'
@@ -47,5 +49,24 @@ export class AcDbViewportTable extends AcDbSymbolTable<AcDbViewportTableRecord> 
       return ACTIVE_VPORT_NAME
     }
     return name.toUpperCase()
+  }
+
+  /**
+   * Returns the model-space VPORT table record AutoCAD saves as `*Active`.
+   */
+  getActiveVport(): AcDbViewportTableRecord | undefined {
+    return this.getAt(ACTIVE_VPORT_NAME)
+  }
+
+  /**
+   * Returns the initial model-space view box from VPORT `*ACTIVE`, if present
+   * and usable.
+   */
+  getActiveVportBox(
+    canvasAspectRatio: number,
+    drawingExtents?: AcGeBox2d
+  ): AcGeBox2d | undefined {
+    const vport = this.getActiveVport()
+    return vport?.resolveModelViewBox(canvasAspectRatio, drawingExtents)
   }
 }

--- a/packages/data-model/src/database/AcDbViewportTableRecord.ts
+++ b/packages/data-model/src/database/AcDbViewportTableRecord.ts
@@ -1,8 +1,73 @@
-import { AcGePoint2d } from '@mlightcad/geometry-engine'
+import { AcGeBox2d, AcGePoint2d } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { ACTIVE_VPORT_NAME } from '../misc/AcDbConstants'
 import { AcDbAbstractViewTableRecord } from './AcDbAbstractViewTableRecord'
+
+/** Reject saved views zoomed out more than this factor vs drawing EXTMIN/EXTMAX. */
+const MAX_VIEW_TO_EXTENT_RATIO = 2
+
+/** Max distance from drawing-extent center as a fraction of the larger span. */
+const MAX_VIEW_CENTER_OFFSET_RATIO = 0.45
+
+/** Max model-space view span when EXTMIN/EXTMAX are unavailable. */
+const MAX_VIEW_SPAN_WITHOUT_EXTENTS = 1e5
+
+type VportAspectRatioSource = {
+  aspectRatio?: number
+  gsView?: { aspectRatio?: number }
+}
+
+function readVportAspectRatio(
+  vport: AcDbViewportTableRecord
+): number | undefined {
+  const source = vport as AcDbViewportTableRecord & VportAspectRatioSource
+  const aspectRatio = source.aspectRatio ?? source.gsView?.aspectRatio
+  return Number.isFinite(aspectRatio) ? aspectRatio : undefined
+}
+
+function resolveViewAspectRatio(
+  vport: AcDbViewportTableRecord,
+  canvasAspectRatio: number
+): number {
+  if (Number.isFinite(canvasAspectRatio) && canvasAspectRatio > 0) {
+    return canvasAspectRatio
+  }
+  const storedAspect = readVportAspectRatio(vport)
+  if (storedAspect != null && storedAspect > 0) {
+    return storedAspect
+  }
+  return 1
+}
+
+function intersectionArea(viewBox: AcGeBox2d, drawingExtents: AcGeBox2d): number {
+  const minX = Math.max(viewBox.min.x, drawingExtents.min.x)
+  const minY = Math.max(viewBox.min.y, drawingExtents.min.y)
+  const maxX = Math.min(viewBox.max.x, drawingExtents.max.x)
+  const maxY = Math.min(viewBox.max.y, drawingExtents.max.y)
+  if (minX >= maxX || minY >= maxY) {
+    return 0
+  }
+  return (maxX - minX) * (maxY - minY)
+}
+
+function viewCenter(viewBox: AcGeBox2d) {
+  return {
+    x: (viewBox.min.x + viewBox.max.x) / 2,
+    y: (viewBox.min.y + viewBox.max.y) / 2
+  }
+}
+
+function hasMeaningfulDrawingExtents(
+  drawingExtents?: AcGeBox2d
+): drawingExtents is AcGeBox2d {
+  if (!drawingExtents || drawingExtents.isEmpty()) {
+    return false
+  }
+  const spanX = drawingExtents.max.x - drawingExtents.min.x
+  const spanY = drawingExtents.max.y - drawingExtents.min.y
+  return spanX > 0 && spanY > 0
+}
 
 /**
  * Represents a viewport table record in AutoCAD.
@@ -253,6 +318,145 @@ export class AcDbViewportTableRecord extends AcDbAbstractViewTableRecord {
   }
   set backgroundObjectId(value: string | undefined) {
     this._backgroundObjectId = value
+  }
+
+  /**
+   * Builds the model-space WCS view rectangle from this VPORT record.
+   *
+   * AutoCAD stores:
+   * - view center in groups 10/20 (mapped to `centerPoint`)
+   * - view height in group 40/45 (`viewHeight`)
+   * - aspect ratio in group 41 (`gsView.aspectRatio`) — the AutoCAD graphics
+   *   window width/height at save time, not the model-space view on its own
+   *
+   * View width = view height × aspect ratio. The viewer uses the current canvas
+   * aspect ratio so DWG/DXF exports of the same drawing frame identically even
+   * when group 41 differs.
+   */
+  modelViewBox(canvasAspectRatio: number): AcGeBox2d | undefined {
+    const center = this.centerPoint
+    const viewHeight = this.viewHeight
+
+    if (
+      !Number.isFinite(center.x) ||
+      !Number.isFinite(center.y) ||
+      !Number.isFinite(viewHeight) ||
+      viewHeight <= 0
+    ) {
+      return undefined
+    }
+
+    const aspectRatio = resolveViewAspectRatio(this, canvasAspectRatio)
+
+    const viewWidth = viewHeight * aspectRatio
+    const halfHeight = viewHeight / 2
+    const halfWidth = viewWidth / 2
+
+    return new AcGeBox2d()
+      .expandByPoint({
+        x: center.x - halfWidth,
+        y: center.y - halfHeight
+      })
+      .expandByPoint({
+        x: center.x + halfWidth,
+        y: center.y + halfHeight
+      })
+  }
+
+  /**
+   * Returns whether a VPORT-derived view box is sane enough to frame the drawing
+   * on open. Rejects stale saves that are zoomed far beyond the sheet (common
+   * when `$EXTMIN`/`$EXTMAX` reflect the title block but `*ACTIVE` still stores
+   * a huge `view height`) or panned to a corner with no real geometry.
+   */
+  static isModelViewBoxUsable(
+    viewBox: AcGeBox2d,
+    drawingExtents: AcGeBox2d
+  ): boolean {
+    if (viewBox.isEmpty() || drawingExtents.isEmpty()) {
+      return false
+    }
+
+    const viewSpanX = viewBox.max.x - viewBox.min.x
+    const viewSpanY = viewBox.max.y - viewBox.min.y
+    const extSpanX = drawingExtents.max.x - drawingExtents.min.x
+    const extSpanY = drawingExtents.max.y - drawingExtents.min.y
+
+    if (viewSpanX <= 0 || viewSpanY <= 0 || extSpanX <= 0 || extSpanY <= 0) {
+      return false
+    }
+
+    if (
+      viewSpanX > extSpanX * MAX_VIEW_TO_EXTENT_RATIO ||
+      viewSpanY > extSpanY * MAX_VIEW_TO_EXTENT_RATIO
+    ) {
+      return false
+    }
+
+    const centerOffsetLimit =
+      Math.max(extSpanX, extSpanY) * MAX_VIEW_CENTER_OFFSET_RATIO
+    const viewCenterPoint = viewCenter(viewBox)
+    const extentCenterPoint = viewCenter(drawingExtents)
+    const centerDistance = Math.hypot(
+      viewCenterPoint.x - extentCenterPoint.x,
+      viewCenterPoint.y - extentCenterPoint.y
+    )
+    if (centerDistance > centerOffsetLimit) {
+      return false
+    }
+
+    const viewArea = viewSpanX * viewSpanY
+    const overlap = intersectionArea(viewBox, drawingExtents)
+    if (overlap <= 0 || overlap / viewArea < 0.25) {
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * Returns the model-space view box from this record when structurally valid
+   * and plausible for the given drawing extents.
+   */
+  resolveModelViewBox(
+    canvasAspectRatio: number,
+    drawingExtents?: AcGeBox2d
+  ): AcGeBox2d | undefined {
+    const viewBox = this.modelViewBox(canvasAspectRatio)
+    if (!viewBox || !AcDbViewportTableRecord.isModelViewBoxStructurallyValid(viewBox)) {
+      return undefined
+    }
+    if (hasMeaningfulDrawingExtents(drawingExtents)) {
+      if (!AcDbViewportTableRecord.isModelViewBoxUsable(viewBox, drawingExtents)) {
+        return undefined
+      }
+    } else if (!AcDbViewportTableRecord.isModelViewBoxPlausibleWithoutExtents(viewBox)) {
+      return undefined
+    }
+    return viewBox
+  }
+
+  private static isModelViewBoxStructurallyValid(viewBox: AcGeBox2d): boolean {
+    if (viewBox.isEmpty()) {
+      return false
+    }
+
+    const viewSpanX = viewBox.max.x - viewBox.min.x
+    const viewSpanY = viewBox.max.y - viewBox.min.y
+    return (
+      Number.isFinite(viewSpanX) &&
+      Number.isFinite(viewSpanY) &&
+      viewSpanX > 0 &&
+      viewSpanY > 0
+    )
+  }
+
+  private static isModelViewBoxPlausibleWithoutExtents(
+    viewBox: AcGeBox2d
+  ): boolean {
+    const viewSpanX = viewBox.max.x - viewBox.min.x
+    const viewSpanY = viewBox.max.y - viewBox.min.y
+    return Math.max(viewSpanX, viewSpanY) <= MAX_VIEW_SPAN_WITHOUT_EXTENTS
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `modelViewBox` / `resolveModelViewBox` on `AcDbViewportTableRecord` to derive the model-space WCS view rectangle from VPORT `*ACTIVE` (center, view height, and canvas aspect ratio).
- Add `getActiveVport` / `getActiveVportBox` on `AcDbViewportTable` and reject stale saved views that are zoomed far beyond drawing extents or panned away from geometry.
- Add unit tests covering aspect-ratio fallback, DWG/DXF parity, extent validation, and degenerate EXTMIN/EXTMAX cases.

## Test plan
- [x] Run `AcDbActiveModelView` unit tests in `packages/data-model`
- [ ] Open a DWG/DXF with a reasonable saved `*ACTIVE` view and confirm the viewer frames the drawing correctly
- [ ] Open a DWG/DXF with an oversized or off-center saved view and confirm the viewer falls back instead of using the stale VPORT state