### PR TITLE
feat(data-model): implement grip point editing across entity types

### DIFF
--- a/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
@@ -1,4 +1,4 @@
-import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 import { acdbHostApplicationServices } from '../src/base'
 import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
 import { AcDbAlignedDimension, AcDbLine } from '../src/entity'
@@ -151,5 +151,36 @@ describe('AcDbAlignedDimension', () => {
 
     expect(dim.geometricExtents.min).toMatchObject({ x: 5, y: 5, z: 0 })
     expect(dim.geometricExtents.max).toMatchObject({ x: 20, y: 12, z: 0 })
+  })
+
+  it('returns definition and text grip points', () => {
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.textPosition = new AcGePoint3d(3, 4, 0)
+
+    const grips = dim.subGetGripPoints()
+
+    expect(grips).toHaveLength(4)
+    expect(grips[0]).toBe(dim.xLine1Point)
+    expect(grips[1]).toBe(dim.xLine2Point)
+    expect(grips[2]).toBe(dim.dimLinePoint)
+    expect(grips[3]).toBe(dim.textPosition)
+  })
+
+  it('moves definition and text grip points', () => {
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.textPosition = new AcGePoint3d(3, 4, 0)
+
+    dim.subMoveGripPointsAt([0, 3], new AcGeVector3d(1, 2, 0))
+
+    expect(dim.xLine1Point).toMatchObject({ x: 1, y: 2, z: 0 })
+    expect(dim.textPosition).toMatchObject({ x: 4, y: 6, z: 0 })
   })
 })

--- a/packages/data-model/__tests__/AcDbCircle.spec.ts
+++ b/packages/data-model/__tests__/AcDbCircle.spec.ts
@@ -62,14 +62,40 @@ describe('AcDbCircle', () => {
     expect(circle.geometricExtents.max).toMatchObject({ x: 12, y: 22, z: 0 })
   })
 
-  it('returns grip points with center point', () => {
-    const circle = new AcDbCircle(new AcGePoint3d(2, 3, 4), 5)
+  it('returns grip points with center and quadrant points', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(1, 2, 0), 3)
 
     const grips = circle.subGetGripPoints()
 
-    expect(grips).toHaveLength(1)
+    expect(grips).toHaveLength(5)
     expect(grips[0]).toBe(circle.center)
-    expect(grips[0]).toMatchObject({ x: 2, y: 3, z: 4 })
+    expect(grips[0]).toMatchObject({ x: 1, y: 2, z: 0 })
+    expect(grips[1].x).toBeCloseTo(4, 8)
+    expect(grips[1].y).toBeCloseTo(2, 8)
+    expect(grips[2].x).toBeCloseTo(1, 8)
+    expect(grips[2].y).toBeCloseTo(5, 8)
+    expect(grips[3].x).toBeCloseTo(-2, 8)
+    expect(grips[3].y).toBeCloseTo(2, 8)
+    expect(grips[4].x).toBeCloseTo(1, 8)
+    expect(grips[4].y).toBeCloseTo(-1, 8)
+  })
+
+  it('translates the circle when moving grip index 0', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(2, 3, 4), 5)
+
+    circle.subMoveGripPointsAt([0], new AcGeVector3d(1, -2, 3))
+
+    expect(circle.center).toMatchObject({ x: 3, y: 1, z: 7 })
+    expect(circle.radius).toBe(5)
+  })
+
+  it('scales the circle when moving a quadrant grip', () => {
+    const circle = new AcDbCircle(new AcGePoint3d(0, 0, 0), 5)
+
+    circle.subMoveGripPointsAt([1], new AcGeVector3d(3, 0, 0))
+
+    expect(circle.center).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(circle.radius).toBeCloseTo(8, 8)
   })
 
   it('collects center and centroid osnap points', () => {

--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -652,4 +652,26 @@ describe('AcDbHatch', () => {
     hatch.add(createRectLoop(2, 2, 6, 6))
     expect(hatch.area).toBeCloseTo(64, 8)
   })
+
+  it('returns boundary grip points for non-associative hatches', () => {
+    const hatch = new AcDbHatch()
+    hatch.associative = false
+    hatch.add(createRectLoop(0, 0, 10, 5))
+
+    const grips = hatch.subGetGripPoints()
+
+    expect(grips).toHaveLength(4)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(grips[1]).toMatchObject({ x: 10, y: 0, z: 0 })
+    expect(grips[2]).toMatchObject({ x: 10, y: 5, z: 0 })
+    expect(grips[3]).toMatchObject({ x: 0, y: 5, z: 0 })
+  })
+
+  it('returns no grip points for associative hatches', () => {
+    const hatch = new AcDbHatch()
+    hatch.associative = true
+    hatch.add(createRectLoop(0, 0, 10, 5))
+
+    expect(hatch.subGetGripPoints()).toEqual([])
+  })
 })

--- a/packages/data-model/__tests__/AcDbLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbLine.spec.ts
@@ -1,4 +1,4 @@
-import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcGeMatrix3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
 import { AcDbLine } from '../src/entity'
