### PR TITLE
feat(libredwg-converter): improve MLeader conversion and add SHAPE entity support

### DIFF
--- a/packages/data-model/__tests__/AcDbMLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLeader.spec.ts
@@ -192,8 +192,8 @@ describe('AcDbMLeader arrowhead rendering', () => {
     mleader.textLocation = new AcGePoint3d(5, 2, 0)
 
     // Simulate DXF payload that writes entity raw color fields as ByBlock.
-    mleader.leaderLineColor = (0xc1 << 24) >> 0
-    mleader.textColor = (0xc1 << 24) >> 0
+    mleader.leaderLineColor = new AcCmColor().setByBlock()
+    mleader.textColor = new AcCmColor().setByBlock()
 
     const style = new AcDbMLeaderStyle()
     style.leaderLineColor = new AcCmColor(AcCmColorMethod.ByColor, 0xff0000)
@@ -223,6 +223,22 @@ describe('AcDbMLeader arrowhead rendering', () => {
 
     expect(lineRgbLog[0]).toBe(0xff0000)
     expect(mtextRgb).toBe(0x00aa00)
+  })
+
+  it('forwards the delay flag to nested MText rendering', () => {
+    const db = createWorkingDb()
+    const mleader = createSimpleLeader(db)
+    mleader.contents = 'Delayed text'
+    mleader.textLocation = new AcGePoint3d(5, 2, 0)
+
+    const renderer = createRenderer()
+    mleader.worldDraw(renderer as never, true)
+
+    expect(renderer.mtext).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Delayed text' }),
+      expect.anything(),
+      true
+    )
   })
 
   it('applies style leader linetype id and lineweight to rendered leader line', () => {

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -22,7 +22,6 @@ import {
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { DEFAULT_MLEADER_STYLE } from '../misc/AcDbConstants'
-import { decodeMLeaderStyleRawColor } from '../misc/AcDbMLeaderStyleColorCodec'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbRenderingCache } from '../misc/AcDbRenderingCache'
 import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
@@ -189,7 +188,7 @@ export interface AcDbMLeaderBlockContentLike {
   position?: AcGePoint3dLike
   scale?: AcGeVector3dLike
   rotation?: number
-  color?: number
+  color?: AcCmColor
   transformationMatrix?: number[]
 }
 
@@ -203,7 +202,7 @@ export interface AcDbMLeaderBlockContent {
   position?: AcGePoint3d
   scale: AcGeVector3d
   rotation: number
-  color?: number
+  color?: AcCmColor
   transformationMatrix: number[]
 }
 
@@ -265,7 +264,7 @@ export class AcDbMLeader extends AcDbEntity {
   private _version?: number
   private _leaderStyleId?: string
   private _propertyOverrideFlag?: number
-  private _leaderLineColor?: number
+  private _leaderLineColor?: AcCmColor
   private _leaderLineTypeId?: string
   private _leaderLineWeight?: number
   private _landingEnabled?: boolean
@@ -276,13 +275,13 @@ export class AcDbMLeader extends AcDbEntity {
   private _textRightAttachmentType?: number
   private _textAngleType?: number
   private _textAlignmentType?: number
-  private _textColor?: number
+  private _textColor?: AcCmColor
   private _textFrameEnabled?: boolean
   private _landingGap?: number
   private _textAttachment?: number
   private _textFlowDirection?: number
   private _blockContentId?: string
-  private _blockContentColor?: number
+  private _blockContentColor?: AcCmColor
   private _blockContentScale?: AcGeVector3d
   private _blockContentRotation?: number
   private _blockContentConnectionType?: number
@@ -297,7 +296,7 @@ export class AcDbMLeader extends AcDbEntity {
   private _contentBasePosition?: AcGePoint3d
   private _textAnchor?: AcGePoint3d
   private _textLineSpacingStyle?: number
-  private _textBackgroundColor?: number
+  private _textBackgroundColor?: AcCmColor
   private _textBackgroundScaleFactor?: number
   private _textBackgroundTransparency?: number
   private _textBackgroundColorOn?: boolean
@@ -495,8 +494,8 @@ export class AcDbMLeader extends AcDbEntity {
   get leaderLineColor() {
     return this._leaderLineColor
   }
-  set leaderLineColor(value: number | undefined) {
-    this._leaderLineColor = value
+  set leaderLineColor(value: AcCmColor | undefined) {
+    this._leaderLineColor = value?.clone()
   }
 
   /**
@@ -605,8 +604,8 @@ export class AcDbMLeader extends AcDbEntity {
   get textColor() {
     return this._textColor
   }
-  set textColor(value: number | undefined) {
-    this._textColor = value
+  set textColor(value: AcCmColor | undefined) {
+    this._textColor = value?.clone()
   }
 
   /**
@@ -665,8 +664,8 @@ export class AcDbMLeader extends AcDbEntity {
   get blockContentColor() {
     return this._blockContentColor
   }
-  set blockContentColor(value: number | undefined) {
-    this._blockContentColor = value
+  set blockContentColor(value: AcCmColor | undefined) {
+    this._blockContentColor = value?.clone()
   }
 
   /**
@@ -817,8 +816,8 @@ export class AcDbMLeader extends AcDbEntity {
   get textBackgroundColor() {
     return this._textBackgroundColor
   }
-  set textBackgroundColor(value: number | undefined) {
-    this._textBackgroundColor = value
+  set textBackgroundColor(value: AcCmColor | undefined) {
+    this._textBackgroundColor = value?.clone()
   }
 
   /**
@@ -1188,7 +1187,7 @@ export class AcDbMLeader extends AcDbEntity {
           position: this._blockContent.position?.clone(),
           scale: this._blockContent.scale.clone(),
           rotation: this._blockContent.rotation,
-          color: this._blockContent.color,
+          color: this._blockContent.color?.clone(),
           transformationMatrix: [...this._blockContent.transformationMatrix]
         }
       : undefined
@@ -1208,7 +1207,7 @@ export class AcDbMLeader extends AcDbEntity {
       position: value.position ? this.createPoint(value.position) : undefined,
       scale: new AcGeVector3d(value.scale ?? { x: 1, y: 1, z: 1 }),
       rotation: value.rotation ?? 0,
-      color: value.color,
+      color: value.color?.clone(),
       transformationMatrix: value.transformationMatrix
         ? [...value.transformationMatrix]
         : []
@@ -1697,7 +1696,7 @@ export class AcDbMLeader extends AcDbEntity {
    * @param renderer Graphics renderer used to create draw entities.
    * @returns A single entity, an entity group, or undefined when nothing is drawable.
    */
-  subWorldDraw(renderer: AcGiRenderer): AcGiEntity | undefined {
+  subWorldDraw(renderer: AcGiRenderer, delay?: boolean): AcGiEntity | undefined {
     const entities: AcGiEntity[] = []
     const traits = renderer.subEntityTraits
     const originalColor = traits.color
@@ -1746,9 +1745,9 @@ export class AcDbMLeader extends AcDbEntity {
         drawingDirection: this.textDrawingDirection,
         lineSpaceFactor: this.textLineSpacingFactor
       }
-      // MLeader draws multiple primitives as a group. Delayed MText rendering is
-      // only scheduled for top-level entities, so render nested MText eagerly.
-      entities.push(renderer.mtext(mtextData, this.getTextStyle(), false))
+      // Nested MText must follow the same delay flag as top-level MTEXT so the
+      // viewer can finish geometry asynchronously in worker render mode.
+      entities.push(renderer.mtext(mtextData, this.getTextStyle(), delay))
     }
 
     traits.color = originalColor
@@ -2395,12 +2394,18 @@ export class AcDbMLeader extends AcDbEntity {
       ? textStyleTable.getIdAt(styleIdFromStyle)?.name
       : undefined
 
-    if (this.textStyleName) return this.textStyleName
-
-    const directStyle = this.textStyleId
-      ? textStyleTable.getIdAt(this.textStyleId)
+    const styleNameFromEntityId = this.textStyleId
+      ? textStyleTable.getIdAt(this.textStyleId)?.name
       : undefined
-    if (directStyle?.name) return directStyle.name
+
+    if (this.textStyleName) {
+      const byName = textStyleTable.getAt(this.textStyleName)
+      if (byName?.name) return byName.name
+      const byId = textStyleTable.getIdAt(this.textStyleName)
+      if (byId?.name) return byId.name
+    }
+
+    if (styleNameFromEntityId) return styleNameFromEntityId
 
     return styleNameFromStyleId
   }
@@ -2546,14 +2551,10 @@ export class AcDbMLeader extends AcDbEntity {
    * @returns Effective color used for rendering and trait application.
    */
   private getResolvedComponentColor(
-    rawEntityColor: number | undefined,
+    entityColor: AcCmColor | undefined,
     styleColor: AcCmColor | undefined,
     overrideFlagMask: number
   ) {
-    const entityColor =
-      rawEntityColor != null
-        ? decodeMLeaderStyleRawColor(rawEntityColor)
-        : undefined
     if (!entityColor) return styleColor
 
     const overrideEnabled = this.isPropertyOverrideEnabled(overrideFlagMask)

--- a/packages/data-model/src/misc/AcDbMLeaderStyleColorCodec.ts
+++ b/packages/data-model/src/misc/AcDbMLeaderStyleColorCodec.ts
@@ -100,8 +100,12 @@ export function decodeMLeaderStyleRawColor(rawColor: number) {
       color.setRGBValue(rawColor & 0xffffff)
       break
     default:
-      // Compatibility fallback for generators that output plain ACI (0..256).
-      if (rawColor >= 0 && rawColor <= 256) {
+      // Plain ACI from libredwg index-only exports (legacy) and other producers.
+      if (rawColor === 256) {
+        color.setByLayer()
+      } else if (rawColor === 0) {
+        color.setByBlock()
+      } else if (rawColor > 0 && rawColor < 256) {
         color.colorIndex = rawColor
       }
       break

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -292,6 +292,7 @@ describe('AcDbEntityConverter', () => {
     expect(mleader.version).toBe(2)
     expect(mleader.leaderStyleId).toBe('STYLE')
     expect(mleader.leaderLineType).toBe(AcDbMLeaderLineType.StraightLeader)
+    expect(mleader.leaderLineColor?.isByLayer).toBe(true)
     expect(mleader.textHeight).toBe(4)
     expect(mleader.landingEnabled).toBe(true)
     expect(mleader.textFrameEnabled).toBe(true)

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -71,6 +71,7 @@ import {
   AcGeVector3d,
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection,
+  decodeMLeaderStyleRawColor,
   hexStringsToBytes,
   transformOcsPointToWcs
 } from '@mlightcad/data-model'
@@ -914,7 +915,11 @@ export class AcDbEntityConverter {
     dbEntity.propertyOverrideFlag = mleader.propertyOverrideFlag
     dbEntity.leaderLineType = (mleader.leaderLineType ??
       AcDbMLeaderLineType.StraightLeader) as AcDbMLeaderLineType
-    dbEntity.leaderLineColor = mleader.leaderLineColor
+    if (mleader.leaderLineColor != null) {
+      dbEntity.leaderLineColor = decodeMLeaderStyleRawColor(
+        mleader.leaderLineColor
+      )
+    }
     dbEntity.leaderLineTypeId = mleader.leaderLineTypeId
     dbEntity.leaderLineWeight = mleader.leaderLineWeight
     dbEntity.landingEnabled = mleader.landingEnabled
@@ -927,13 +932,21 @@ export class AcDbEntityConverter {
     dbEntity.textRightAttachmentType = mleader.textRightAttachmentType
     dbEntity.textAngleType = mleader.textAngleType
     dbEntity.textAlignmentType = mleader.textAlignmentType
-    dbEntity.textColor = mleader.textColor
+    if (mleader.textColor != null) {
+      dbEntity.textColor = decodeMLeaderStyleRawColor(mleader.textColor)
+    }
     dbEntity.textFrameEnabled = mleader.textFrameEnabled
     dbEntity.landingGap = mleader.landingGap
     dbEntity.textAttachment = mleader.textAttachment
     dbEntity.textFlowDirection = mleader.textFlowDirection
-    dbEntity.blockContentId = mleader.blockContentId
-    dbEntity.blockContentColor = mleader.blockContentColor
+    if (this.isValidHandleId(mleader.blockContentId)) {
+      dbEntity.blockContentId = mleader.blockContentId
+    }
+    if (mleader.blockContentColor != null) {
+      dbEntity.blockContentColor = decodeMLeaderStyleRawColor(
+        mleader.blockContentColor
+      )
+    }
     dbEntity.blockContentRotation = mleader.blockContentRotation
     dbEntity.blockContentConnectionType = mleader.blockContentConnectionType
     dbEntity.annotativeScaleEnabled = mleader.annotativeScaleEnabled
@@ -950,7 +963,11 @@ export class AcDbEntityConverter {
     dbEntity.topTextAttachmentDirection = mleader.topTextAttachmentDirection
     dbEntity.contentScale = mleader.contentScale
     dbEntity.textLineSpacingStyle = mleader.textLineSpacingStyle
-    dbEntity.textBackgroundColor = mleader.textBackgroundColor
+    if (mleader.textBackgroundColor != null) {
+      dbEntity.textBackgroundColor = decodeMLeaderStyleRawColor(
+        mleader.textBackgroundColor
+      )
+    }
     dbEntity.textBackgroundScaleFactor = mleader.textBackgroundScaleFactor
     dbEntity.textBackgroundTransparency = mleader.textBackgroundTransparency
     dbEntity.textBackgroundColorOn = mleader.textBackgroundColorOn
@@ -1020,12 +1037,7 @@ export class AcDbEntityConverter {
         'textStyleName',
         'textStyle'
       ]) ??
-      this.readString(raw, [
-        'textStyleName',
-        'textStyle',
-        'styleName',
-        'textStyleId'
-      ])
+      this.readString(raw, ['textStyleName', 'textStyle', 'styleName'])
     if (textStyleName) dbEntity.textStyleName = textStyleName
 
     const textHeight =
@@ -1084,7 +1096,7 @@ export class AcDbEntityConverter {
       'textAttachmentPoint',
       'attachmentPoint'
     ])
-    if (textAttachmentPoint != null) {
+    if (textAttachmentPoint != null && textAttachmentPoint !== 0) {
       dbEntity.textAttachmentPoint =
         textAttachmentPoint as unknown as AcGiMTextAttachmentPoint
     }
@@ -1133,25 +1145,32 @@ export class AcDbEntityConverter {
         string,
         unknown
       >
-      dbEntity.blockContent = {
-        blockContentId: mleader.blockContent.blockContentId,
-        normal: this.readPoint(blockRecord, ['normal']),
-        position: mleader.blockContent.position,
-        scale: this.readPoint(blockRecord, ['scale']),
-        rotation: this.readNumber(blockRecord, ['rotation']),
-        color: this.readNumber(blockRecord, ['color']),
-        transformationMatrix: Array.isArray(
-          mleader.blockContent.transformationMatrix
-        )
-          ? mleader.blockContent.transformationMatrix
+      const blockContentId = mleader.blockContent.blockContentId
+      if (this.isValidHandleId(blockContentId)) {
+        const rawBlockColor = this.readNumber(blockRecord, ['color'])
+        dbEntity.blockContent = {
+          blockContentId,
+          normal: this.readPoint(blockRecord, ['normal']),
+          position: mleader.blockContent.position,
+          scale: this.readPoint(blockRecord, ['scale']),
+          rotation: this.readNumber(blockRecord, ['rotation']),
+          color:
+            rawBlockColor != null
+              ? decodeMLeaderStyleRawColor(rawBlockColor)
+              : undefined,
+          transformationMatrix: Array.isArray(
+            mleader.blockContent.transformationMatrix
+          )
+            ? mleader.blockContent.transformationMatrix
           : []
+        }
       }
-    } else if (mleader.blockContentId) {
+    } else if (this.isValidHandleId(mleader.blockContentId)) {
       dbEntity.blockContent = {
         blockContentId: mleader.blockContentId,
         scale: mleader.blockContentScale,
         rotation: mleader.blockContentRotation,
-        color: mleader.blockContentColor,
+        color: dbEntity.blockContentColor,
         transformationMatrix: []
       }
     }
@@ -1460,6 +1479,10 @@ export class AcDbEntityConverter {
     if (entity.transparency != null) {
       dbEntity.transparency = AcCmTransparency.deserialize(entity.transparency)
     }
+  }
+
+  private isValidHandleId(id: string | undefined): id is string {
+    return id != null && id !== '' && id !== '0'
   }
 
   private readNumber(source: Record<string, unknown>, names: string[]) {

--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -6,6 +6,7 @@ import {
   AcDbDatabase,
   AcDbHatch,
   AcDbProxyEntity,
+  AcDbShape,
   acdbHostApplicationServices
 } from '@mlightcad/data-model'
 
@@ -233,5 +234,58 @@ describe('libredwg AcDbEntityConverter', () => {
       expect(hatch.color.colorIndex).toBe(7)
       expect(hatch.color.isForeground).toBe(true)
     })
+  })
+
+  it('converts libredwg SHAPE entity', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'SHAPE',
+      subclassMarker: 'AcDbShape',
+      layer: '0',
+      handle: '19AAD3',
+      insertionPoint: { x: 100, y: 200, z: 0 },
+      size: 2.5,
+      shapeNumber: 42,
+      styleName: 'TECOGISSHAPE0',
+      rotation: Math.PI / 4,
+      xScale: 1.5,
+      obliqueAngle: Math.PI / 18,
+      thickness: 0.5,
+      extrusionDirection: { x: 0, y: 0, z: 1 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbShape)
+    const shape = result as AcDbShape
+    expect(shape.type).toBe('Shape')
+    expect(shape.shapeNumber).toBe(42)
+    expect(shape.styleName).toBe('TECOGISSHAPE0')
+    expect(shape.position).toMatchObject({ x: 100, y: 200, z: 0 })
+    expect(shape.size).toBe(2.5)
+    expect(shape.rotation).toBeCloseTo(Math.PI / 4)
+    expect(shape.widthFactor).toBe(1.5)
+    expect(shape.oblique).toBeCloseTo(Math.PI / 18)
+    expect(shape.thickness).toBe(0.5)
+    expect(shape.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+  })
+
+  it('converts libredwg SHAPE OCS insertion point into WCS when extrusion points to -Z', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'SHAPE',
+      subclassMarker: 'AcDbShape',
+      insertionPoint: { x: 1, y: 2, z: 0 },
+      size: 1,
+      shapeNumber: 1,
+      rotation: 0,
+      xScale: 1,
+      obliqueAngle: 0,
+      thickness: 0,
+      extrusionDirection: { x: 0, y: 0, z: -1 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbShape)
+    expect((result as AcDbShape).position).toMatchObject({ x: -1, y: 2, z: 0 })
   })
 })

--- a/packages/libredwg-converter/__tests__/AcDbMLeaderConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbMLeaderConverter.spec.ts
@@ -1,0 +1,162 @@
+import {
+  AcDbDatabase,
+  AcDbMLeader,
+  AcGiMTextAttachmentPoint,
+  acdbHostApplicationServices
+} from '@mlightcad/data-model'
+
+import { AcDbEntityConverter } from '../src/AcDbEntitiyConverter'
+import { AcDbObjectConverter } from '../src/AcDbObjectConverter'
+
+describe('libredwg AcDbObjectConverter', () => {
+  it('decodes MLEADERSTYLE raw colors (ACI/true color/ByLayer) to AcCmColor', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbObjectConverter()
+
+    const style = converter.convertMLeaderStyle({
+      handle: 'MLS-1',
+      ownerHandle: 'OWNER-1',
+      leaderLineColor: ((0xc3 << 24) | 1) >> 0,
+      textColor: ((0xc2 << 24) | 0x112233) >> 0,
+      blockContentColor: (0xc0 << 24) >> 0
+    } as any)
+
+    expect(style.leaderLineColor.isByACI).toBe(true)
+    expect(style.leaderLineColor.colorIndex).toBe(1)
+    expect(style.textColor.isByColor).toBe(true)
+    expect(style.textColor.RGB).toBe(0x112233)
+    expect(style.blockContentColor.isByLayer).toBe(true)
+  })
+})
+
+describe('libredwg AcDbEntityConverter MLEADER', () => {
+  it('converts MULTILEADER with text content and leader sections', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+
+    const result = converter.convert({
+      type: 'MULTILEADER',
+      subclassMarker: 'AcDbMLeader',
+      handle: 'ML-1',
+      layer: '0',
+      leaderStyleId: 'STYLE-1',
+      contentType: 2,
+      textContent: 'Note text',
+      textAnchor: { x: 10, y: 20, z: 0 },
+      textHeight: 2.5,
+      textWidth: 40,
+      leaderSections: [
+        {
+          lastLeaderLinePoint: { x: 10, y: 20, z: 0 },
+          lastLeaderLinePointSet: true,
+          doglegLength: 8,
+          leaderLines: [
+            {
+              vertices: [
+                { x: 0, y: 0, z: 0 },
+                { x: 5, y: 10, z: 0 }
+              ]
+            }
+          ]
+        }
+      ]
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMLeader)
+    const mleader = result as AcDbMLeader
+    expect(mleader.mleaderStyleId).toBe('STYLE-1')
+    expect(mleader.mtextContent?.text).toBe('Note text')
+    expect(mleader.mtextContent?.anchorPoint).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(mleader.textHeight).toBe(2.5)
+    expect(mleader.textWidth).toBe(40)
+    expect(mleader.numberOfLeaders).toBe(1)
+    expect(mleader.leaders[0].leaderLines[0].vertices).toHaveLength(2)
+  })
+
+  it('ignores zero text attachment point from libredwg justification field', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+
+    const result = converter.convert({
+      type: 'MULTILEADER',
+      subclassMarker: 'AcDbMLeader',
+      handle: 'ML-2',
+      layer: '0',
+      contentType: 2,
+      textContent: 'Note text',
+      textAnchor: { x: 10, y: 20, z: 0 },
+      textAttachmentPoint: 0,
+      leaderSections: [
+        {
+          leaderLines: [
+            {
+              vertices: [
+                { x: 0, y: 0, z: 0 },
+                { x: 5, y: 10, z: 0 }
+              ]
+            }
+          ]
+        }
+      ]
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMLeader)
+    expect((result as AcDbMLeader).textAttachmentPoint).toBe(
+      AcGiMTextAttachmentPoint.MiddleLeft
+    )
+  })
+
+  it('keeps MText contentType when blockContentId is the null handle "0"', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+
+    const result = converter.convert({
+      type: 'MULTILEADER',
+      subclassMarker: 'AcDbMLeader',
+      handle: 'ML-3',
+      layer: '0',
+      contentType: 2,
+      textContent: 'yellow non-standard line',
+      textAnchor: { x: 1848.17, y: 1891.26, z: 0 },
+      blockContentId: '0',
+      leaderSections: [
+        {
+          leaderLines: [{ vertices: [{ x: 0, y: 0, z: 0 }] }]
+        }
+      ]
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMLeader)
+    const mleader = result as AcDbMLeader
+    expect(mleader.contentType).toBe(2)
+    expect(mleader.mtextContent?.text).toBe('yellow non-standard line')
+    expect(mleader.blockContent).toBeUndefined()
+  })
+
+  it('converts MLeader raw int32 component colors to AcCmColor', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+
+    const result = converter.convert({
+      type: 'MULTILEADER',
+      subclassMarker: 'AcDbMLeader',
+      handle: 'ML-4',
+      layer: '0',
+      contentType: 2,
+      textContent: 'yellow non-standard line',
+      textColor: -1023410174,
+      leaderLineColor: -1056964608,
+      leaderSections: [
+        {
+          leaderLines: [{ vertices: [{ x: 0, y: 0, z: 0 }] }]
+        }
+      ]
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMLeader)
+    const mleader = result as AcDbMLeader
+    expect(mleader.textColor?.isByACI).toBe(true)
+    expect(mleader.textColor?.colorIndex).toBe(2)
+    expect(mleader.leaderLineColor?.isByBlock).toBe(true)
+  })
+})

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "^0.7.4"
+    "@mlightcad/libredwg-web": "^0.7.5"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -28,6 +28,7 @@ import {
   AcDbMLeader,
   AcDbMLeaderContentType,
   AcDbMLeaderLineType,
+  AcDbMLeaderTextAttachmentDirection,
   AcDbMLine,
   AcDbMLineJustification,
   AcDbMText,
@@ -44,6 +45,7 @@ import {
   AcDbRasterImageClipBoundaryType,
   AcDbRay,
   AcDbRotatedDimension,
+  AcDbShape,
   AcDbSpline,
   AcDbTable,
   AcDbTableCell,
@@ -68,6 +70,7 @@ import {
   AcGeVector3d,
   AcGiMTextAttachmentPoint,
   AcGiMTextFlowDirection,
+  decodeMLeaderStyleRawColor,
   hexStringsToBytes,
   transformOcsPointToWcs
 } from '@mlightcad/data-model'
@@ -96,6 +99,7 @@ import type {
   DwgLWPolylineEntity,
   DwgMLineEntity,
   DwgMTextEntity,
+  DwgMultiLeaderEntity,
   DwgOrdinateDimensionEntity,
   DwgPointEntity,
   DwgPolyline2dEntity,
@@ -104,6 +108,7 @@ import type {
   DwgProxyEntity,
   DwgRadialDiameterDimensionEntity,
   DwgRayEntity,
+  DwgShapeEntity,
   DwgSolidEntity,
   DwgSplineEdge,
   DwgSplineEntity,
@@ -114,56 +119,28 @@ import type {
   DwgXlineEntity
 } from '@mlightcad/libredwg-web'
 
-interface DwgMLeaderBreak {
+type ParsedMLeaderBreak = {
+  index?: number
   start: AcGePoint3dLike
   end: AcGePoint3dLike
 }
 
-interface DwgMLeaderLeaderLine {
-  vertices?: AcGePoint3dLike[]
-  breaks?: DwgMLeaderBreak[]
+type ParsedMLeaderLine = {
+  vertices: AcGePoint3dLike[]
+  breakPointIndexes?: number[]
+  leaderLineIndex?: number
+  breaks?: ParsedMLeaderBreak[]
 }
 
-interface DwgMLeaderLeader {
-  landingPoint?: AcGePoint3dLike
+type ParsedMLeaderLeader = {
+  lastLeaderLinePoint?: AcGePoint3dLike
+  lastLeaderLinePointSet?: boolean
   doglegVector?: AcGePoint3dLike
+  doglegVectorSet?: boolean
   doglegLength?: number
-  leaderLines?: DwgMLeaderLeaderLine[]
-}
-
-interface DwgMLeaderEntity extends DwgEntity {
-  type: 'MLEADER' | 'MULTILEADER'
-  multileaderType?: number
-  leaderLineType?: number
-  leaderType?: number
-  doglegEnabled?: boolean | number
-  enableDogleg?: boolean | number
-  doglegLength?: number
-  contentType?: number
-  landingPoint?: AcGePoint3dLike
-  doglegVector?: AcGePoint3dLike
-  normal?: AcGePoint3dLike
-  extrusionDirection?: AcGePoint3dLike
-  mleaderStyleId?: string
-  mLeaderStyleId?: string
-  mleaderStyleHandle?: string
-  styleHandle?: string
-  styleName?: string
-  textContent?: {
-    text?: string
-    anchorPoint?: AcGePoint3dLike
-    textHeight?: number
-    textWidth?: number
-    textRotation?: number
-    styleName?: string
-  }
-  blockContent?: {
-    blockHandle?: string
-    position?: AcGePoint3dLike
-  }
-  leaders?: DwgMLeaderLeader[]
-  leaderLines?: DwgMLeaderLeaderLine[]
-  vertices?: AcGePoint3dLike[]
+  breaks?: ParsedMLeaderBreak[]
+  leaderBranchIndex?: number
+  leaderLines?: ParsedMLeaderLine[]
 }
 
 export class AcDbEntityConverter {
@@ -210,7 +187,7 @@ export class AcDbEntityConverter {
     } else if (entity.type == 'MTEXT') {
       return this.convertMText(entity as DwgMTextEntity)
     } else if (entity.type == 'MULTILEADER' || entity.type == 'MLEADER') {
-      return this.convertMLeader(entity as DwgMLeaderEntity)
+      return this.convertMLeader(entity as DwgMultiLeaderEntity)
     } else if (entity.type == 'POINT') {
       return this.convertPoint(entity as DwgPointEntity)
     } else if (entity.type == 'POLYLINE2D') {
@@ -225,6 +202,8 @@ export class AcDbEntityConverter {
       return this.convertTable(entity as DwgTableEntity)
     } else if (entity.type == 'TEXT') {
       return this.convertText(entity as DwgTextEntity)
+    } else if (entity.type == 'SHAPE') {
+      return this.convertShape(entity as DwgShapeEntity)
     } else if (entity.type == 'SOLID') {
       return this.convertSolid(entity as DwgSolidEntity)
     } else if (entity.type == 'VIEWPORT') {
@@ -350,6 +329,23 @@ export class AcDbEntityConverter {
   private convertPoint(point: DwgPointEntity) {
     const dbEntity = new AcDbPoint()
     dbEntity.position = point.position
+    return dbEntity
+  }
+
+  private convertShape(shape: DwgShapeEntity) {
+    const normal = shape.extrusionDirection ?? AcGeVector3d.Z_AXIS
+    const dbEntity = new AcDbShape()
+    dbEntity.position = transformOcsPointToWcs(shape.insertionPoint, normal)
+    dbEntity.size = shape.size
+    dbEntity.shapeNumber = shape.shapeNumber
+    if (shape.styleName) {
+      dbEntity.styleName = shape.styleName
+    }
+    dbEntity.rotation = shape.rotation ?? 0
+    dbEntity.widthFactor = shape.xScale ?? 1
+    dbEntity.oblique = shape.obliqueAngle ?? 0
+    dbEntity.thickness = shape.thickness ?? 0
+    dbEntity.normal.copy(normal)
     return dbEntity
   }
 
@@ -803,72 +799,194 @@ export class AcDbEntityConverter {
     return dbEntity
   }
 
-  private convertMLeader(mleader: DwgMLeaderEntity) {
+  private convertMLeader(mleader: DwgMultiLeaderEntity) {
     const dbEntity = new AcDbMLeader()
-    const raw = mleader as DwgMLeaderEntity & Record<string, unknown>
+    const raw = mleader as DwgMultiLeaderEntity & Record<string, unknown>
 
-    dbEntity.leaderLineType = (this.readNumber(raw, [
-      'multileaderType',
-      'leaderLineType',
-      'leaderType'
-    ]) ?? AcDbMLeaderLineType.StraightLeader) as AcDbMLeaderLineType
+    dbEntity.version = mleader.version
+    dbEntity.leaderStyleId = mleader.leaderStyleId
+    if (mleader.leaderStyleId) dbEntity.mleaderStyleId = mleader.leaderStyleId
+    dbEntity.propertyOverrideFlag = mleader.propertyOverrideFlag
+    dbEntity.leaderLineType = (mleader.leaderLineType ??
+      AcDbMLeaderLineType.StraightLeader) as AcDbMLeaderLineType
+    if (mleader.leaderLineColor != null) {
+      dbEntity.leaderLineColor = this.convertMLeaderEntityColor(
+        mleader.leaderLineColor
+      )
+    }
+    dbEntity.leaderLineTypeId = mleader.leaderLineTypeId
+    dbEntity.leaderLineWeight = mleader.leaderLineWeight
+    dbEntity.landingEnabled = mleader.landingEnabled
+    dbEntity.doglegEnabled = mleader.doglegEnabled ?? false
+    dbEntity.doglegLength = mleader.doglegLength ?? 0
+    dbEntity.arrowheadId = mleader.arrowheadId
+    dbEntity.arrowheadSize = mleader.arrowheadSize
+    dbEntity.textStyleId = mleader.textStyleId
+    dbEntity.textLeftAttachmentType = mleader.textLeftAttachmentType
+    dbEntity.textRightAttachmentType = mleader.textRightAttachmentType
+    dbEntity.textAngleType = mleader.textAngleType
+    dbEntity.textAlignmentType = mleader.textAlignmentType
+    if (mleader.textColor != null) {
+      dbEntity.textColor = this.convertMLeaderEntityColor(mleader.textColor)
+    }
+    dbEntity.textFrameEnabled = mleader.textFrameEnabled
+    dbEntity.landingGap = mleader.landingGap
+    dbEntity.textAttachment = mleader.textAttachment
+    dbEntity.textFlowDirection = mleader.textFlowDirection
+    if (this.isValidHandleId(mleader.blockContentId)) {
+      dbEntity.blockContentId = mleader.blockContentId
+    }
+    if (mleader.blockContentColor != null) {
+      dbEntity.blockContentColor = this.convertMLeaderEntityColor(
+        mleader.blockContentColor
+      )
+    }
+    dbEntity.blockContentRotation = mleader.blockContentRotation
+    dbEntity.blockContentConnectionType = mleader.blockContentConnectionType
+    dbEntity.annotativeScaleEnabled = mleader.annotativeScaleEnabled
+    dbEntity.arrowheadOverrides = mleader.arrowheadOverrides
+      ? mleader.arrowheadOverrides.map(
+          (item: { index: number; handle: string }) => ({ ...item })
+        )
+      : []
+    dbEntity.blockAttributes = mleader.blockAttributes
+      ? mleader.blockAttributes.map(
+          (item: {
+            id?: string
+            index?: number
+            width?: number
+            text?: string
+          }) => ({ ...item })
+        )
+      : []
+    dbEntity.textDirectionNegative = mleader.textDirectionNegative
+    dbEntity.textAlignInIPE = mleader.textAlignInIPE
+    dbEntity.bottomTextAttachmentDirection =
+      mleader.bottomTextAttachmentDirection
+    dbEntity.topTextAttachmentDirection = mleader.topTextAttachmentDirection
+    dbEntity.contentScale = mleader.contentScale
+    dbEntity.textLineSpacingStyle = mleader.textLineSpacingStyle
+    if (mleader.textBackgroundColor != null) {
+      dbEntity.textBackgroundColor = this.convertMLeaderEntityColor(
+        mleader.textBackgroundColor
+      )
+    }
+    dbEntity.textBackgroundScaleFactor = mleader.textBackgroundScaleFactor
+    dbEntity.textBackgroundTransparency = mleader.textBackgroundTransparency
+    dbEntity.textBackgroundColorOn = mleader.textBackgroundColorOn
+    dbEntity.textFillOn = mleader.textFillOn
+    dbEntity.textColumnType = mleader.textColumnType
+    dbEntity.textUseAutoHeight = mleader.textUseAutoHeight
+    dbEntity.textColumnWidth = mleader.textColumnWidth
+    dbEntity.textColumnGutterWidth = mleader.textColumnGutterWidth
+    dbEntity.textColumnFlowReversed = mleader.textColumnFlowReversed
+    dbEntity.textColumnHeight = mleader.textColumnHeight
+    dbEntity.textUseWordBreak = mleader.textUseWordBreak
+    dbEntity.hasMText = mleader.hasMText
+    dbEntity.hasBlock = mleader.hasBlock
+    dbEntity.planeNormalReversed = mleader.planeNormalReversed
+
+    if (mleader.blockContentScale) {
+      dbEntity.blockContentScale = new AcGeVector3d(mleader.blockContentScale)
+    }
+    if (mleader.contentBasePosition) {
+      dbEntity.contentBasePosition = new AcGePoint3d().copy(
+        mleader.contentBasePosition
+      )
+    }
+    if (mleader.textAnchor) {
+      dbEntity.textAnchor = new AcGePoint3d().copy(mleader.textAnchor)
+    }
+    if (mleader.planeOrigin) {
+      dbEntity.planeOrigin = new AcGePoint3d().copy(mleader.planeOrigin)
+    }
+    if (mleader.planeXAxisDirection) {
+      dbEntity.planeXAxisDirection = new AcGeVector3d(
+        mleader.planeXAxisDirection
+      )
+    }
+    if (mleader.planeYAxisDirection) {
+      dbEntity.planeYAxisDirection = new AcGeVector3d(
+        mleader.planeYAxisDirection
+      )
+    }
+
+    const rawTextContent = raw.textContent as unknown
+    const rawTextContentRecord =
+      rawTextContent && typeof rawTextContent === 'object'
+        ? (rawTextContent as Record<string, unknown>)
+        : undefined
+    const hasMTextContent =
+      (typeof rawTextContent === 'string' && rawTextContent.length > 0) ||
+      this.readString(rawTextContentRecord ?? {}, ['text', 'contents']) !=
+        null ||
+      this.readString(raw, ['text', 'contents', 'mtext']) != null
 
     const contentType =
-      this.readNumber(raw, ['contentType']) ??
-      (mleader.textContent
+      mleader.contentType ??
+      (hasMTextContent
         ? AcDbMLeaderContentType.MTextContent
         : mleader.blockContent
           ? AcDbMLeaderContentType.BlockContent
           : AcDbMLeaderContentType.NoneContent)
     dbEntity.contentType = contentType as AcDbMLeaderContentType
 
-    dbEntity.doglegEnabled =
-      this.readBoolean(raw, ['doglegEnabled', 'enableDogleg']) ?? false
-    dbEntity.doglegLength = this.readNumber(raw, ['doglegLength']) ?? 0
-    if (mleader.landingPoint) dbEntity.landingPoint = mleader.landingPoint
-    if (mleader.doglegVector) dbEntity.doglegVector = mleader.doglegVector
-
-    const styleId = this.readString(raw, [
-      'mleaderStyleId',
-      'mLeaderStyleId',
-      'mleaderStyleHandle',
-      'styleHandle',
-      'styleName'
-    ])
-    if (styleId) dbEntity.mleaderStyleId = styleId
-
     const normal = this.readPoint(raw, ['normal', 'extrusionDirection'])
     if (normal) dbEntity.normal = normal
 
-    const textContent = mleader.textContent as
-      | (NonNullable<DwgMLeaderEntity['textContent']> & Record<string, unknown>)
-      | undefined
     const textStyleName =
-      this.readString(textContent ?? {}, ['styleName', 'textStyleName']) ??
+      this.readString(rawTextContentRecord ?? {}, [
+        'styleName',
+        'textStyleName',
+        'textStyle'
+      ]) ??
       this.readString(raw, ['textStyleName', 'textStyle', 'styleName'])
     if (textStyleName) dbEntity.textStyleName = textStyleName
 
-    dbEntity.textHeight =
-      this.readNumber(textContent ?? {}, ['textHeight', 'height']) ??
-      this.readNumber(raw, [
+    const textHeight =
+      this.readPositiveNumber(rawTextContentRecord ?? {}, [
+        'textHeight',
+        'height'
+      ]) ??
+      this.readPositiveNumber(raw, [
         'textHeight',
         'mtextHeight',
         'textContentHeight'
       ]) ??
-      dbEntity.textHeight
-    dbEntity.textWidth =
-      this.readNumber(textContent ?? {}, ['textWidth', 'width']) ??
-      this.readNumber(raw, ['textWidth', 'mtextWidth', 'textContentWidth']) ??
-      dbEntity.textWidth
+      this.readPositiveNumber(raw, ['arrowheadSize', 'contentScale'])
+    if (textHeight != null) dbEntity.textHeight = textHeight
 
+    const textWidth =
+      this.readPositiveNumber(rawTextContentRecord ?? {}, [
+        'textWidth',
+        'width'
+      ]) ??
+      this.readPositiveNumber(raw, [
+        'textWidth',
+        'mtextWidth',
+        'textContentWidth'
+      ])
+    if (textWidth != null) dbEntity.textWidth = textWidth
+    dbEntity.textLineSpacingFactor =
+      this.readNumber(rawTextContentRecord ?? {}, [
+        'lineSpacingFactor',
+        'textLineSpacingFactor'
+      ]) ??
+      this.readNumber(raw, ['textLineSpacingFactor']) ??
+      dbEntity.textLineSpacingFactor
     const textRotation =
-      this.readNumber(textContent ?? {}, ['textRotation', 'rotation']) ??
+      this.readNumber(rawTextContentRecord ?? {}, [
+        'textRotation',
+        'rotation'
+      ]) ??
       this.readNumber(raw, [
         'textRotation',
         'mtextRotation',
         'textContentRotation'
       ])
-    if (textRotation != null) dbEntity.textRotation = textRotation
+    if (textRotation != null) {
+      dbEntity.textRotation = textRotation
+    }
 
     const textDirection = this.readPoint(raw, [
       'textDirection',
@@ -881,9 +999,15 @@ export class AcDbEntityConverter {
       'textAttachmentPoint',
       'attachmentPoint'
     ])
-    if (textAttachmentPoint != null) {
+    if (textAttachmentPoint != null && textAttachmentPoint !== 0) {
       dbEntity.textAttachmentPoint =
         textAttachmentPoint as unknown as AcGiMTextAttachmentPoint
+    }
+
+    const textAttachmentDirection = mleader.textAttachmentDirection
+    if (textAttachmentDirection != null) {
+      dbEntity.textAttachmentDirection =
+        textAttachmentDirection as unknown as AcDbMLeaderTextAttachmentDirection
     }
 
     const textDrawingDirection = this.readNumber(raw, [
@@ -895,71 +1019,89 @@ export class AcDbEntityConverter {
         textDrawingDirection as unknown as AcGiMTextFlowDirection
     }
 
-    if (mleader.textContent?.text != null && mleader.textContent.anchorPoint) {
-      dbEntity.mtextContent = {
-        text: mleader.textContent.text,
-        anchorPoint: mleader.textContent.anchorPoint
-      }
-    } else {
-      const text = this.readString(raw, ['text', 'contents', 'mtext'])
-      const anchorPoint = this.readPoint(raw, [
+    const text =
+      typeof rawTextContent === 'string'
+        ? rawTextContent
+        : (this.readString(rawTextContentRecord ?? {}, ['text', 'contents']) ??
+          this.readString(raw, ['text', 'contents', 'mtext']))
+    const anchorPoint =
+      this.readPoint(rawTextContentRecord ?? {}, [
+        'anchorPoint',
+        'textAnchor',
         'textLocation',
         'textPosition',
         'textAnchorPoint'
+      ]) ??
+      this.readPoint(raw, [
+        'textAnchor',
+        'textLocation',
+        'textPosition',
+        'textAnchorPoint',
+        'contentBasePosition'
       ])
-      if (text != null && anchorPoint) {
-        dbEntity.mtextContent = { text, anchorPoint }
-      }
+    if (text != null && anchorPoint) {
+      dbEntity.mtextContent = { text, anchorPoint }
     }
 
-    if (mleader.blockContent?.blockHandle && mleader.blockContent.position) {
-      dbEntity.blockContent = {
-        blockHandle: mleader.blockContent.blockHandle,
-        position: mleader.blockContent.position
-      }
-    } else {
-      const blockHandle = this.readString(raw, [
-        'blockHandle',
-        'blockContentHandle',
-        'blockId'
-      ])
-      const blockPosition = this.readPoint(raw, [
-        'blockPosition',
-        'blockContentPosition'
-      ])
-      if (blockHandle && blockPosition) {
+    if (mleader.blockContent) {
+      const blockRecord = mleader.blockContent as unknown as Record<
+        string,
+        unknown
+      >
+      const blockContentId = mleader.blockContent.blockContentId
+      if (this.isValidHandleId(blockContentId)) {
+        const rawBlockColor = this.readMLeaderEntityColor(blockRecord, ['color'])
         dbEntity.blockContent = {
-          blockHandle,
-          position: blockPosition
+          blockContentId,
+          normal: this.readPoint(blockRecord, ['normal']),
+          position: mleader.blockContent.position,
+          scale: this.readPoint(blockRecord, ['scale']),
+          rotation: this.readNumber(blockRecord, ['rotation']),
+          color: rawBlockColor,
+          transformationMatrix: Array.isArray(
+            mleader.blockContent.transformationMatrix
+          )
+            ? mleader.blockContent.transformationMatrix
+            : []
         }
       }
+    } else if (this.isValidHandleId(mleader.blockContentId)) {
+      dbEntity.blockContent = {
+        blockContentId: mleader.blockContentId,
+        scale: mleader.blockContentScale,
+        rotation: mleader.blockContentRotation,
+        color: dbEntity.blockContentColor,
+        transformationMatrix: []
+      }
     }
 
-    mleader.leaders?.forEach(leader => {
-      const leaderIndex = dbEntity.addLeader({
-        landingPoint: leader.landingPoint ?? mleader.landingPoint,
-        doglegVector: leader.doglegVector ?? mleader.doglegVector,
-        doglegLength: leader.doglegLength ?? mleader.doglegLength
-      })
-      leader.leaderLines?.forEach(line => {
-        const lineIndex = dbEntity.addLeaderLine(
-          leaderIndex,
-          line.vertices ?? []
-        )
-        line.breaks?.forEach(item => {
-          dbEntity.addBreak(leaderIndex, lineIndex, item.start, item.end)
-        })
+    this.readMLeaderLeaders(raw)?.forEach(leader => {
+      dbEntity.addLeader({
+        lastLeaderLinePoint: leader.lastLeaderLinePoint,
+        lastLeaderLinePointSet: leader.lastLeaderLinePointSet,
+        doglegVector: leader.doglegVector,
+        doglegVectorSet: leader.doglegVectorSet,
+        doglegLength: leader.doglegLength ?? mleader.doglegLength,
+        breaks: leader.breaks,
+        leaderBranchIndex: leader.leaderBranchIndex,
+        leaderLines: leader.leaderLines
       })
     })
 
     if (dbEntity.numberOfLeaders === 0) {
       this.readLeaderLineArray(raw)?.forEach(line => {
-        const leaderIndex = dbEntity.addLeader({
-          landingPoint: mleader.landingPoint,
-          doglegVector: mleader.doglegVector,
+        dbEntity.addLeader({
           doglegLength: mleader.doglegLength
         })
-        dbEntity.addLeaderLine(leaderIndex, line)
+        dbEntity.addLeaderLine(dbEntity.numberOfLeaders - 1, line)
+      })
+    }
+
+    if (dbEntity.numberOfLeaders === 0 && mleader.contentBasePosition) {
+      dbEntity.addLeader({
+        lastLeaderLinePoint: mleader.contentBasePosition,
+        lastLeaderLinePointSet: true,
+        doglegLength: mleader.doglegLength
       })
     }
 
@@ -1288,12 +1430,38 @@ export class AcDbEntityConverter {
     }
   }
 
+  private convertMLeaderEntityColor(color: number) {
+    return decodeMLeaderStyleRawColor(color)
+  }
+
+  private readMLeaderEntityColor(
+    source: Record<string, unknown>,
+    names: string[]
+  ) {
+    for (const name of names) {
+      const value = source[name]
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return decodeMLeaderStyleRawColor(value)
+      }
+    }
+    return undefined
+  }
+
+  private isValidHandleId(id: string | undefined): id is string {
+    return id != null && id !== '' && id !== '0'
+  }
+
   private readNumber(source: Record<string, unknown>, names: string[]) {
     for (const name of names) {
       const value = source[name]
       if (typeof value === 'number' && Number.isFinite(value)) return value
     }
     return undefined
+  }
+
+  private readPositiveNumber(source: Record<string, unknown>, names: string[]) {
+    const value = this.readNumber(source, names)
+    return value != null && value > 0 ? value : undefined
   }
 
   private readString(source: Record<string, unknown>, names: string[]) {
@@ -1348,6 +1516,105 @@ export class AcDbEntityConverter {
       return line.length > 0 ? [line] : undefined
     }
     return undefined
+  }
+
+  private readMLeaderLeaders(
+    source: Record<string, unknown>
+  ): ParsedMLeaderLeader[] | undefined {
+    const leaders = source.leaderSections
+    if (!Array.isArray(leaders)) return undefined
+
+    const dbLeaders: ParsedMLeaderLeader[] = []
+    leaders.forEach(leader => {
+      if (!leader || typeof leader !== 'object') return
+      const leaderRecord = leader as Record<string, unknown>
+      const leaderLines = leaderRecord.leaderLines
+      const lines: ParsedMLeaderLine[] | undefined = Array.isArray(leaderLines)
+        ? leaderLines.reduce<ParsedMLeaderLine[]>((result, line) => {
+            const dbLine = this.readMLeaderLine(line)
+            if (dbLine) result.push(dbLine)
+            return result
+          }, [])
+        : undefined
+
+      const dbLeader: ParsedMLeaderLeader = {}
+      const lastLeaderLinePoint = this.readPoint(leaderRecord, [
+        'lastLeaderLinePoint'
+      ])
+      const doglegVector = this.readPoint(leaderRecord, ['doglegVector'])
+      const doglegLength = this.readNumber(leaderRecord, ['doglegLength'])
+      const leaderBreaks = this.readMLeaderBreaks(leaderRecord.breaks)
+      const leaderBranchIndex = this.readNumber(leaderRecord, [
+        'leaderBranchIndex'
+      ])
+      if (lastLeaderLinePoint)
+        dbLeader.lastLeaderLinePoint = lastLeaderLinePoint
+      if (leaderRecord.lastLeaderLinePointSet != null) {
+        dbLeader.lastLeaderLinePointSet = this.readBoolean(leaderRecord, [
+          'lastLeaderLinePointSet'
+        ])
+      }
+      if (doglegVector) dbLeader.doglegVector = doglegVector
+      if (leaderRecord.doglegVectorSet != null) {
+        dbLeader.doglegVectorSet = this.readBoolean(leaderRecord, [
+          'doglegVectorSet'
+        ])
+      }
+      if (doglegLength != null) dbLeader.doglegLength = doglegLength
+      if (leaderBreaks) dbLeader.breaks = leaderBreaks
+      if (leaderBranchIndex != null) {
+        dbLeader.leaderBranchIndex = leaderBranchIndex
+      }
+      if (lines) dbLeader.leaderLines = lines
+      dbLeaders.push(dbLeader)
+    })
+    return dbLeaders
+  }
+
+  private readMLeaderLine(value: unknown): ParsedMLeaderLine | undefined {
+    if (!value || typeof value !== 'object') return undefined
+    const lineRecord = value as Record<string, unknown>
+    const vertices = lineRecord.vertices
+    const dbVertices = Array.isArray(vertices)
+      ? vertices.filter(point => this.isPointLike(point))
+      : []
+
+    const dbBreaks = this.readMLeaderBreaks(lineRecord.breaks)
+    const breakPointIndexes = Array.isArray(lineRecord.breakPointIndexes)
+      ? lineRecord.breakPointIndexes.filter(
+          (item): item is number => typeof item === 'number'
+        )
+      : undefined
+    const leaderLineIndex = this.readNumber(lineRecord, ['leaderLineIndex'])
+
+    return dbVertices.length > 0 || (dbBreaks && dbBreaks.length > 0)
+      ? {
+          vertices: dbVertices,
+          breakPointIndexes,
+          leaderLineIndex,
+          breaks: dbBreaks
+        }
+      : undefined
+  }
+
+  private readMLeaderBreaks(value: unknown): ParsedMLeaderBreak[] | undefined {
+    if (!Array.isArray(value)) return undefined
+
+    const breaks = value
+      .map((item): ParsedMLeaderBreak | undefined => {
+        if (!item || typeof item !== 'object') return undefined
+        const breakRecord = item as Record<string, unknown>
+        const start = this.readPoint(breakRecord, ['start'])
+        const end = this.readPoint(breakRecord, ['end'])
+        const index = this.readNumber(breakRecord, ['index'])
+        if (!start || !end) return undefined
+        const parsed: ParsedMLeaderBreak = { start, end }
+        if (index != null) parsed.index = index
+        return parsed
+      })
+      .filter((item): item is ParsedMLeaderBreak => !!item)
+
+    return breaks.length > 0 ? breaks : undefined
   }
 
   private isPointLike(value: unknown): value is AcGePoint3dLike {

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -30,6 +30,7 @@ import {
   AcGiRenderMode,
   ByLayer,
   createWorkerApi,
+  DEFAULT_MLEADER_STYLE,
   DEFAULT_TEXT_STYLE,
   VPORT_FALLBACK_CENTER_2D,
   VPORT_FALLBACK_LLC,
@@ -45,10 +46,12 @@ import {
   DwgEntity,
   DwgInsertEntity,
   DwgMTextEntity,
+  DwgMultiLeaderEntity,
   DwgTextEntity
 } from '@mlightcad/libredwg-web'
 
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
+import { AcDbObjectConverter } from './AcDbObjectConverter'
 
 const MODEL_SPACE = '*MODEL_SPACE'
 
@@ -127,12 +130,21 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     })
 
     const fonts: Set<string> = new Set<string>()
+    // Shape styles (standardFlag bit 0) define SHX shape fonts used by SHAPE entities.
+    dwg.tables.STYLE.entries.forEach(style => {
+      if (style.standardFlag & 1) {
+        const fontName = getFontName(style.font)
+        if (fontName) {
+          fonts.add(fontName)
+        }
+      }
+    })
     this.getFontsInBlock(dwg.entities, blockMap, styleMap, fonts)
     return Array.from(fonts)
   }
 
   /**
-   * Iterate entities in model space to get fonts used by text, mtext and insert entities
+   * Iterate entities in model space to get fonts used by text, mtext, shape and insert entities
    */
   private getFontsInBlock(
     entities: DwgEntity[],
@@ -153,26 +165,18 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         const text = entity as DwgTextEntity
         const fontNames = styleMap.get(text.styleName)
         fontNames?.forEach(name => fonts.add(name))
+      } else if (entity.type == 'SHAPE') {
+        const shape = entity as DwgEntity & { styleName?: string }
+        const fontNames = shape.styleName
+          ? styleMap.get(shape.styleName)
+          : undefined
+        fontNames?.forEach(name => fonts.add(name))
       } else if (entity.type == 'MULTILEADER' || entity.type == 'MLEADER') {
-        const mleader = entity as DwgEntity & Record<string, unknown>
-        const textContent = mleader.textContent as
-          | Record<string, unknown>
-          | undefined
-        const text =
-          typeof textContent?.text === 'string' ? textContent.text : ''
+        const mleader = entity as DwgMultiLeaderEntity
+        const text = mleader.textContent ?? ''
         ;[...text.matchAll(regex)].forEach(match => {
           fonts.add(match[1].toLowerCase())
         })
-        const styleName =
-          typeof textContent?.styleName === 'string'
-            ? textContent.styleName
-            : typeof mleader.textStyleName === 'string'
-              ? mleader.textStyleName
-              : typeof mleader.styleName === 'string'
-                ? mleader.styleName
-                : undefined
-        const fontNames = styleName ? styleMap.get(styleName) : undefined
-        fontNames?.forEach(name => fonts.add(name))
       } else if (entity.type == 'INSERT') {
         const insert = entity as DwgInsertEntity
         const block = blockMap.get(insert.name)
@@ -560,6 +564,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     db.pdmode = header.PDMODE ?? 0
     db.pdsize = header.PDSIZE ?? 0.0
     db.textstyle = header.TEXTSTYLE ?? DEFAULT_TEXT_STYLE
+    const cmleaderStyle =
+      this.normalizeHeaderStringValue(
+        (header as { CMLEADERSTYLE?: string }).CMLEADERSTYLE
+      ) ?? DEFAULT_MLEADER_STYLE
+    db.cmleaderstyle = cmleaderStyle
   }
 
   private processCommonTableEntryAttrs(
@@ -576,6 +585,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   protected processObjects(model: DwgDatabase, db: AcDbDatabase) {
     this.processLayouts(model, db)
     this.processImageDefs(model, db)
+    this.processMLeaderStyles(model, db)
   }
 
   private processLayouts(model: DwgDatabase, db: AcDbDatabase) {
@@ -629,6 +639,18 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     })
   }
 
+  private processMLeaderStyles(model: DwgDatabase, db: AcDbDatabase) {
+    const mleaderStyles = model.objects.MLEADERSTYLE
+    if (!mleaderStyles?.length) return
+
+    const mleaderStyleDict = db.objects.mleaderStyle
+    const objectConverter = new AcDbObjectConverter()
+    mleaderStyles.forEach(style => {
+      const dbStyle = objectConverter.convertMLeaderStyle(style)
+      mleaderStyleDict.setAt(dbStyle.objectId, dbStyle)
+    })
+  }
+
   private processCommonObjectAttrs(
     object: DwgCommonObject,
     dbObject: AcDbObject
@@ -669,5 +691,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
 
   private isModelSpace(name: string) {
     return name && name.toUpperCase() == MODEL_SPACE
+  }
+
+  private normalizeHeaderStringValue(value: unknown) {
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
   }
 }

--- a/packages/libredwg-converter/src/AcDbObjectConverter.ts
+++ b/packages/libredwg-converter/src/AcDbObjectConverter.ts
@@ -1,0 +1,138 @@
+import {
+  AcDbMLeaderStyle,
+  AcDbObject,
+  decodeMLeaderStyleRawColor
+} from '@mlightcad/data-model'
+import {
+  DwgCommonObject,
+  DwgMLeaderStyleObject
+} from '@mlightcad/libredwg-web'
+
+/**
+ * Converts libredwg object records to AcDbObject instances.
+ */
+export class AcDbObjectConverter {
+  /**
+   * Converts a DWG MLEADERSTYLE object to an AcDbMLeaderStyle.
+   */
+  convertMLeaderStyle(style: DwgMLeaderStyleObject) {
+    const dbObject = new AcDbMLeaderStyle()
+    dbObject.unknown1 = style.unknown1
+    if (style.contentType != null) dbObject.contentType = style.contentType
+    if (style.drawMLeaderOrderType != null) {
+      dbObject.drawMLeaderOrderType = style.drawMLeaderOrderType
+    }
+    if (style.drawLeaderOrderType != null) {
+      dbObject.drawLeaderOrderType = style.drawLeaderOrderType
+    }
+    if (style.maxLeaderSegmentPoints != null) {
+      dbObject.maxLeaderSegmentPoints = style.maxLeaderSegmentPoints
+    }
+    if (style.firstSegmentAngleConstraint != null) {
+      dbObject.firstSegmentAngleConstraint = style.firstSegmentAngleConstraint
+    }
+    if (style.secondSegmentAngleConstraint != null) {
+      dbObject.secondSegmentAngleConstraint = style.secondSegmentAngleConstraint
+    }
+    if (style.leaderLineType != null) {
+      dbObject.leaderLineType = style.leaderLineType
+    }
+    if (style.leaderLineColor != null) {
+      dbObject.leaderLineColor = decodeMLeaderStyleRawColor(
+        style.leaderLineColor
+      )
+    }
+    dbObject.leaderLineTypeId = style.leaderLineTypeId
+    if (style.leaderLineWeight != null) {
+      dbObject.leaderLineWeight = style.leaderLineWeight
+    }
+    if (style.landingEnabled != null) {
+      dbObject.landingEnabled = style.landingEnabled
+    }
+    if (style.landingGap != null) dbObject.landingGap = style.landingGap
+    if (style.doglegEnabled != null)
+      dbObject.doglegEnabled = style.doglegEnabled
+    if (style.doglegLength != null) dbObject.doglegLength = style.doglegLength
+    if (style.description != null) dbObject.description = style.description
+    dbObject.arrowheadId = style.arrowheadId
+    if (style.arrowheadSize != null)
+      dbObject.arrowheadSize = style.arrowheadSize
+    if (style.defaultMTextContents != null) {
+      dbObject.defaultMTextContents = style.defaultMTextContents
+    }
+    dbObject.textStyleId = style.textStyleId
+    if (style.textLeftAttachmentType != null) {
+      dbObject.textLeftAttachmentType = style.textLeftAttachmentType
+    }
+    if (style.textAngleType != null)
+      dbObject.textAngleType = style.textAngleType
+    if (style.textAlignmentType != null) {
+      dbObject.textAlignmentType = style.textAlignmentType
+    }
+    if (style.textRightAttachmentType != null) {
+      dbObject.textRightAttachmentType = style.textRightAttachmentType
+    }
+    if (style.textColor != null) {
+      dbObject.textColor = decodeMLeaderStyleRawColor(style.textColor)
+    }
+    if (style.textHeight != null) dbObject.textHeight = style.textHeight
+    if (style.textFrameEnabled != null) {
+      dbObject.textFrameEnabled = style.textFrameEnabled
+    }
+    if (style.textAlignAlwaysLeft != null) {
+      dbObject.textAlignAlwaysLeft = style.textAlignAlwaysLeft
+    }
+    if (style.alignSpace != null) dbObject.alignSpace = style.alignSpace
+    dbObject.blockContentId = style.blockContentId
+    if (style.blockContentColor != null) {
+      dbObject.blockContentColor = decodeMLeaderStyleRawColor(
+        style.blockContentColor
+      )
+    }
+    if (style.blockContentScale) {
+      dbObject.blockContentScale = {
+        x: style.blockContentScale.x,
+        y: style.blockContentScale.y,
+        z: style.blockContentScale.z ?? 1
+      }
+    }
+    if (style.blockContentScaleEnabled != null) {
+      dbObject.blockContentScaleEnabled = style.blockContentScaleEnabled
+    }
+    if (style.blockContentRotation != null) {
+      dbObject.blockContentRotation = style.blockContentRotation
+    }
+    if (style.blockContentRotationEnabled != null) {
+      dbObject.blockContentRotationEnabled = style.blockContentRotationEnabled
+    }
+    if (style.blockContentConnectionType != null) {
+      dbObject.blockContentConnectionType = style.blockContentConnectionType
+    }
+    if (style.scale != null) dbObject.scale = style.scale
+    if (style.overwritePropertyValue != null) {
+      dbObject.overwritePropertyValue = style.overwritePropertyValue
+    }
+    if (style.annotative != null) dbObject.annotative = style.annotative
+    if (style.breakGapSize != null) dbObject.breakGapSize = style.breakGapSize
+    if (style.textAttachmentDirection != null) {
+      dbObject.textAttachmentDirection = style.textAttachmentDirection
+    }
+    if (style.bottomTextAttachmentDirection != null) {
+      dbObject.bottomTextAttachmentDirection =
+        style.bottomTextAttachmentDirection
+    }
+    if (style.topTextAttachmentDirection != null) {
+      dbObject.topTextAttachmentDirection = style.topTextAttachmentDirection
+    }
+    dbObject.unknown2 = style.unknown2
+    this.processCommonAttrs(style, dbObject)
+    return dbObject
+  }
+
+  private processCommonAttrs(object: DwgCommonObject, dbObject: AcDbObject) {
+    dbObject.objectId = object.handle
+    if (object.ownerHandle != null) {
+      dbObject.ownerId = object.ownerHandle
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/libredwg-converter:
     dependencies:
       '@mlightcad/libredwg-web':
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.7.5
+        version: 0.7.5
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1409,8 +1409,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.4':
-    resolution: {integrity: sha512-l6qHbM6NgyCsI308J4hrfCb97jvsYZkwviPY6ZthQPMXvy2a1DNFb00TlOzwPjhbT1kdsHaJ0EWuN+L0eNfVng==}
+  '@mlightcad/libredwg-web@0.7.5':
+    resolution: {integrity: sha512-oPV5Wm7I02PXfPt5NE/nM+wtei/On2fyUbCxejGXUiPmIyFJA0spykmTnBzKMCcFDmC5wNDzZptN2VQbYeJwZQ==}
     engines: {node: '>=20'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6359,7 +6359,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.4': {}
+  '@mlightcad/libredwg-web@0.7.5': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

- Migrate AcDbMLeader component colors (leader line, text, block content, text background) from raw int32 values to AcCmColor across data-model, dxf-json-converter, and libredwg-converter.
- Add AcDbObjectConverter for MLEADERSTYLE objects with proper raw-color decoding via decodeMLeaderStyleRawColor.
- Improve libredwg MLeader conversion: handle leader sections, ignore zero text attachment point, reject null blockContentId handle "0", and resolve text style names more robustly.
- Add SHAPE entity conversion in libredwg-converter with OCS-to-WCS insertion point transform.
- Forward the delay flag to nested MText rendering in AcDbMLeader so worker render mode can finish geometry asynchronously.
- Bump @mlightcad/libredwg-web to ^0.7.5.

## Test plan

- [x] Run libredwg-converter tests (AcDbMLeaderConverter.spec.ts, AcDbEntitiyConverter.spec.ts)
- [x] Run data-model AcDbMLeader.spec.ts
- [x] Run dxf-json-converter AcDbEntityConverter.spec.ts
- [ ] Verify MLeader entities from DWG files render with correct colors and text styles
- [ ] Verify SHAPE entities convert and display correctly