### PR TITLE
feat(data-model): add DWGNAME system variable with read-only support

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -1,8 +1,28 @@
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbSystemVariables } from '../src/database/AcDbSystemVariables'
+import { AcDbSysVarManager } from '../src/database/AcDbSysVarManager'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 describe('AcDbDatabase', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbDatabase())
+  })
+
+  it('assigns sequential default DWGNAME values to new databases', () => {
+    const db1 = new AcDbDatabase()
+    const db2 = new AcDbDatabase()
+
+    expect(db1.dwgname).toMatch(/^Drawing\d+\.dwg$/)
+    expect(db2.dwgname).toMatch(/^Drawing\d+\.dwg$/)
+    expect(db1.dwgname).not.toBe(db2.dwgname)
+  })
+
+  it('updates DWGNAME when setDwgName is called', () => {
+    const db = new AcDbDatabase()
+    const manager = AcDbSysVarManager.instance()
+
+    db.setDwgName('Site Plan.dxf')
+    expect(db.dwgname).toBe('Site Plan.dxf')
+    expect(manager.getVar(AcDbSystemVariables.DWGNAME, db)).toBe('Site Plan.dxf')
   })
 })

--- a/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbSysVarManager.spec.ts
@@ -1,5 +1,6 @@
 import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
 
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbSystemVariables } from '../src/database/AcDbSystemVariables'
 import { AcDbSysVarManager } from '../src/database/AcDbSysVarManager'