@@ -106,6 +106,24 @@ describe('AcDbLine', () => {
     expect(gripPoints[0]).toMatchObject({ x: 4, y: 1, z: 0 })
     expect(gripPoints[1]).toBe(line.startPoint)
     expect(gripPoints[2]).toBe(line.endPoint)
+  })
+
+  it('moves grip points by index', () => {
+    const line = new AcDbLine(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(10, 0, 0)
+    )
+
+    line.subMoveGripPointsAt([0], new AcGeVector3d(1, 2, 3))
+    expect(line.startPoint).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(line.endPoint).toMatchObject({ x: 11, y: 2, z: 3 })
+
+    line.subMoveGripPointsAt([1], new AcGeVector3d(-1, 0, 0))
+    expect(line.startPoint).toMatchObject({ x: 0, y: 2, z: 3 })
+    expect(line.endPoint).toMatchObject({ x: 11, y: 2, z: 3 })
+
+    line.subMoveGripPointsAt([2], new AcGeVector3d(0, 1, 0))
+    expect(line.endPoint).toMatchObject({ x: 11, y: 3, z: 3 })
   })
 
   it('computes osnap points for all supported modes', () => {

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -728,4 +728,23 @@ describe('AcDbMLine', () => {
     expect(after.max.x).toBeCloseTo(40)
     expect(after.max.y).toBeGreaterThan(before.max.y)
   })
+
+  it('returns grip points on the reference path', () => {
+    const db = createDb()
+    const style = new AcDbMlineStyle()
+    style.styleName = 'GRIP_STYLE'
+    style.elements = [
+      { offset: 0.5, color: createAciColor(3), lineType: 'BYLAYER' },
+      { offset: -0.5, color: createAciColor(5), lineType: 'BYLAYER' }
+    ]
+    db.objects.mlineStyle.setAt(style.styleName, style)
+
+    const mline = createBasicMline(style)
+    const grips = mline.subGetGripPoints()
+
+    expect(grips).toHaveLength(3)
+    expect(grips[0]).toBe(mline.startPosition)
+    expect(grips[1]).toMatchObject({ x: 10, y: 0, z: 0 })
+    expect(grips[2]).toMatchObject({ x: 20, y: 0, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -1,7 +1,8 @@
 import {
   AcGeMatrix3d,
   AcGePoint2d,
-  AcGePoint3d
+  AcGePoint3d,
+  AcGeVector3d
 } from '@mlightcad/geometry-engine'
 
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
@@ -162,6 +163,19 @@ describe('AcDbPolyline', () => {
       centerSnaps
     )
     expect(centerSnaps).toHaveLength(0)
+  })
+
+  it('moves vertex grip points by index', () => {
+    const polyline = new AcDbPolyline()
+    polyline.elevation = 2
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0))
+    polyline.addVertexAt(1, new AcGePoint2d(2, 0))
+    polyline.addVertexAt(2, new AcGePoint2d(2, 3))
+
+    polyline.subMoveGripPointsAt([1], new AcGeVector3d(1, 2, 0))
+
+    expect(polyline.getPoint2dAt(1)).toEqual(new AcGePoint2d(3, 2))
+    expect(polyline.getPoint3dAt(1)).toMatchObject({ x: 3, y: 2, z: 2 })
   })
 
   it('transforms points, updates elevation and flips bulges for mirrored transforms', () => {

--- a/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
@@ -142,4 +142,22 @@ describe('AcDbProxyEntity', () => {
     expect(extents.min).toMatchObject({ x: 0, y: 0, z: 0 })
     expect(extents.max).toMatchObject({ x: 10, y: 20, z: 0 })
   })
+
+  it('returns entity origins or extents corners as grip points', () => {
+    setupWorkingDatabase()
+    const entity = new AcDbProxyEntity()
+    entity.setEntityOrigins([new AcGePoint3d(1, 2, 3)])
+
+    expect(entity.subGetGripPoints()).toEqual([entity.entityOrigins[0]])
+
+    const extentsEntity = new AcDbProxyEntity()
+    extentsEntity.setProxyGraphic(
+      buildExtentsProxyGraphic([0, 0, 0], [10, 20, 0])
+    )
+    const grips = extentsEntity.subGetGripPoints()
+
+    expect(grips).toHaveLength(2)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(grips[1]).toMatchObject({ x: 10, y: 20, z: 0 })
+  })
 })

--- a/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
@@ -15,11 +15,21 @@ describe('AcDbSysVarManager', () => {
     )
 
     const oldPickbox = manager.getVar(AcDbSystemVariables.PICKBOX, db)
+    const oldGripObjLimit = manager.getVar(AcDbSystemVariables.GRIPOBJLIMIT, db)
     const events: string[] = []
     manager.events.sysVarChanged.addEventListener(e => events.push(e.name))
 
     manager.setVar(AcDbSystemVariables.PICKBOX, '12', db)
     expect(manager.getVar(AcDbSystemVariables.PICKBOX, db)).toBe(12)
+
+    expect(manager.getVar(AcDbSystemVariables.GRIPOBJLIMIT, db)).toBe(100)
+    manager.setVar(AcDbSystemVariables.GRIPOBJLIMIT, '50', db)
+    expect(manager.getVar(AcDbSystemVariables.GRIPOBJLIMIT, db)).toBe(50)
+    manager.setVar(AcDbSystemVariables.GRIPOBJLIMIT, 0, db)
+    expect(manager.getVar(AcDbSystemVariables.GRIPOBJLIMIT, db)).toBe(0)
+    expect(() =>
+      manager.setVar(AcDbSystemVariables.GRIPOBJLIMIT, 32768, db)
+    ).toThrow('Invalid GRIPOBJLIMIT value! Valid range is 0 to 32767.')
 
     manager.setVar(AcDbSystemVariables.DYNPROMPT, 'false', db)
     expect(manager.getVar(AcDbSystemVariables.DYNPROMPT, db)).toBe(false)
@@ -99,6 +109,11 @@ describe('AcDbSysVarManager', () => {
     ).toThrow('Invalid color value!')
 
     manager.setVar(AcDbSystemVariables.PICKBOX, oldPickbox as number, db)
+    manager.setVar(
+      AcDbSystemVariables.GRIPOBJLIMIT,
+      oldGripObjLimit as number,
+      db
+    )
   })
 
   it('supports registry helpers and defaults', () => {
@@ -163,6 +178,7 @@ describe('AcDbSysVarManager', () => {
     expect(manager.getDefaultValue(AcDbSystemVariables.POLARADDANG)).toBe('')
     expect(manager.getDefaultValue(AcDbSystemVariables.POLARMODE)).toBe(0)
     expect(manager.getDefaultValue(AcDbSystemVariables.POLARANG)).toBe(90)
+    expect(manager.getDefaultValue(AcDbSystemVariables.GRIPOBJLIMIT)).toBe(100)
     expect(manager.getAllDescriptors().length).toBeGreaterThan(0)
     expect(() => manager.getDefaultValue('__NOT_FOUND__')).toThrow(
       'System variable __not_found__ not found!'

--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -1,7 +1,8 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
-  AcGePoint3d
+  AcGePoint3d,
+  AcGeVector3d
 } from '@mlightcad/geometry-engine'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
@@ -258,5 +259,36 @@ describe('AcDbViewport', () => {
     expect(out).toContain('12\n4\n22\n5\n32\n6\n')
     expect(out).toContain('45\n33\n')
     expect(out).toContain('69\n4\n')
+  })
+
+  it('returns center and corner grip points', () => {
+    const viewport = new AcDbViewport()
+    viewport.width = 10
+    viewport.height = 6
+    viewport.centerPoint = new AcGePoint3d(2, 4, 0)
+
+    const grips = viewport.subGetGripPoints()
+
+    expect(grips).toHaveLength(5)
+    expect(grips[0]).toBe(viewport.centerPoint)
+    expect(grips[1]).toMatchObject({ x: -3, y: 1, z: 0 })
+    expect(grips[2]).toMatchObject({ x: 7, y: 1, z: 0 })
+    expect(grips[3]).toMatchObject({ x: 7, y: 7, z: 0 })
+    expect(grips[4]).toMatchObject({ x: -3, y: 7, z: 0 })
+  })
+
+  it('moves center and resizes from opposite corner grips', () => {
+    const viewport = new AcDbViewport()
+    viewport.width = 10
+    viewport.height = 6
+    viewport.centerPoint = new AcGePoint3d(2, 4, 0)
+
+    viewport.subMoveGripPointsAt([0], new AcGeVector3d(1, 1, 0))
+    expect(viewport.centerPoint).toMatchObject({ x: 3, y: 5, z: 0 })
+
+    viewport.subMoveGripPointsAt([2], new AcGeVector3d(2, 0, 0))
+    expect(viewport.width).toBeCloseTo(12)
+    expect(viewport.height).toBe(6)
+    expect(viewport.centerPoint).toMatchObject({ x: 4, y: 5, z: 0 })
   })
 })

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -252,6 +252,19 @@ export class AcDbSysVarManager {
       defaultValue: true
     })
     /**
+     * Suppresses the display of grips when the initial selection set includes
+     * more than the specified number of objects. Valid range is **0–32767**;
+     * `0` always displays grips. Saved in the registry (not in the drawing).
+     *
+     * @see https://help.autodesk.com/view/ACD/2022/ENU/?guid=GUID-705F3A42-4A2F-4B5C-A2A6-0CF8949B8ED5
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.GRIPOBJLIMIT,
+      type: 'number',
+      isDbVar: false,
+      defaultValue: 100
+    })
+    /**
      * Sets the default angle, in radians, for new hatch patterns in this session.
      */
     this.registerVar({
@@ -656,6 +669,13 @@ export class AcDbSysVarManager {
           }
           value = tmp
         }
+      }
+      if (name === AcDbSystemVariables.GRIPOBJLIMIT.toLowerCase()) {
+        const intVal = Math.trunc(value as number)
+        if (!Number.isFinite(intVal) || intVal < 0 || intVal > 32767) {
+          throw new Error('Invalid GRIPOBJLIMIT value! Valid range is 0 to 32767.')
+        }
+        value = intVal
       }
       if (descriptor.isDbVar) {
         ;(db as unknown as Record<string, unknown>)[name.toLowerCase()] = value

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -56,6 +56,12 @@ export const AcDbSystemVariables = {
   EXTMAX: 'EXTMAX',
   /** Lower-left corner of the model-space drawing extents. */
   EXTMIN: 'EXTMIN',
+  /**
+   * Maximum number of selected objects that display grips. When the initial
+   * selection set exceeds this limit, grips are suppressed to improve
+   * performance. `0` disables the limit and always shows grips.
+   */
+  GRIPOBJLIMIT: 'GRIPOBJLIMIT',
   /** Default angle, in radians, for newly created hatch patterns. */
   HPANG: 'HPANG',
   /** Controls whether newly created hatches are associative. */

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -5,7 +5,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
-  AcGePolyline2dVertex
+  AcGePolyline2dVertex,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -13,6 +14,10 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbForEachGripIndex,
+  acdbMovePolyline2dVertexAt
+} from './AcDbGripHelpers'
 import {
   acdbCollectPolyline2dSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -237,6 +242,14 @@ export class AcDb2dPolyline extends AcDbCurve {
       gripPoints.push(new AcGePoint3d(temp.x, temp.y, this._elevation))
     }
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      acdbMovePolyline2dVertexAt(this._geo.vertices, index, offset)
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDb2dVertex.ts
+++ b/packages/data-model/src/entity/AcDb2dVertex.ts
@@ -2,13 +2,15 @@ import {
   AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 export enum AcDb2dVertexType {
   /**
@@ -185,6 +187,12 @@ export class AcDb2dVertex extends AcDbEntity {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this._position)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._position)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -5,7 +5,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
-  AcGePolyline2dVertex
+  AcGePolyline2dVertex,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -13,6 +14,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -164,6 +166,14 @@ export class AcDb3dPolyline extends AcDbCurve {
       gripPoints.push(this.getPointAt(i))
     }
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveVertexAt(index, offset)
+    })
+    return this
   }
 
   /**
@@ -494,5 +504,14 @@ export class AcDb3dPolyline extends AcDbCurve {
       }
     }
     return bestZ
+  }
+
+  private moveVertexAt(index: number, offset: AcGeVector3dLike) {
+    const vertex = this._geo.vertices[index]
+    if (!vertex) return
+    vertex.x += offset.x
+    vertex.y += offset.y
+    const point = vertex as AcGePoint3dLike
+    point.z = (point.z ?? 0) + (offset.z ?? 0)
   }
 }

--- a/packages/data-model/src/entity/AcDb3dVertex.ts
+++ b/packages/data-model/src/entity/AcDb3dVertex.ts
@@ -2,13 +2,15 @@ import {
   AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 export enum AcDb3dVertexType {
   /**
@@ -104,6 +106,12 @@ export class AcDb3dVertex extends AcDbEntity {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this._position)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._position)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -16,6 +16,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
@@ -491,6 +492,14 @@ export class AcDbArc extends AcDbCurve {
     return gripPoints
   }
 
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveGripAt(index, offset)
+    })
+    return this
+  }
+
   /**
    * Gets the object snap points for this arc.
    *
@@ -623,6 +632,42 @@ export class AcDbArc extends AcDbCurve {
     const c = this.center
     const r = this.radius
     return Math.sqrt((point.x - c.x) ** 2 + (point.y - c.y) ** 2) >= r ? 1 : -1
+  }
+
+  private moveGripAt(gripIndex: number, offset: AcGeVector3dLike) {
+    switch (gripIndex) {
+      case 0:
+        this.transformBy(AcGeMatrix3d.makeTranslation(offset))
+        break
+      case 1: {
+        const point = this._geo.startPoint
+        this._geo.startAngle = getOcsAngle(
+          this._geo.center,
+          {
+            x: point.x + offset.x,
+            y: point.y + offset.y,
+            z: (point.z ?? 0) + (offset.z ?? 0)
+          },
+          this._geo.normal
+        )
+        break
+      }
+      case 2: {
+        const point = this._geo.endPoint
+        this._geo.endAngle = getOcsAngle(
+          this._geo.center,
+          {
+            x: point.x + offset.x,
+            y: point.y + offset.y,
+            z: (point.z ?? 0) + (offset.z ?? 0)
+          },
+          this._geo.normal
+        )
+        break
+      }
+      default:
+        break
+    }
   }
 
   private createOffsetCurve(offsetDist: number): AcDbArc | null {

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -20,6 +20,7 @@ import {
   AcDbEntityProperties,
   AcDbEntityPropertyGroup
 } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
@@ -420,6 +421,12 @@ export class AcDbBlockReference extends AcDbEntity {
    */
   subGetGripPoints() {
     return [this._position]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._position)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -16,7 +16,11 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
+
+/** Quadrant grip angles in radians: 0°, 90°, 180°, 270°. */
+const CIRCLE_QUADRANT_GRIP_ANGLES = [0, Math.PI / 2, Math.PI, (Math.PI / 2) * 3]
 
 /**
  * Represents a circle entity in AutoCAD.
@@ -373,20 +377,32 @@ export class AcDbCircle extends AcDbCurve {
    * Gets the grip points for this circle.
    *
    * Grip points are control points that can be used to modify the circle.
-   * For a circle, the grip point is the center point.
+   * For a circle, the grip points are the center and the four quadrant
+   * points at 0°, 90°, 180°, and 270°.
    *
-   * @returns Array of grip points (center point)
+   * @returns Array of grip points (center, then quadrant points)
    *
    * @example
    * ```typescript
    * const gripPoints = circle.subGetGripPoints();
-   * // gripPoints contains: [center]
+   * // gripPoints contains: [center, q0, q90, q180, q270]
    * ```
    */
   subGetGripPoints() {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this.center)
+    for (const angle of CIRCLE_QUADRANT_GRIP_ANGLES) {
+      gripPoints.push(this._geo.getPointAtAngle(angle))
+    }
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveGripAt(index, offset)
+    })
+    return this
   }
 
   /**
@@ -454,5 +470,32 @@ export class AcDbCircle extends AcDbCurve {
     const geo = this._geo.offset(offsetDist)
     if (!geo) return null
     return new AcDbCircle(geo.center, geo.radius, geo.normal)
+  }
+
+  private moveGripAt(gripIndex: number, offset: AcGeVector3dLike) {
+    switch (gripIndex) {
+      case 0:
+        this.transformBy(AcGeMatrix3d.makeTranslation(offset))
+        break
+      case 1:
+      case 2:
+      case 3:
+      case 4: {
+        const angle = CIRCLE_QUADRANT_GRIP_ANGLES[gripIndex - 1]
+        const point = this._geo.getPointAtAngle(angle)
+        const newPoint = new AcGePoint3d(
+          point.x + offset.x,
+          point.y + offset.y,
+          (point.z ?? 0) + (offset.z ?? 0)
+        )
+        const newRadius = newPoint.distanceTo(this.center)
+        if (newRadius > 0) {
+          this.radius = newRadius
+        }
+        break
+      }
+      default:
+        break
+    }
   }
 }

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -4,7 +4,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
-  AcGeVector3dLike
+  AcGeVector3dLike,
+  getOcsAngle
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -12,6 +13,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
@@ -339,6 +341,14 @@ export class AcDbEllipse extends AcDbCurve {
     return gripPoints
   }
 
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveGripAt(index, offset)
+    })
+    return this
+  }
+
   /**
    * Gets the object snap points for this ellipse or ellipse arc.
    *
@@ -612,6 +622,42 @@ export class AcDbEllipse extends AcDbCurve {
     const u = dx * ux + dy * uy
     const v = dx * vx + dy * vy
     return (u / majorLen) ** 2 + (v / minorLen) ** 2 >= 1 ? 1 : -1
+  }
+
+  private moveGripAt(gripIndex: number, offset: AcGeVector3dLike) {
+    switch (gripIndex) {
+      case 0:
+        this.transformBy(AcGeMatrix3d.makeTranslation(offset))
+        break
+      case 1: {
+        const point = this._geo.startPoint
+        this._geo.startAngle = getOcsAngle(
+          this._geo.center,
+          {
+            x: point.x + offset.x,
+            y: point.y + offset.y,
+            z: (point.z ?? 0) + (offset.z ?? 0)
+          },
+          this._geo.normal
+        )
+        break
+      }
+      case 2: {
+        const point = this._geo.endPoint
+        this._geo.endAngle = getOcsAngle(
+          this._geo.center,
+          {
+            x: point.x + offset.x,
+            y: point.y + offset.y,
+            z: (point.z ?? 0) + (offset.z ?? 0)
+          },
+          this._geo.normal
+        )
+        break
+      }
+      default:
+        break
+    }
   }
 
   private createOffsetCurve(offsetDist: number): AcDbEllipse | null {

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -2,7 +2,8 @@ import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
 import {
   AcGeBox3d,
   AcGeMatrix3d,
-  AcGePoint3d
+  AcGePoint3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
@@ -519,6 +520,30 @@ export abstract class AcDbEntity extends AcDbObject {
   subGetGripPoints() {
     const gripPoints = new Array<AcGePoint3d>()
     return gripPoints
+  }
+
+  /**
+   * Moves the grip points at the specified indices by the given offset.
+   *
+   * This method should be overridden by subclasses to provide entity-specific
+   * grip editing behavior, matching AutoCAD `AcDbEntity::subMoveGripPointsAt`.
+   *
+   * @param indices - Zero-based indexes into the array returned by {@link subGetGripPoints}
+   * @param offset - WCS translation offset applied to the selected grips
+   * @returns This entity after the grip edit
+   *
+   * @example
+   * ```typescript
+   * entity.subMoveGripPointsAt([0], new AcGeVector3d(1, 0, 0));
+   * ```
+   */
+  subMoveGripPointsAt(
+    // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
+    indices: number[],
+    // @ts-expect-error not use '_' prefix so that typedoc can the correct parameter to generate doc
+    offset: AcGeVector3dLike
+  ): this {
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -4,13 +4,15 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGePointLike
+  AcGePointLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbMovePointArrayGripAt } from './AcDbGripHelpers'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 
 /**
@@ -207,6 +209,12 @@ export class AcDbFace extends AcDbEntity {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(...this._vertices)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePointArrayGripAt(indices, offset, this._vertices)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbGripHelpers.ts
+++ b/packages/data-model/src/entity/AcDbGripHelpers.ts
@@ -1,0 +1,63 @@
+import {
+  AcGePoint3d,
+  AcGeVector3dLike
+} from '@mlightcad/geometry-engine'
+
+/**
+ * Invokes a grip move handler for each valid grip index.
+ */
+export function acdbForEachGripIndex(
+  indices: readonly number[],
+  moveAtIndex: (index: number) => void
+) {
+  for (const index of indices) {
+    if (Number.isInteger(index) && index >= 0) {
+      moveAtIndex(index)
+    }
+  }
+}
+
+/**
+ * Moves the primary grip point at index 0.
+ */
+export function acdbMovePrimaryGripPointAt(
+  indices: readonly number[],
+  offset: AcGeVector3dLike,
+  point: AcGePoint3d
+) {
+  acdbForEachGripIndex(indices, index => {
+    if (index === 0) {
+      point.add(offset)
+    }
+  })
+}
+
+/**
+ * Moves one vertex on a 2D polyline geometry object.
+ */
+export function acdbMovePolyline2dVertexAt(
+  vertices: Array<{ x: number; y: number }>,
+  index: number,
+  offset: AcGeVector3dLike
+) {
+  const vertex = vertices[index]
+  if (!vertex) return
+  vertex.x += offset.x
+  vertex.y += offset.y
+}
+
+/**
+ * Moves indexed points in a mutable point array.
+ */
+export function acdbMovePointArrayGripAt(
+  indices: readonly number[],
+  offset: AcGeVector3dLike,
+  points: readonly AcGePoint3d[]
+) {
+  acdbForEachGripIndex(indices, index => {
+    const point = points[index]
+    if (point) {
+      point.add(offset)
+    }
+  })
+}

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -14,7 +14,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePolyline2d,
-  AcGeSpline3d
+  AcGeSpline3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import {
   AcGiHatchPatternLine,
@@ -34,6 +35,10 @@ import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbPredefinedAcadIsoPat } from '../misc/pat/AcDbPatPredefined'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbForEachGripIndex,
+  acdbMovePolyline2dVertexAt
+} from './AcDbGripHelpers'
 import {
   acdbCollectPolyline2dSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -1099,6 +1104,269 @@ export class AcDbHatch extends AcDbEntity {
           ]
         }
       ]
+    }
+  }
+
+  /**
+   * Gets the grip points for this hatch.
+   *
+   * Associative hatches do not expose editable grips in AutoCAD. Non-associative
+   * hatches return boundary definition points from all loops.
+   *
+   * @returns Array of grip points as 3D points
+   */
+  subGetGripPoints() {
+    if (this.associative) {
+      return []
+    }
+    return this.collectBoundaryGripPoints()
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    if (this.associative) {
+      return this
+    }
+    acdbForEachGripIndex(indices, index => {
+      this.moveBoundaryGripPointAt(index, offset)
+    })
+    return this
+  }
+
+  /**
+   * Collects editable grip points from hatch boundary loops.
+   */
+  private collectBoundaryGripPoints() {
+    const gripPoints = new Array<AcGePoint3d>()
+    const elevation = this._elevation
+    const seen = new Set<string>()
+
+    const appendPoint = (point: AcGePoint3dLike) => {
+      const key = `${point.x},${point.y},${point.z ?? 0}`
+      if (seen.has(key)) return
+      seen.add(key)
+      gripPoints.push(new AcGePoint3d(point.x, point.y, point.z ?? elevation))
+    }
+
+    this._geo.loops.forEach(loop => {
+      if (loop instanceof AcGePolyline2d) {
+        const vertexCount = loop.numberOfVertices
+        for (let index = 0; index < vertexCount; index++) {
+          const vertex = loop.getPointAt(index)
+          appendPoint({ x: vertex.x, y: vertex.y, z: elevation })
+        }
+        return
+      }
+
+      loop.curves.forEach(curve => {
+        if (curve instanceof AcGeLine2d) {
+          appendPoint({
+            x: curve.startPoint.x,
+            y: curve.startPoint.y,
+            z: elevation
+          })
+          appendPoint({
+            x: curve.endPoint.x,
+            y: curve.endPoint.y,
+            z: elevation
+          })
+        } else if (curve instanceof AcGeCircArc2d) {
+          appendPoint({
+            x: curve.startPoint.x,
+            y: curve.startPoint.y,
+            z: elevation
+          })
+          appendPoint({
+            x: curve.endPoint.x,
+            y: curve.endPoint.y,
+            z: elevation
+          })
+          appendPoint({
+            x: curve.midPoint.x,
+            y: curve.midPoint.y,
+            z: elevation
+          })
+        } else if (curve instanceof AcGeEllipseArc2d) {
+          appendPoint({
+            x: curve.startPoint.x,
+            y: curve.startPoint.y,
+            z: elevation
+          })
+          appendPoint({
+            x: curve.endPoint.x,
+            y: curve.endPoint.y,
+            z: elevation
+          })
+          const mid = curve.getPoint(0.5)
+          appendPoint({ x: mid.x, y: mid.y, z: elevation })
+        }
+      })
+    })
+
+    return gripPoints
+  }
+
+  /**
+   * Moves one boundary grip point using the same index order as
+   * {@link collectBoundaryGripPoints}.
+   */
+  private moveBoundaryGripPointAt(
+    gripIndex: number,
+    offset: AcGeVector3dLike
+  ) {
+    let currentIndex = 0
+    const elevation = this._elevation
+    const seen = new Set<string>()
+
+    const tryMove = (point: AcGePoint3dLike, move: () => void) => {
+      const key = `${point.x},${point.y},${point.z ?? 0}`
+      if (seen.has(key)) return
+      seen.add(key)
+      if (currentIndex === gripIndex) {
+        move()
+      }
+      currentIndex++
+    }
+
+    this._geo.loops.forEach(loop => {
+      if (loop instanceof AcGePolyline2d) {
+        const vertexCount = loop.numberOfVertices
+        for (let index = 0; index < vertexCount; index++) {
+          const vertex = loop.vertices[index]
+          if (!vertex) continue
+          tryMove({ x: vertex.x, y: vertex.y, z: elevation }, () => {
+            acdbMovePolyline2dVertexAt(loop.vertices, index, offset)
+          })
+        }
+        return
+      }
+
+      loop.curves.forEach(curve => {
+        if (curve instanceof AcGeLine2d) {
+          tryMove(
+            { x: curve.startPoint.x, y: curve.startPoint.y, z: elevation },
+            () => {
+              curve.startPoint.x += offset.x
+              curve.startPoint.y += offset.y
+            }
+          )
+          tryMove(
+            { x: curve.endPoint.x, y: curve.endPoint.y, z: elevation },
+            () => {
+              curve.endPoint.x += offset.x
+              curve.endPoint.y += offset.y
+            }
+          )
+        } else if (curve instanceof AcGeCircArc2d) {
+          tryMove(
+            { x: curve.startPoint.x, y: curve.startPoint.y, z: elevation },
+            () => this.moveCircArc2dGripPoint(curve, 'start', offset)
+          )
+          tryMove(
+            { x: curve.endPoint.x, y: curve.endPoint.y, z: elevation },
+            () => this.moveCircArc2dGripPoint(curve, 'end', offset)
+          )
+          tryMove(
+            { x: curve.midPoint.x, y: curve.midPoint.y, z: elevation },
+            () => this.moveCircArc2dGripPoint(curve, 'mid', offset)
+          )
+        } else if (curve instanceof AcGeEllipseArc2d) {
+          tryMove(
+            { x: curve.startPoint.x, y: curve.startPoint.y, z: elevation },
+            () => this.moveEllipseArc2dGripPoint(curve, 'start', offset)
+          )
+          tryMove(
+            { x: curve.endPoint.x, y: curve.endPoint.y, z: elevation },
+            () => this.moveEllipseArc2dGripPoint(curve, 'end', offset)
+          )
+          const mid = curve.getPoint(0.5)
+          tryMove({ x: mid.x, y: mid.y, z: elevation }, () =>
+            this.moveEllipseArc2dGripPoint(curve, 'mid', offset)
+          )
+        }
+      })
+    })
+  }
+
+  private moveCircArc2dGripPoint(
+    arc: AcGeCircArc2d,
+    which: 'start' | 'end' | 'mid',
+    offset: AcGeVector3dLike
+  ) {
+    const center = arc.center
+    switch (which) {
+      case 'start': {
+        const point = arc.startPoint
+        arc.startAngle = Math.atan2(
+          point.y + offset.y - center.y,
+          point.x + offset.x - center.x
+        )
+        break
+      }
+      case 'end': {
+        const point = arc.endPoint
+        arc.endAngle = Math.atan2(
+          point.y + offset.y - center.y,
+          point.x + offset.x - center.x
+        )
+        break
+      }
+      case 'mid': {
+        const mid = arc.midPoint
+        const movedArc = new AcGeCircArc2d(
+          arc.startPoint,
+          { x: mid.x + offset.x, y: mid.y + offset.y },
+          arc.endPoint
+        )
+        arc.center = movedArc.center
+        arc.radius = movedArc.radius
+        arc.startAngle = movedArc.startAngle
+        arc.endAngle = movedArc.endAngle
+        arc.clockwise = movedArc.clockwise
+        break
+      }
+    }
+  }
+
+  private moveEllipseArc2dGripPoint(
+    arc: AcGeEllipseArc2d,
+    which: 'start' | 'end' | 'mid',
+    offset: AcGeVector3dLike
+  ) {
+    const center = arc.center
+    switch (which) {
+      case 'start': {
+        const point = arc.startPoint
+        arc.startAngle = Math.atan2(
+          point.y + offset.y - center.y,
+          point.x + offset.x - center.x
+        )
+        break
+      }
+      case 'end': {
+        const point = arc.endPoint
+        arc.endAngle = Math.atan2(
+          point.y + offset.y - center.y,
+          point.x + offset.x - center.x
+        )
+        break
+      }
+      case 'mid': {
+        const mid = arc.getPoint(0.5)
+        const dx = mid.x + offset.x - arc.center.x
+        const dy = mid.y + offset.y - arc.center.y
+        const currentRadius = Math.hypot(
+          mid.x - arc.center.x,
+          mid.y - arc.center.y
+        )
+        const targetRadius = Math.hypot(dx, dy)
+        if (currentRadius > 0 && targetRadius > 0) {
+          const scale = targetRadius / currentRadius
+          arc.majorAxisRadius *= scale
+          arc.minorAxisRadius *= scale
+        }
+        break
+      }
     }
   }
 

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -13,6 +13,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
+import { acdbMovePointArrayGripAt } from './AcDbGripHelpers'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -401,6 +402,12 @@ export class AcDbLeader extends AcDbCurve {
    */
   subGetGripPoints() {
     return this._vertices.map(vertex => vertex.clone())
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePointArrayGripAt(indices, offset, this._vertices)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbLine.ts
+++ b/packages/data-model/src/entity/AcDbLine.ts
@@ -3,7 +3,8 @@ import {
   AcGeLine3d,
   AcGeMatrix3d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -11,6 +12,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 
 /**
  * Represents a line entity in AutoCAD.
@@ -290,6 +292,31 @@ export class AcDbLine extends AcDbCurve {
     gripPoints.push(this.startPoint)
     gripPoints.push(this.endPoint)
     return gripPoints
+  }
+
+  /**
+   * Moves grip points for this line.
+   *
+   * Index 0 moves the midpoint and translates the whole line. Indices 1 and 2
+   * move the start and end points respectively.
+   */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      switch (index) {
+        case 0:
+          this.transformBy(AcGeMatrix3d.makeTranslation(offset))
+          break
+        case 1:
+          this.startPoint.add(offset)
+          break
+        case 2:
+          this.endPoint.add(offset)
+          break
+        default:
+          break
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMLeader.ts
+++ b/packages/data-model/src/entity/AcDbMLeader.ts
@@ -27,6 +27,7 @@ import { AcDbRenderingCache } from '../misc/AcDbRenderingCache'
 import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -1413,6 +1414,14 @@ export class AcDbMLeader extends AcDbEntity {
     return this.collectGeometryPoints().map(point => point.clone())
   }
 
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveGeometryGripPointAt(index, offset)
+    })
+    return this
+  }
+
   /**
    * Gets the object snap points for this multileader.
    */
@@ -1934,6 +1943,93 @@ export class AcDbMLeader extends AcDbEntity {
     if (this._blockContent?.position) points.push(this._blockContent.position)
     if (this.planeOrigin) points.push(this.planeOrigin)
     return points
+  }
+
+  /**
+   * Moves one geometry grip point using the same index order as
+   * {@link collectGeometryPoints}.
+   */
+  private moveGeometryGripPointAt(
+    gripIndex: number,
+    offset: AcGeVector3dLike
+  ) {
+    let currentIndex = 0
+
+    const visit = (
+      point: AcGePoint3d | undefined,
+      onComputed?: () => void
+    ) => {
+      if (point) {
+        if (currentIndex === gripIndex) {
+          point.add(offset)
+        }
+        currentIndex++
+        return
+      }
+      if (onComputed) {
+        if (currentIndex === gripIndex) {
+          onComputed()
+        }
+        currentIndex++
+      }
+    }
+
+    this._leaders.forEach(leader => {
+      visit(leader.lastLeaderLinePoint)
+      visit(leader.landingPoint)
+      leader.breaks.forEach(item => {
+        visit(item.start)
+        visit(item.end)
+      })
+      leader.leaderLines.forEach(line => {
+        line.vertices.forEach(vertex => visit(vertex))
+        line.breaks.forEach(item => {
+          visit(item.start)
+          visit(item.end)
+        })
+      })
+      const doglegPoints = this.getDoglegPoints(leader)
+      if (doglegPoints) {
+        visit(doglegPoints[0])
+        visit(undefined, () => {
+          const start = doglegPoints[0]
+          const end = doglegPoints[1]
+          if (!start || !end) return
+          const newLength = start.distanceTo({
+            x: end.x + offset.x,
+            y: end.y + offset.y,
+            z: (end.z ?? 0) + (offset.z ?? 0)
+          })
+          if (leader.doglegLength != null || leader.doglegVectorSet) {
+            leader.doglegLength = newLength
+          } else {
+            this._doglegLength = newLength
+          }
+        })
+      }
+      leader.leaderLines.forEach(line => {
+        const drawPoints = this.getLeaderLineDrawPoints(leader, line)
+        const arrowPoints = this.getArrowheadPoints(drawPoints)
+        if (!arrowPoints) return
+        arrowPoints.forEach((_, arrowIndex) => {
+          if (arrowIndex === 0 || arrowIndex === arrowPoints.length - 1) {
+            visit(drawPoints[0])
+          } else {
+            visit(undefined)
+          }
+        })
+      })
+    })
+    visit(this._landingPoint)
+    visit(this.contentBasePosition)
+    visit(this.textAnchor)
+    if (this._mtextContent) {
+      visit(this._mtextContent.anchorPoint)
+    }
+    if (this._blockContent?.position) {
+      visit(this._blockContent.position)
+    }
+    visit(this.planeOrigin)
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMLine.ts
+++ b/packages/data-model/src/entity/AcDbMLine.ts
@@ -22,6 +22,7 @@ import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbMlineStyle } from '../object/AcDbMlineStyle'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -572,6 +573,36 @@ export class AcDbMLine extends AcDbEntity {
         }
       ]
     }
+  }
+
+  /**
+   * Gets the grip points for this MLINE reference path.
+   *
+   * Grip points are placed at the start point and each segment vertex,
+   * matching AutoCAD MLINE grip behavior on the reference path.
+   *
+   * @returns Array of grip points as 3D points
+   */
+  subGetGripPoints() {
+    const gripPoints = new Array<AcGePoint3d>()
+    gripPoints.push(this._startPosition)
+    this._segments.forEach(segment => gripPoints.push(segment.position))
+    return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      if (index === 0) {
+        this._startPosition.add(offset)
+      } else {
+        const segment = this._segments[index - 1]
+        if (segment) {
+          segment.position.add(offset)
+        }
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -17,6 +17,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 import {
   acdbCountMTextLines,
   acdbEstimateMTextHeight,
@@ -383,6 +384,12 @@ export class AcDbMText extends AcDbEntity {
    */
   subGetGripPoints() {
     return [this._location]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._location)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPoint.ts
+++ b/packages/data-model/src/entity/AcDbPoint.ts
@@ -3,7 +3,8 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGePointLike
+  AcGePointLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -11,6 +12,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 /**
  * Represents a point entity in AutoCAD.
@@ -126,6 +128,12 @@ export class AcDbPoint extends AcDbEntity {
    */
   subGetGripPoints() {
     return [this._geo]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._geo)
+    return this
   }
 
   subGetOsnapPoints(

--- a/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolyFaceMesh.ts
@@ -3,7 +3,8 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -11,6 +12,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
@@ -166,6 +168,17 @@ export class AcDbPolyFaceMesh extends AcDbCurve {
       gripPoints.push(vertex.position)
     })
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      const vertex = this._vertices[index]
+      if (vertex) {
+        vertex.position.add(offset)
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPolygonMesh.ts
+++ b/packages/data-model/src/entity/AcDbPolygonMesh.ts
@@ -3,7 +3,8 @@ import {
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
-  AcGePoint3dLike
+  AcGePoint3dLike,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -11,6 +12,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
 /**
@@ -188,6 +190,17 @@ export class AcDbPolygonMesh extends AcDbCurve {
       gripPoints.push(vertex.position)
     })
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      const vertex = this._vertices[index]
+      if (vertex) {
+        vertex.position.add(offset)
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -8,6 +8,7 @@ import {
   AcGePoint3dLike,
   AcGePolyline2d,
   AcGePolyline2dVertex,
+  AcGeVector3dLike,
   offsetVertexPath
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
@@ -16,6 +17,10 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import {
+  acdbForEachGripIndex,
+  acdbMovePolyline2dVertexAt
+} from './AcDbGripHelpers'
 import {
   acdbCollectPolyline2dSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -326,6 +331,14 @@ export class AcDbPolyline extends AcDbCurve {
       gripPoints.push(this.getPoint3dAt(index))
     }
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      acdbMovePolyline2dVertexAt(this._geo.vertices, index, offset)
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbProxyEntity.ts
+++ b/packages/data-model/src/entity/AcDbProxyEntity.ts
@@ -1,7 +1,8 @@
 import {
   AcGeBox3d,
   AcGeMatrix3d,
-  AcGePoint3d
+  AcGePoint3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -12,6 +13,10 @@ import {
   loadAcDbProxyGraphicFromDxf
 } from '../misc/proxyGraphic'
 import { AcDbEntity } from './AcDbEntity'
+import {
+  acdbForEachGripIndex,
+  acdbMovePointArrayGripAt
+} from './AcDbGripHelpers'
 
 /**
  * Represents a proxy entity for custom objects not natively supported by the
@@ -275,6 +280,50 @@ export class AcDbProxyEntity extends AcDbEntity {
       return new AcGeBox3d().setFromPoints(extents)
     }
     return new AcGeBox3d()
+  }
+
+  /**
+   * Gets the grip points for this proxy entity.
+   *
+   * When entity origins are stored on the proxy, they are returned as grips.
+   * Otherwise the axis-aligned extents corners are used when available.
+   *
+   * @returns Array of grip points as 3D points
+   */
+  subGetGripPoints() {
+    if (this._entityOrigins.length > 0) {
+      return [...this._entityOrigins]
+    }
+
+    const extents = this.geometricExtents
+    if (!extents.isEmpty()) {
+      return [
+        new AcGePoint3d(extents.min.x, extents.min.y, extents.min.z),
+        new AcGePoint3d(extents.max.x, extents.max.y, extents.max.z)
+      ]
+    }
+
+    return []
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    if (this._entityOrigins.length > 0) {
+      acdbMovePointArrayGripAt(indices, offset, this._entityOrigins)
+      return this
+    }
+
+    const extents = this.geometricExtents
+    if (extents.isEmpty()) {
+      return this
+    }
+
+    acdbForEachGripIndex(indices, index => {
+      if (index === 0) {
+        this.transformBy(AcGeMatrix3d.makeTranslation(offset))
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbRasterImage.ts
+++ b/packages/data-model/src/entity/AcDbRasterImage.ts
@@ -6,7 +6,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeVector2d,
-  AcGeVector3d
+  AcGeVector3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
@@ -14,6 +15,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObjectId } from '../base/AcDbObject'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 
 /**
@@ -365,6 +367,18 @@ export class AcDbRasterImage extends AcDbEntity {
     return this.boundaryPath()
   }
 
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      if (this.isClipped && this._clipBoundary.length > 3) {
+        this.moveClippedBoundaryGripAt(index, offset)
+      } else {
+        this.moveUnclippedGripAt(index, offset)
+      }
+    })
+    return this
+  }
+
   /**
    * Gets the object snap points for this raster image.
    */
@@ -458,6 +472,70 @@ export class AcDbRasterImage extends AcDbEntity {
     this._height = transformedV.length()
     this._scale.set(1, 1)
     return this
+  }
+
+  private moveUnclippedGripAt(index: number, offset: AcGeVector3dLike) {
+    const px = this._position.x
+    const py = this._position.y
+    const w = this._width
+    const h = this._height
+
+    switch (index) {
+      case 0:
+        this._position.add(offset)
+        break
+      case 1: {
+        const fixedX = px
+        const fixedY = py + h
+        const movedX = px + w + offset.x
+        const movedY = py + offset.y
+        this._position.x = fixedX
+        this._position.y = movedY
+        this._width = movedX - fixedX
+        this._height = fixedY - movedY
+        break
+      }
+      case 2: {
+        const movedX = px + w + offset.x
+        const movedY = py + h + offset.y
+        this._width = movedX - px
+        this._height = movedY - py
+        break
+      }
+      case 3: {
+        const fixedX = px + w
+        const fixedY = py
+        const movedX = px + offset.x
+        const movedY = py + h + offset.y
+        this._position.x = movedX
+        this._position.y = fixedY
+        this._width = fixedX - movedX
+        this._height = movedY - fixedY
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  private moveClippedBoundaryGripAt(index: number, offset: AcGeVector3dLike) {
+    if (index < 0 || index >= this._clipBoundary.length) {
+      return
+    }
+
+    const wcsWidth = this._width
+    const wcsHeight = this._height
+    const ocsBox = new AcGeBox2d()
+    ocsBox.setFromPoints(this._clipBoundary)
+    const translation = new AcGePoint2d()
+    translation.setX(this._position.x - ocsBox.min.x * wcsWidth)
+    translation.setY(this._position.y - ocsBox.min.y * wcsHeight)
+
+    const clipPoint = this._clipBoundary[index]
+    const wcsX = clipPoint.x * wcsWidth + translation.x + offset.x
+    const wcsY = clipPoint.y * wcsHeight + translation.y + offset.y
+    clipPoint.x = (wcsX - translation.x) / wcsWidth
+    clipPoint.y = (wcsY - translation.y) / wcsHeight
   }
 
   protected boundaryPath() {

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -5,6 +5,7 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeVector3d,
+  AcGeVector3dLike,
   offsetPointByDirectionInXY
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
@@ -13,6 +14,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 /**
  * Represents a ray entity in AutoCAD.
@@ -277,6 +279,12 @@ export class AcDbRay extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this.basePoint)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this.basePoint)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbShape.ts
+++ b/packages/data-model/src/entity/AcDbShape.ts
@@ -17,6 +17,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 /**
  * Represents a shape entity in AutoCAD.
@@ -285,6 +286,12 @@ export class AcDbShape extends AcDbEntity {
 
   subGetGripPoints() {
     return [this._position]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._position)
+    return this
   }
 
   subGetOsnapPoints(

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -1,11 +1,13 @@
 import { AcCmErrors } from '@mlightcad/common'
 import {
+  AcGeGeometryUtil,
   AcGeKnotParameterizationType,
   AcGeMatrix3d,
   AcGePoint2d,
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeSpline3d,
+  AcGeVector3dLike,
   offsetSmoothedSampledPath
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
@@ -13,6 +15,7 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 import { AcDbPolyline } from './AcDbPolyline'
 
 function resolveSplineKnotParameterization(
@@ -473,6 +476,17 @@ export class AcDbSpline extends AcDbCurve {
     return this._geo.controlPoints.map(
       point => new AcGePoint3d(point.x, point.y, point.z ?? 0)
     )
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      const point = this._geo.controlPoints[index]
+      if (point) {
+        AcGeGeometryUtil.applyOffsetToPoint3d(point, offset)
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbText.ts
+++ b/packages/data-model/src/entity/AcDbText.ts
@@ -3,7 +3,8 @@ import {
   AcGeMatrix3d,
   AcGePoint3d,
   AcGePoint3dLike,
-  AcGeVector3d
+  AcGeVector3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
@@ -18,6 +19,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 import {
   acdbEstimatePlainTextWidth,
   acdbExpandBoxByOrientedTextRect
@@ -516,6 +518,12 @@ export class AcDbText extends AcDbEntity {
    */
   subGetGripPoints() {
     return [this._position]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._position)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -6,13 +6,15 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
-  AcGePolyline2d
+  AcGePolyline2d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
+import { acdbMovePointArrayGripAt } from './AcDbGripHelpers'
 import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
 
@@ -246,6 +248,12 @@ export class AcDbTrace extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(...this._vertices)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePointArrayGripAt(indices, offset, this._vertices)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbViewport.ts
+++ b/packages/data-model/src/entity/AcDbViewport.ts
@@ -2,7 +2,8 @@ import {
   AcGeBox3d,
   AcGeMatrix3d,
   AcGePoint3d,
-  AcGeVector3d
+  AcGeVector3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import {
   AcGiEntity,
@@ -12,6 +13,7 @@ import {
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbEntity } from './AcDbEntity'
+import { acdbForEachGripIndex } from './AcDbGripHelpers'
 
 /**
  * Represents a viewport entity in AutoCAD drawings.
@@ -209,6 +211,56 @@ export class AcDbViewport extends AcDbEntity {
   }
 
   /**
+   * Gets the grip points for this viewport.
+   *
+   * Grip points are the center point and the four corners of the viewport
+   * boundary in paper space, matching AutoCAD viewport grip behavior.
+   *
+   * @returns Array of grip points as 3D points
+   */
+  subGetGripPoints() {
+    const gripPoints = new Array<AcGePoint3d>()
+    const halfWidth = this._width / 2
+    const halfHeight = this._height / 2
+    const z = this._centerPoint.z
+
+    gripPoints.push(this._centerPoint)
+    if (halfWidth > 0 || halfHeight > 0) {
+      gripPoints.push(
+        new AcGePoint3d(
+          this._centerPoint.x - halfWidth,
+          this._centerPoint.y - halfHeight,
+          z
+        ),
+        new AcGePoint3d(
+          this._centerPoint.x + halfWidth,
+          this._centerPoint.y - halfHeight,
+          z
+        ),
+        new AcGePoint3d(
+          this._centerPoint.x + halfWidth,
+          this._centerPoint.y + halfHeight,
+          z
+        ),
+        new AcGePoint3d(
+          this._centerPoint.x - halfWidth,
+          this._centerPoint.y + halfHeight,
+          z
+        )
+      )
+    }
+    return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbForEachGripIndex(indices, index => {
+      this.moveGripAt(index, offset)
+    })
+    return this
+  }
+
+  /**
    * Transforms this viewport entity by the specified matrix.
    */
   transformBy(matrix: AcGeMatrix3d) {
@@ -378,5 +430,42 @@ export class AcDbViewport extends AcDbEntity {
     filer.writeDouble(45, this.viewHeight)
     filer.writeInt32(69, this.number)
     return this
+  }
+
+  private moveGripAt(gripIndex: number, offset: AcGeVector3dLike) {
+    switch (gripIndex) {
+      case 0:
+        this._centerPoint.add(offset)
+        break
+      case 1:
+      case 2:
+      case 3:
+      case 4: {
+        const halfWidth = this.width / 2
+        const halfHeight = this.height / 2
+        const cx = this._centerPoint.x
+        const cy = this._centerPoint.y
+        const corners: Record<number, { x: number; y: number }> = {
+          1: { x: cx - halfWidth, y: cy - halfHeight },
+          2: { x: cx + halfWidth, y: cy - halfHeight },
+          3: { x: cx + halfWidth, y: cy + halfHeight },
+          4: { x: cx - halfWidth, y: cy + halfHeight }
+        }
+        const oppositeCornerIndex =
+          gripIndex === 1 ? 3 : gripIndex === 2 ? 4 : gripIndex === 3 ? 1 : 2
+        const moved = corners[gripIndex]
+        const fixed = corners[oppositeCornerIndex]
+        moved.x += offset.x
+        moved.y += offset.y
+        this._centerPoint.x = (moved.x + fixed.x) / 2
+        this._centerPoint.y = (moved.y + fixed.y) / 2
+        this._centerPoint.z = (this._centerPoint.z ?? 0) + (offset.z ?? 0)
+        this.width = Math.abs(fixed.x - moved.x)
+        this.height = Math.abs(fixed.y - moved.y)
+        break
+      }
+      default:
+        break
+    }
   }
 }

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -5,6 +5,7 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGeVector3d,
+  AcGeVector3dLike,
   offsetPointByDirectionInXY
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
@@ -13,6 +14,7 @@ import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 
 /**
  * Represents an xline entity in AutoCAD.
@@ -278,6 +280,12 @@ export class AcDbXline extends AcDbCurve {
     const gripPoints = new Array<AcGePoint3d>()
     gripPoints.push(this.basePoint)
     return gripPoints
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this.basePoint)
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDb3PointAngularDimension.ts
@@ -156,6 +156,18 @@ export class AcDb3PointAngularDimension extends AcDbDimension {
   /**
    * @inheritdoc
    */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [
+      this.centerPoint,
+      this.xLine1Point,
+      this.xLine2Point,
+      this.arcPoint
+    ]
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._arcPoint.applyMatrix4(matrix)
     this._centerPoint.applyMatrix4(matrix)

--- a/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbAlignedDimension.ts
@@ -5,7 +5,8 @@ import {
   AcGePoint3d,
   AcGePoint3dLike,
   AcGePointLike,
-  AcGeVector3d
+  AcGeVector3d,
+  AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
@@ -308,6 +309,20 @@ export class AcDbAlignedDimension extends AcDbDimension {
         }
       ]
     }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [this.xLine1Point, this.xLine2Point, this.dimLinePoint]
+  }
+
+  /** @inheritdoc */
+  override subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    super.subMoveGripPointsAt(indices, offset)
+    this.calculateRotation()
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbArcDimension.ts
@@ -158,6 +158,18 @@ export class AcDbArcDimension extends AcDbDimension {
   /**
    * @inheritdoc
    */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [
+      this.centerPoint,
+      this.xLine1Point,
+      this.xLine2Point,
+      this.arcPoint
+    ]
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._arcPoint.applyMatrix4(matrix)
     this._centerPoint.applyMatrix4(matrix)

--- a/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDiametricDimension.ts
@@ -200,6 +200,13 @@ export class AcDbDiametricDimension extends AcDbDimension {
   /**
    * @inheritdoc
    */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [this.chordPoint, this.farChordPoint]
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._chordPoint.applyMatrix4(matrix)
     this._farChordPoint.applyMatrix4(matrix)

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -27,6 +27,9 @@ import {
   AcDbEntityPropertyType,
   AcDbEntityRuntimeProperty
 } from '../AcDbEntityProperties'
+import {
+  acdbForEachGripIndex
+} from '../AcDbGripHelpers'
 
 /**
  * Defines the line spacing style for dimension text.
@@ -515,6 +518,44 @@ export abstract class AcDbDimension extends AcDbEntity {
   private hasExplicitTextPosition(): boolean {
     const { x, y, z } = this.textPosition
     return x !== 0 || y !== 0 || z !== 0
+  }
+
+  /**
+   * Collects dimension-specific definition grip points in WCS coordinates.
+   *
+   * Subclasses override this to expose their editable definition points,
+   * matching AutoCAD `AcDbDimension::getGripPoints` behavior.
+   */
+  protected collectDimensionDefinitionGripPoints(): AcGePoint3d[] {
+    return []
+  }
+
+  /**
+   * Gets the grip points for this dimension.
+   *
+   * Returns definition points together with the dimension text position.
+   *
+   * @returns Array of grip points as 3D points
+   */
+  subGetGripPoints() {
+    return this.collectDimensionDefinitionGripPoints().concat([
+      this.textPosition
+    ])
+  }
+
+  /**
+   * Moves dimension definition and text grip points by the given offset.
+   */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    const definitionPoints = this.collectDimensionDefinitionGripPoints()
+    acdbForEachGripIndex(indices, index => {
+      if (index >= 0 && index < definitionPoints.length) {
+        definitionPoints[index].add(offset)
+      } else if (index === definitionPoints.length) {
+        this.textPosition.add(offset)
+      }
+    })
+    return this
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbOrdinateDimension.ts
@@ -114,6 +114,13 @@ export class AcDbOrdinateDimension extends AcDbDimension {
   /**
    * @inheritdoc
    */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [this.definingPoint, this.leaderEndPoint]
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._definingPoint.applyMatrix4(matrix)
     this._leaderEndPoint.applyMatrix4(matrix)

--- a/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbRadialDimension.ts
@@ -309,6 +309,13 @@ export class AcDbRadialDimension extends AcDbDimension {
   /**
    * @inheritdoc
    */
+  protected override collectDimensionDefinitionGripPoints() {
+    return [this.center, this.chordPoint]
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected override subTransformBy(matrix: AcGeMatrix3d) {
     this._center.applyMatrix4(matrix)
     this._chordPoint.applyMatrix4(matrix)

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -205,6 +205,8 @@ export type {
 } from './entity'
 export {
   ACAD_APPID,
+  ACDB_GRIPOBJLIMIT_MAX,
+  ACDB_GRIPOBJLIMIT_MIN,
   ACTIVE_VPORT_NAME,
   AcDbAngleUnits,
   AcDbCodePage,
@@ -404,8 +406,6 @@ export {
   inverseLerp,
   isBetween,
   isBetweenAngle,
-  isPointInPolygon,
-  isPolygonIntersect,
   isPowerOfTwo,
   lerp,
   mapLinear,

--- a/packages/data-model/src/misc/AcDbConstants.ts
+++ b/packages/data-model/src/misc/AcDbConstants.ts
@@ -99,3 +99,7 @@ export const VPORT_FALLBACK_LLC = Object.freeze({ x: 0, y: 0 })
 export const VPORT_FALLBACK_URC = Object.freeze({ x: 1, y: 1 })
 export const VPORT_FALLBACK_VIEW_DIR = Object.freeze({ x: 0, y: 0, z: 1 })
 export const VPORT_FALLBACK_VIEW_TARGET = Object.freeze({ x: 0, y: 0, z: 0 })
+
+/** AutoCAD valid range for the GRIPOBJLIMIT system variable. */
+export const ACDB_GRIPOBJLIMIT_MIN = 0
+export const ACDB_GRIPOBJLIMIT_MAX = 32767

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -6,6 +6,8 @@ export { AcDbRenderingCache } from './AcDbRenderingCache'
 export { AcDbCodePage, dwgCodePageToEncoding } from './AcDbCodePage'
 export {
   ACAD_APPID,
+  ACDB_GRIPOBJLIMIT_MAX,
+  ACDB_GRIPOBJLIMIT_MIN,
   ACTIVE_VPORT_NAME,
   ByBlock,
   ByLayer,

--- a/packages/geometry-engine/__tests__/AcGeGeometryUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeGeometryUtil.spec.ts
@@ -1,6 +1,21 @@
-import { AcGeGeometryUtil } from '../src'
+import { AcGeGeometryUtil, AcGePoint3dLike } from '../src'
 
 describe('AcGeGeometryUtil', () => {
+  it('converts 2d points to 3d points with default or preserved z', () => {
+    expect(AcGeGeometryUtil.point2dToPoint3d({ x: 1, y: 2 })).toEqual({
+      x: 1,
+      y: 2,
+      z: 0
+    })
+    expect(
+      AcGeGeometryUtil.point2dToPoint3d({ x: 3, y: 4, z: 5 } as AcGePoint3dLike)
+    ).toEqual({
+      x: 3,
+      y: 4,
+      z: 5
+    })
+  })
+
   it('handles empty, disjoint and duplicate-point polygons', () => {
     expect(AcGeGeometryUtil.isPolygonIntersect([], [])).toBe(false)
 

--- a/packages/geometry-engine/__tests__/AcGeMatrix3d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeMatrix3d.spec.ts
@@ -22,6 +22,18 @@ describe('AcGeMatrix3d', () => {
     expect(rotation.length()).toBeCloseTo(1, 8)
   })
 
+  it('creates translation matrices from vectors and numbers', () => {
+    const fromVector = AcGeMatrix3d.makeTranslation({ x: 1, y: 2, z: 0 })
+    expect(fromVector.elements[12]).toBe(1)
+    expect(fromVector.elements[13]).toBe(2)
+    expect(fromVector.elements[14]).toBe(0)
+
+    const fromNumbers = AcGeMatrix3d.makeTranslation(3, -2, 5)
+    expect(fromNumbers.elements[12]).toBe(3)
+    expect(fromNumbers.elements[13]).toBe(-2)
+    expect(fromNumbers.elements[14]).toBe(5)
+  })
+
   it('covers constructor and branch-heavy helpers', () => {
     const constructed = new AcGeMatrix3d(
       1,

--- a/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeSpline3d.ts
@@ -8,6 +8,7 @@ import {
   AcGePoint3dLike,
   AcGePointLike
 } from '../math'
+import { AcGeGeometryUtil } from '../util/AcGeGeometryUtil'
 import { acGeClosedPolygonArea3d } from '../util/AcGePolygonAreaUtil'
 import { AcGeCurve3d } from './AcGeCurve3d'
 import { AcGeKnotParameterizationType, AcGeNurbsCurve } from './AcGeNurbsCurve'
@@ -276,19 +277,11 @@ export class AcGeSpline3d extends AcGeCurve3d {
   }
 
   get controlPoints() {
-    return this._controlPoints.map(point => ({
-      x: point.x,
-      y: point.y,
-      z: point.z || 0
-    }))
+    return this._controlPoints.map(AcGeGeometryUtil.point2dToPoint3d)
   }
 
   get fitPoints() {
-    return this._fitPoints?.map(point => ({
-      x: point.x,
-      y: point.y,
-      z: point.z || 0
-    }))
+    return this._fitPoints?.map(AcGeGeometryUtil.point2dToPoint3d)
   }
 
   get knots() {
@@ -363,7 +356,7 @@ export class AcGeSpline3d extends AcGeCurve3d {
     const length = this._fitPoints.length
     const newIndex = index < 0 || index >= length ? length - 1 : index
     const point = this._fitPoints[newIndex]
-    return { x: point.x, y: point.y, z: point.z || 0 }
+    return AcGeGeometryUtil.point2dToPoint3d(point)
   }
 
   /**
@@ -507,37 +500,17 @@ export class AcGeSpline3d extends AcGeCurve3d {
   clone() {
     if (this._fitPoints && this._knotParameterization) {
       return new AcGeSpline3d(
-        this._fitPoints.map(point => ({
-          x: point.x,
-          y: point.y,
-          z: point.z || 0
-        })),
+        this._fitPoints.map(AcGeGeometryUtil.point2dToPoint3d),
         this._knotParameterization,
         this._degree,
         this._closed,
-        this._startTangent
-          ? {
-              x: this._startTangent.x,
-              y: this._startTangent.y,
-              z: this._startTangent.z || 0
-            }
-          : undefined,
-        this._endTangent
-          ? {
-              x: this._endTangent.x,
-              y: this._endTangent.y,
-              z: this._endTangent.z || 0
-            }
-          : undefined
+        this._startTangent ? AcGeGeometryUtil.point2dToPoint3d(this._startTangent) : undefined,
+        this._endTangent ? AcGeGeometryUtil.point2dToPoint3d(this._endTangent) : undefined
       )
     }
 
     return new AcGeSpline3d(
-      this._controlPoints.map(point => ({
-        x: point.x,
-        y: point.y,
-        z: point.z || 0
-      })),
+      this._controlPoints.map(AcGeGeometryUtil.point2dToPoint3d),
       this._nurbsCurve.knots(),
       this._nurbsCurve.weights(),
       this._degree,
@@ -738,11 +711,7 @@ export class AcGeSpline3d extends AcGeCurve3d {
     endTangent?: { x: number; y: number; z?: number } | null
   }): AcGeSpline3d | null {
     if (spline.numberOfControlPoints > 0 && spline.numberOfKnots > 0) {
-      const controlPoints = spline.controlPoints.map(item => ({
-        x: item.x,
-        y: item.y,
-        z: item.z ?? 0
-      }))
+      const controlPoints = spline.controlPoints.map(AcGeGeometryUtil.point2dToPoint3d)
       let hasWeights = true
       const weights = spline.controlPoints.map(item => {
         if (item.weight == null) hasWeights = false
@@ -758,28 +727,17 @@ export class AcGeSpline3d extends AcGeCurve3d {
     }
 
     if (spline.numberOfFitData > 0) {
-      const fitPoints = spline.fitDatum.map(item => ({
-        x: item.x,
-        y: item.y,
-        z: item.z ?? 0
-      }))
+      const fitPoints = spline.fitDatum.map(AcGeGeometryUtil.point2dToPoint3d)
       return AcGeSpline3d.fromFitPoints(
         fitPoints,
         'Uniform',
         spline.degree,
         false,
-        AcGeSpline3d.toPoint3dLike(spline.startTangent),
-        AcGeSpline3d.toPoint3dLike(spline.endTangent)
+        spline.startTangent ? AcGeGeometryUtil.point2dToPoint3d(spline.startTangent) : undefined,
+        spline.endTangent ? AcGeGeometryUtil.point2dToPoint3d(spline.endTangent) : undefined
       )
     }
 
     return null
-  }
-
-  private static toPoint3dLike(
-    point?: { x: number; y: number; z?: number } | null
-  ): AcGePoint3dLike | undefined {
-    if (!point) return undefined
-    return { x: point.x, y: point.y, z: point.z ?? 0 }
   }
 }

--- a/packages/geometry-engine/src/index.ts
+++ b/packages/geometry-engine/src/index.ts
@@ -81,8 +81,6 @@ export {
   inverseLerp,
   isBetween,
   isBetweenAngle,
-  isPointInPolygon,
-  isPolygonIntersect,
   isPowerOfTwo,
   lerp,
   mapLinear,

--- a/packages/geometry-engine/src/math/AcGeMatrix3d.ts
+++ b/packages/geometry-engine/src/math/AcGeMatrix3d.ts
@@ -11,6 +11,17 @@ export class AcGeMatrix3d {
    * Identity matrix.
    */
   static IDENTITY = Object.freeze(new AcGeMatrix3d())
+
+  /**
+   * Create a translation matrix from a vector or numbers x, y and z.
+   */
+  static makeTranslation(
+    x: number | AcGeVector3dLike,
+    y?: number,
+    z?: number
+  ): AcGeMatrix3d {
+    return new AcGeMatrix3d().makeTranslation(x, y, z)
+  }
   /**
    * A column-major list of matrix values.
    */
@@ -1014,9 +1025,9 @@ export class AcGeMatrix3d {
    * @param z Input one number
    * @returns Return this matrix
    */
-  makeTranslation(x: number | AcGeVector3d, y?: number, z?: number) {
-    if (x instanceof AcGeVector3d) {
-      this.set(1, 0, 0, x.x, 0, 1, 0, x.y, 0, 0, 1, x.z, 0, 0, 0, 1)
+  makeTranslation(x: number | AcGeVector3dLike, y?: number, z?: number) {
+    if (typeof x === 'object') {
+      this.set(1, 0, 0, x.x, 0, 1, 0, x.y, 0, 0, 1, x.z ?? 0, 0, 0, 0, 1)
     } else {
       this.set(1, 0, 0, x, 0, 1, 0, y!, 0, 0, 1, z!, 0, 0, 0, 1)
     }

--- a/packages/geometry-engine/src/util/AcGeGeometryUtil.ts
+++ b/packages/geometry-engine/src/util/AcGeGeometryUtil.ts
@@ -1,5 +1,30 @@
-import { AcGeBox2d, AcGePoint2dLike } from '../math'
+import {
+  AcGeBox2d,
+  AcGePoint2dLike,
+  AcGePoint3dLike,
+  AcGeVector3dLike
+} from '../math'
 import { DEFAULT_TOL } from './AcGeTol'
+
+/**
+ * Converts a 2D point to a 3D point, preserving an optional `z` when present.
+ */
+function point2dToPoint3d(point: AcGePoint2dLike): AcGePoint3dLike {
+  const p = point as AcGePoint3dLike
+  return { x: point.x, y: point.y, z: p.z ?? 0 }
+}
+
+/**
+ * Applies a translation offset to a mutable 3D point.
+ */
+function applyOffsetToPoint3d(
+  point: AcGePoint3dLike,
+  offset: AcGeVector3dLike
+) {
+  point.x += offset.x
+  point.y += offset.y
+  point.z = (point.z ?? 0) + (offset.z ?? 0)
+}
 
 /**
  * Determine if the 2d point is inside the polygon
@@ -50,7 +75,7 @@ function isPolygonIntersect(
   }
 
   for (let i = 0; i < polygon1.length; ) {
-    if (isPointInPolygon(polygon1[i], polygon2, true)) {
+    if (AcGeGeometryUtil.isPointInPolygon(polygon1[i], polygon2, true)) {
       return true
     }
 
@@ -67,8 +92,10 @@ function isPolygonIntersect(
 }
 
 const AcGeGeometryUtil = {
+  applyOffsetToPoint3d: applyOffsetToPoint3d,
   isPointInPolygon: isPointInPolygon,
-  isPolygonIntersect: isPolygonIntersect
+  isPolygonIntersect: isPolygonIntersect,
+  point2dToPoint3d: point2dToPoint3d
 }
 
-export { isPointInPolygon, isPolygonIntersect, AcGeGeometryUtil }
+export { AcGeGeometryUtil }

--- a/packages/geometry-engine/src/util/index.ts
+++ b/packages/geometry-engine/src/util/index.ts
@@ -4,11 +4,7 @@ export {
   ORIGIN_POINT_3D,
   TAU
 } from './AcGeConstants'
-export {
-  AcGeGeometryUtil,
-  isPointInPolygon,
-  isPolygonIntersect
-} from './AcGeGeometryUtil'
+export { AcGeGeometryUtil } from './AcGeGeometryUtil'
 export {
   AcGeMathUtil,
   DEG2RAD,


### PR DESCRIPTION
## Summary

- Add `subMoveGripPointsAt` overrides across entity types (lines, circles, polylines, splines, dimensions, hatches, viewports, and more) to support interactive grip editing aligned with AutoCAD behavior.
- Expand `subGetGripPoints` coverage (e.g. circle quadrant grips, dimension definition/text grips, hatch boundary grips) and introduce shared `AcDbGripHelpers` utilities.
- Extend geometry-engine with `AcGeMatrix3d.makeTranslation`, `AcGeGeometryUtil.point2dToPoint3d` 、`applyOffsetToPoint3d`, and add `GRIPOBJLIMIT` system variable support.

## Test plan

- [ ] Run `pnpm test` and verify data-model and geometry-engine specs pass
- [ ] Confirm circle center vs quadrant grip moves (translate vs scale)
- [ ] Confirm line, polyline, and dimension grip moves update geometry correctly
- [ ] Confirm associative hatches return no grips; non-associative hatches expose boundary grips
- [ ] Verify `GRIPOBJLIMIT` sysvar accepts values 0–32767 and rejects out-of-range input