@@ -183,5 +184,29 @@ describe('AcDbSysVarManager', () => {
     expect(() => manager.getDefaultValue('__NOT_FOUND__')).toThrow(
       'System variable __not_found__ not found!'
     )
+  })
+
+  it('exposes read-only DWGNAME on the working database', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    const manager = AcDbSysVarManager.instance()
+    const workingDb = acdbHostApplicationServices().workingDatabase
+
+    expect(workingDb.dwgname).toMatch(/^Drawing\d+\.dwg$/)
+    expect(manager.getVar(AcDbSystemVariables.DWGNAME, workingDb)).toBe(
+      workingDb.dwgname
+    )
+    expect(manager.getDefaultValue(AcDbSystemVariables.DWGNAME)).toBe(
+      'Drawing1.dwg'
+    )
+
+    workingDb.setDwgName('Floor Plan.dwg')
+    expect(manager.getVar(AcDbSystemVariables.DWGNAME, workingDb)).toBe(
+      'Floor Plan.dwg'
+    )
+
+    expect(() =>
+      manager.setVar(AcDbSystemVariables.DWGNAME, 'Other.dwg', workingDb)
+    ).toThrow('System variable dwgname is read-only!')
   })
 })

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -256,6 +256,13 @@ export interface AcDbOpenDatabaseOptions {
    *   no-plot layers are omitted from display.
    */
   drawNoPlotLayers?: boolean
+
+  /**
+   * File name of the drawing being opened, including extension (for example `Plan.dwg`).
+   *
+   * When provided, updates the read-only **DWGNAME** system variable for this database.
+   */
+  fileName?: string
 }
 
 /**
@@ -312,6 +319,9 @@ export interface AcDbCreateDefaultDataOptions {
  * ```
  */
 export class AcDbDatabase extends AcDbObject {
+  /** Sequence counter for default unsaved drawing names (Drawing1.dwg, Drawing2.dwg, ...). */
+  private static _unsavedDrawingSequence = 0
+
   /** Version of the database */
   private _version: AcDbDwgVersion
   /** Angle base for the database */
@@ -396,6 +406,8 @@ export class AcDbDatabase extends AcDbObject {
    * Set from {@link AcDbOpenDatabaseOptions.drawNoPlotLayers} when opening a database.
    */
   private _drawNoPlotLayers = true
+  /** Current drawing file name (**DWGNAME**), including extension. */
+  private _dwgname: string
 
   /**
    * Events that can be triggered by the database.
@@ -429,6 +441,8 @@ export class AcDbDatabase extends AcDbObject {
    */
   constructor() {
     super({ objectId: '0' })
+    AcDbDatabase._unsavedDrawingSequence += 1
+    this._dwgname = `Drawing${AcDbDatabase._unsavedDrawingSequence}.dwg`
     this._version = new AcDbDwgVersion('AC1014')
     this._angbase = 0
     this._angdir = 0
@@ -951,6 +965,39 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
+   * Name of the current drawing file (**DWGNAME**), including extension.
+   *
+   * Read-only through the system-variable API; updated when a drawing is opened
+   * or via {@link setDwgName} after save.
+   *
+   * @see https://help.autodesk.com/view/ACD/2023/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-A89861EF-5F4F-46C6-A1DB-9D985A3858C9-htm.html
+   */
+  get dwgname(): string {
+    return this._dwgname
+  }
+
+  /**
+   * Updates **DWGNAME** after opening or saving a drawing.
+   *
+   * @param value - Drawing file name, including extension.
+   */
+  setDwgName(value: string): void {
+    const normalized = value.trim()
+    if (!normalized) {
+      return
+    }
+
+    this.updateSysVar(
+      AcDbSystemVariables.DWGNAME,
+      this._dwgname,
+      normalized,
+      nextValue => {
+        this._dwgname = nextValue
+      }
+    )
+  }
+
+  /**
    * Returns whether entities on the given layer should be drawn under the
    * current {@link drawNoPlotLayers} setting.
    *
@@ -1429,6 +1476,9 @@ export class AcDbDatabase extends AcDbObject {
 
     this.clear()
     this._drawNoPlotLayers = options?.drawNoPlotLayers ?? true
+    if (options?.fileName) {
+      this.setDwgName(options.fileName)
+    }
 
     await converter.read(
       data,
@@ -1539,6 +1589,9 @@ export class AcDbDatabase extends AcDbObject {
     }
 
     const fileName = this.getFileNameFromUri(url)
+    if (fileName) {
+      this.setDwgName(fileName)
+    }
     const fileExtension = fileName.toLowerCase().split('.').pop()
     if (fileExtension === 'dwg') {
       // DWG files are binary, convert to ArrayBuffer

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -61,6 +61,9 @@ export interface AcDbSysVarDescriptor {
 
   /** Optional default value */
   defaultValue?: AcDbSysVarType
+
+  /** When true, the variable cannot be changed via setVar. */
+  readOnly?: boolean
 }
 
 /**
@@ -250,6 +253,20 @@ export class AcDbSysVarManager {
       type: 'boolean',
       isDbVar: false,
       defaultValue: true
+    })
+    /**
+     * Stores the name of the current drawing, including its file extension.
+     * Read-only; synchronized with the active {@link AcDbDatabase} (for example
+     * {@link acdbHostApplicationServices | workingDatabase}).
+     *
+     * @see https://help.autodesk.com/view/ACD/2023/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-A89861EF-5F4F-46C6-A1DB-9D985A3858C9-htm.html
+     */
+    this.registerVar({
+      name: AcDbSystemVariables.DWGNAME,
+      type: 'string',
+      isDbVar: true,
+      readOnly: true,
+      defaultValue: 'Drawing1.dwg'
     })
     /**
      * Suppresses the display of grips when the initial selection set includes
@@ -643,6 +660,9 @@ export class AcDbSysVarManager {
     name = this.normalizeName(name)
     const descriptor = this.getDescriptor(name)
     if (descriptor) {
+      if (descriptor.readOnly) {
+        throw new Error(`System variable ${name} is read-only!`)
+      }
       const oldVal = this.getVar(name, db)
       if (descriptor.type === 'transparency') {
         const tmp = this.parseTransparency(value)

--- a/packages/data-model/src/database/AcDbSystemVariables.ts
+++ b/packages/data-model/src/database/AcDbSystemVariables.ts
@@ -52,6 +52,13 @@ export const AcDbSystemVariables = {
   DYNMODE: 'DYNMODE',
   /** Controls display of prompts in Dynamic Input tooltips. */
   DYNPROMPT: 'DYNPROMPT',
+  /**
+   * Name of the current drawing file, including extension (for example `Drawing1.dwg`).
+   * Does not include the directory path. Read-only; updated when a drawing is opened or saved.
+   *
+   * @see https://help.autodesk.com/view/ACD/2023/ENU/?caas=caas/documentation/ACD/2014/ENU/files/GUID-A89861EF-5F4F-46C6-A1DB-9D985A3858C9-htm.html
+   */
+  DWGNAME: 'DWGNAME',
   /** Upper-right corner of the model-space drawing extents. */
   EXTMAX: 'EXTMAX',
   /** Lower-left corner of the model-space drawing extents. */


### PR DESCRIPTION
## Summary

- Add **DWGNAME** to the system variable registry as a read-only, database-resident string variable.
- Assign sequential default names (`Drawing1.dwg`, `Drawing2.dwg`, ...) to newly created databases.
- Expose `AcDbDatabase.dwgname` and `setDwgName()` to update the name when opening or saving drawings; block direct writes via `AcDbSysVarManager.setVar`.
- Add tests covering default naming, `setDwgName`, and read-only enforcement.

## Test plan

- [x] `pnpm test -- --testPathPattern="AcDbDatabase|AcDbSysVarManager"`
- [ ] Verify `database.read(..., { fileName: 'example.dwg' })` sets `dwgname` correctly
- [ ] Confirm `setVar(DWGNAME, ...)` throws for read-only access
