### PR TITLE
feat(data-model): implement database transaction manager with undo/redo

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
@@ -1,0 +1,384 @@
+import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcDbDxfCode, AcDbOpenMode, AcDbResultBuffer } from '../src/base'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
+import { AcDbSysVarManager } from '../src/database/AcDbSysVarManager'
+import { AcDbLine } from '../src/entity/AcDbLine'
+import { AcDbDictionary } from '../src/object/AcDbDictionary'
+import { AcDbLayout } from '../src/object/layout/AcDbLayout'
+
+const createLine = (
+  start = new AcGePoint3d(0, 0, 0),
+  end = new AcGePoint3d(10, 0, 0)
+) => new AcDbLine(start, end)
+
+describe('AcDbDatabaseTransactionManager', () => {
+  it('rolls back entity geometry changes on abort', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    const manager = db.transactionManager
+    const tr = manager.startTransaction()
+    const opened = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+    opened!.endPoint = new AcGePoint3d(20, 0, 0)
+
+    manager.abortTransaction()
+
+    expect(line.endPoint.x).toBe(10)
+  })
+
+  it('rolls back entity append on abort', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+
+    const manager = db.transactionManager
+    manager.startTransaction()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBe(line)
+
+    manager.abortTransaction()
+
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBeUndefined()
+  })
+
+  it('returns the same object when opened twice in one transaction', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    const tr = db.transactionManager.startTransaction()
+    const first = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+    const second = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+
+    expect(first).toBe(line)
+    expect(second).toBe(line)
+    db.transactionManager.abortTransaction()
+  })
+
+  it('dispatches entity events once on commit and undo', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    let appendCount = 0
+    let eraseCount = 0
+
+    db.events.entityAppended.addEventListener(() => {
+      appendCount++
+    })
+    db.events.entityErased.addEventListener(() => {
+      eraseCount++
+    })
+
+    db.transactionManager.runUndoable('Add Line', () => {
+      db.tables.blockTable.modelSpace.appendEntity(line)
+    })
+    expect(appendCount).toBe(1)
+
+    db.transactionManager.undo()
+    expect(eraseCount).toBe(1)
+  })
+
+  it('supports undo and redo for entity append and remove', () => {
+    const db = new AcDbDatabase()
+    const line = createLine(new AcGePoint3d(1, 2, 3), new AcGePoint3d(4, 5, 6))
+
+    db.transactionManager.runUndoable('Add Line', () => {
+      db.tables.blockTable.modelSpace.appendEntity(line)
+    })
+
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBe(line)
+    expect(db.transactionManager.canUndo()).toBe(true)
+
+    db.transactionManager.undo()
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBeUndefined()
+    expect(db.transactionManager.canRedo()).toBe(true)
+
+    db.transactionManager.redo()
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBeDefined()
+  })
+
+  it('supports undo and redo for entity modification', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    db.transactionManager.runUndoable('Move', tr => {
+      const opened = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+      opened!.endPoint = new AcGePoint3d(30, 0, 0)
+    })
+
+    expect(line.endPoint.x).toBe(30)
+    db.transactionManager.undo()
+    expect(line.endPoint.x).toBe(10)
+    db.transactionManager.redo()
+    expect(line.endPoint.x).toBe(30)
+  })
+
+  it('merges nested transaction changes into one undo record', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    db.transactionManager.startUndoMark('Nested')
+    db.transactionManager.startTransaction()
+    const inner = db.transactionManager.startTransaction()
+    const opened = inner.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+    opened!.endPoint = new AcGePoint3d(40, 0, 0)
+    db.transactionManager.commitTransaction()
+    db.transactionManager.commitTransaction()
+    db.transactionManager.endUndoMark()
+
+    expect(line.endPoint.x).toBe(40)
+    db.transactionManager.undo()
+    expect(line.endPoint.x).toBe(10)
+  })
+
+  it('rolls back committed nested transaction changes on outer abort', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    db.transactionManager.startTransaction()
+    const inner = db.transactionManager.startTransaction()
+    const opened = inner.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+    opened!.endPoint = new AcGePoint3d(40, 0, 0)
+    db.transactionManager.commitTransaction()
+    db.transactionManager.abortTransaction()
+
+    expect(line.endPoint.x).toBe(10)
+  })
+
+  it('rolls back system variable changes on abort', () => {
+    const db = new AcDbDatabase()
+    const original = db.orthomode
+
+    db.transactionManager.startTransaction()
+    db.orthomode = 1
+    db.transactionManager.abortTransaction()
+
+    expect(db.orthomode).toBe(original)
+  })
+
+  it('records symbol table additions and removals', () => {
+    const db = new AcDbDatabase()
+    const layer = new AcDbLayerTableRecord({ name: 'UndoLayer' })
+
+    db.transactionManager.runUndoable('Add Layer', () => {
+      db.tables.layerTable.add(layer)
+    })
+
+    expect(db.tables.layerTable.getAt('UndoLayer')).toBe(layer)
+    db.transactionManager.undo()
+    expect(db.tables.layerTable.getAt('UndoLayer')).toBeUndefined()
+    db.transactionManager.redo()
+    expect(db.tables.layerTable.has('UndoLayer')).toBe(true)
+  })
+
+  it('records system variable changes through updateSysVar', () => {
+    const db = new AcDbDatabase()
+    const original = db.orthomode
+
+    db.transactionManager.runUndoable('Ortho', () => {
+      db.orthomode = 1
+    })
+
+    expect(db.orthomode).toBe(1)
+    db.transactionManager.undo()
+    expect(db.orthomode).toBe(original)
+    db.transactionManager.redo()
+    expect(db.orthomode).toBe(1)
+  })
+
+  it('clears undo stack when clearUndoStack is called', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.transactionManager.runUndoable('Add', () => {
+      db.tables.blockTable.modelSpace.appendEntity(line)
+    })
+    expect(db.transactionManager.canUndo()).toBe(true)
+
+    db.transactionManager.clearUndoStack()
+    expect(db.transactionManager.canUndo()).toBe(false)
+  })
+
+  it('deduplicates modify records for the same object', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    db.transactionManager.startUndoMark()
+    const tr = db.transactionManager.startTransaction()
+    const opened = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+    opened!.endPoint = new AcGePoint3d(20, 0, 0)
+    opened!.endPoint = new AcGePoint3d(30, 0, 0)
+    db.transactionManager.commitTransaction()
+    db.transactionManager.endUndoMark()
+
+    db.transactionManager.undo()
+    expect(line.endPoint.x).toBe(10)
+  })
+
+  it('resolves objects through getObjectById', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')
+    expect(db.getObjectById(db.objectId)).toBe(db)
+    expect(db.getObjectById(layer!.objectId)).toBe(layer)
+  })
+
+  it('does not create undo records for commit without undo mark', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+
+    db.transactionManager.startTransaction()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+    db.transactionManager.commitTransaction()
+
+    expect(db.tables.blockTable.getEntityById(line.objectId)).toBe(line)
+    expect(db.transactionManager.canUndo()).toBe(false)
+  })
+
+  it('cancels append/remove pairs within one undo mark', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const line = createLine()
+
+    db.transactionManager.startUndoMark('Transient')
+    db.transactionManager.startTransaction()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+    db.tables.blockTable.modelSpace.removeEntity(line.objectId)
+    db.transactionManager.commitTransaction()
+    db.transactionManager.endUndoMark()
+
+    expect(db.transactionManager.canUndo()).toBe(false)
+  })
+
+  it('supports undo and redo for dictionary setAt', () => {
+    const db = new AcDbDatabase()
+    const layout = new AcDbLayout()
+
+    db.transactionManager.runUndoable('Add Layout', () => {
+      db.objects.layout.setAt('TestLayout', layout)
+    })
+
+    expect(db.objects.layout.getAt('TestLayout')).toBe(layout)
+    db.transactionManager.undo()
+    expect(db.objects.layout.getAt('TestLayout')).toBeUndefined()
+    db.transactionManager.redo()
+    expect(db.objects.layout.getAt('TestLayout')).toBeDefined()
+  })
+
+  it('dispatches dictionary events once on commit and undo', () => {
+    const db = new AcDbDatabase()
+    const layout = new AcDbLayout()
+    let setCount = 0
+    let eraseCount = 0
+
+    db.events.dictObjetSet.addEventListener(() => {
+      setCount++
+    })
+    db.events.dictObjectErased.addEventListener(() => {
+      eraseCount++
+    })
+
+    db.transactionManager.runUndoable('Add Layout', () => {
+      db.objects.layout.setAt('L1', layout)
+    })
+    expect(setCount).toBe(1)
+
+    db.transactionManager.undo()
+    expect(eraseCount).toBe(1)
+  })
+
+  it('records system variable changes through setVar', () => {
+    const db = new AcDbDatabase()
+    const manager = AcDbSysVarManager.instance()
+    const original = manager.getVar('dynmode', db) ?? 3
+    const next = original === 1 ? 2 : 1
+
+    db.transactionManager.runUndoable('Dynmode', () => {
+      manager.setVar('dynmode', next, db)
+    })
+
+    expect(manager.getVar('dynmode', db)).toBe(next)
+    db.transactionManager.undo()
+    expect(manager.getVar('dynmode', db)).toBe(original)
+    db.transactionManager.redo()
+    expect(manager.getVar('dynmode', db)).toBe(next)
+  })
+
+  it('records isDbVar system variable changes through setVar', () => {
+    const db = new AcDbDatabase()
+    const manager = AcDbSysVarManager.instance()
+    const original = manager.getVar('orthomode', db) ?? 0
+    const next = original === 1 ? 0 : 1
+
+    db.transactionManager.runUndoable('Ortho', () => {
+      manager.setVar('orthomode', next, db)
+    })
+
+    expect(manager.getVar('orthomode', db)).toBe(next)
+    db.transactionManager.undo()
+    expect(manager.getVar('orthomode', db)).toBe(original)
+    db.transactionManager.redo()
+    expect(manager.getVar('orthomode', db)).toBe(next)
+  })
+
+  it('resolves objects in nested dictionaries through getObjectById', () => {
+    const db = new AcDbDatabase()
+    const nested = new AcDbDictionary(db)
+    db.objects.dictionary.setAt('NESTED', nested)
+    const inner = new AcDbDictionary(db)
+    nested.setAt('INNER', inner)
+
+    expect(db.getObjectById(inner.objectId)).toBe(inner)
+    expect(db.getObjectById(nested.objectId)).toBe(nested)
+  })
+
+  it('enforces strictMode for mutations outside transactions', () => {
+    const db = new AcDbDatabase()
+    db.transactionManager.strictMode = true
+    const line = createLine()
+
+    expect(() => {
+      db.tables.blockTable.modelSpace.appendEntity(line)
+    }).toThrow('outside an active transaction')
+  })
+})
+
+describe('AcDbObject restoreFrom', () => {
+  it('restores cloned state while preserving identity fields', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    const snapshot = line.clonePreservingIdentity()
+    snapshot.endPoint = new AcGePoint3d(99, 0, 0)
+
+    line.endPoint = new AcGePoint3d(50, 0, 0)
+    line.restoreFrom(snapshot)
+
+    expect(line.endPoint.x).toBe(99)
+    expect(line.objectId).toBe(snapshot.objectId)
+    expect(line.database).toBe(db)
+  })
+
+  it('restores xdata through restoreFrom', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    const snapshot = line.clonePreservingIdentity()
+    snapshot.setXData(
+      new AcDbResultBuffer([
+        { code: AcDbDxfCode.ExtendedDataRegAppName, value: 'MY_APP' },
+        { code: AcDbDxfCode.ExtendedDataAsciiString, value: 'changed' }
+      ])
+    )
+
+    line.removeXData('MY_APP')
+    line.restoreFrom(snapshot)
+
+    expect(line.getXData('MY_APP')?.at(1)?.value).toBe('changed')
+  })
+})

--- a/packages/data-model/__tests__/AcDbTransaction.spec.ts
+++ b/packages/data-model/__tests__/AcDbTransaction.spec.ts
@@ -23,6 +23,7 @@ describe('AcDbTransaction', () => {
     const tr = new TestTransaction()
     const obj = tr.register(new AcDbObject())
 
+    obj.ownerId = 'original-owner'
     const opened = tr.getObject<AcDbObject>(
       obj.objectId,
       AcDbOpenMode.kForWrite
@@ -30,10 +31,11 @@ describe('AcDbTransaction', () => {
     expect(opened).toBe(obj)
 
     opened!.ownerId = 'changed-owner'
-    expect(() => tr.abort()).not.toThrow()
+    tr.abort()
+    expect(obj.ownerId).toBe('original-owner')
   })
 
-  it('returns undefined when opening the same object twice and clears on commit', () => {
+  it('returns the same object when opening twice and clears on commit', () => {
     const tr = new TestTransaction()
     const obj = tr.register(new AcDbObject())
 
@@ -42,7 +44,7 @@ describe('AcDbTransaction', () => {
     )
     expect(
       tr.getObject<AcDbObject>(obj.objectId, AcDbOpenMode.kForRead)
-    ).toBeUndefined()
+    ).toBe(obj)
 
     tr.commit()
     expect(tr.getObject<AcDbObject>(obj.objectId, AcDbOpenMode.kForRead)).toBe(

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -488,6 +488,104 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    */
   close() {}
 
+  /** Own-property keys omitted from clone/restore snapshots (database back-references). */
+  private static readonly SNAPSHOT_EXCLUDED_KEYS = new Set([
+    '_database',
+    'transactionManager'
+  ])
+
+  /** Own-property keys restored through dedicated attribute/xdata helpers instead of generic copy. */
+  private static readonly SNAPSHOT_INTERNAL_KEYS = new Set([
+    '_attrs',
+    '_xDataMap'
+  ])
+
+  /**
+   * Returns own string property names that participate in generic snapshot copy.
+   *
+   * Excludes {@link SNAPSHOT_EXCLUDED_KEYS} so database and transaction-manager
+   * references are never duplicated onto clones.
+   */
+  private getOwnSnapshotKeys(): string[] {
+    return Reflect.ownKeys(this).filter((key): key is string => {
+      return (
+        typeof key === 'string' &&
+        !AcDbObject.SNAPSHOT_EXCLUDED_KEYS.has(key)
+      )
+    })
+  }
+
+  /**
+   * Deep-clones attribute storage into a new {@link AcCmObject} instance.
+   *
+   * @param source - Attribute container to copy
+   * @returns Detached attribute object with the same values as `source`
+   */
+  private cloneAttrs(source: AcCmObject<ATTRS>): AcCmObject<ATTRS> {
+    const attrs = this.cloneValue(source.attributes) as Partial<ATTRS>
+    return new AcCmObject<ATTRS>(attrs)
+  }
+
+  /**
+   * Replaces this object's attributes from a snapshot, removing keys absent in the source.
+   *
+   * Updates are applied silently so restore does not trigger attribute observers.
+   *
+   * @param source - Attribute container captured before modification
+   */
+  private restoreAttrsFrom(source: AcCmObject<ATTRS>): void {
+    const nextAttrs = this.cloneValue(source.attributes) as Partial<ATTRS>
+    const current = this._attrs.attributes as Record<string, unknown>
+
+    for (const key of Object.keys(current)) {
+      if (!(key in nextAttrs)) {
+        this._attrs.set(key as AcCmStringKey<ATTRS>, undefined, {
+          unset: true,
+          silent: true
+        })
+      }
+    }
+
+    this._attrs.set(nextAttrs, { silent: true })
+  }
+
+  /**
+   * Replaces extended-data entries from a snapshot map.
+   *
+   * @param source - Deep-cloned xdata map from a snapshot object
+   */
+  private restoreXDataMapFrom(source: Map<string, AcDbResultBuffer>): void {
+    this._xDataMap.clear()
+    for (const [key, value] of source.entries()) {
+      this._xDataMap.set(key, this.cloneValue(value) as AcDbResultBuffer)
+    }
+  }
+
+  /**
+   * Copies cloneable internal state from this instance onto `target`.
+   *
+   * Used by {@link clone} and {@link clonePreservingIdentity} to populate a
+   * freshly allocated object of the same runtime type.
+   *
+   * @param target - Newly created instance receiving the copied state
+   */
+  private copySnapshotStateTo(target: this): void {
+    target._attrs = this.cloneAttrs(this._attrs)
+    target._xDataMap = this.cloneValue(this._xDataMap) as Map<
+      string,
+      AcDbResultBuffer
+    >
+
+    const source = this as unknown as Record<string, unknown>
+    const dest = target as unknown as Record<string, unknown>
+    for (const key of this.getOwnSnapshotKeys()) {
+      if (AcDbObject.SNAPSHOT_INTERNAL_KEYS.has(key)) {
+        continue
+      }
+      dest[key] = this.cloneValue(source[key])
+    }
+  }
+
   /**
    * Creates a deep clone of this object.
    *
@@ -497,18 +595,74 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    */
   clone(): this {
     const cloned = Object.create(Object.getPrototypeOf(this)) as this
-    const source = this as unknown as Record<string, unknown>
-    const target = cloned as unknown as Record<string, unknown>
+    this.copySnapshotStateTo(cloned)
+    cloned.objectId = this.generateTemporaryHandle()
+    return cloned
+  }
 
-    for (const key of Object.keys(source)) {
-      if (key === '_database') {
+  /**
+   * Creates a deep clone that preserves database identity fields.
+   *
+   * Used for undo/redo snapshots where {@link objectId}, {@link ownerId},
+   * and {@link database} must match the live object after restore.
+   */
+  clonePreservingIdentity(): this {
+    const cloned = this.clone()
+    const objectId = this.getAttrWithoutException('objectId')
+    if (objectId) {
+      cloned._attrs.set('objectId', objectId)
+    }
+    const ownerId = this.getAttrWithoutException('ownerId')
+    if (ownerId !== undefined) {
+      cloned._attrs.set('ownerId', ownerId)
+    }
+    if (this._database) {
+      cloned._database = this._database
+    }
+    return cloned
+  }
+
+  /**
+   * Restores internal state from a detached clone while preserving identity fields.
+   *
+   * @param snapshot - Clone produced by {@link clone} or {@link clonePreservingIdentity}.
+   */
+  restoreFrom(snapshot: this): void {
+    const preservedObjectId = this.objectId
+    const preservedDatabase = this._database
+
+    this.restoreAttrsFrom(snapshot._attrs)
+    this.restoreXDataMapFrom(snapshot._xDataMap)
+
+    const source = snapshot as unknown as Record<string, unknown>
+    const target = this as unknown as Record<string, unknown>
+    const sourceKeys = new Set(snapshot.getOwnSnapshotKeys())
+
+    for (const key of sourceKeys) {
+      if (
+        AcDbObject.SNAPSHOT_INTERNAL_KEYS.has(key) ||
+        AcDbObject.SNAPSHOT_EXCLUDED_KEYS.has(key)
+      ) {
         continue
       }
       target[key] = this.cloneValue(source[key])
     }
 
-    cloned.objectId = this.generateTemporaryHandle()
-    return cloned
+    for (const key of this.getOwnSnapshotKeys()) {
+      if (
+        AcDbObject.SNAPSHOT_INTERNAL_KEYS.has(key) ||
+        AcDbObject.SNAPSHOT_EXCLUDED_KEYS.has(key) ||
+        sourceKeys.has(key)
+      ) {
+        continue
+      }
+      delete target[key]
+    }
+
+    this.objectId = preservedObjectId
+    if (preservedDatabase) {
+      this.database = preservedDatabase
+    }
   }
 
   /**
@@ -559,6 +713,15 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
 
     if (value instanceof ArrayBuffer) {
       return value.slice(0)
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      'tables' in value &&
+      'transactionManager' in value
+    ) {
+      return value
     }
 
     if (

--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -263,6 +263,17 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord {
    * ```
    */
   appendEntity(entity: AcDbEntity | AcDbEntity[]) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot append entities outside an active transaction.'
+      )
+    }
+
     const commitEntity = (item: AcDbEntity) => {
       item.database = this.database
       item.ownerId = this.objectId
@@ -279,21 +290,28 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord {
       }
     }
 
-    if (Array.isArray(entity)) {
-      for (let i = 0; i < entity.length; ++i) {
-        commitEntity(entity[i])
+    const entitiesToAppend = Array.isArray(entity) ? entity : [entity]
+    for (const item of entitiesToAppend) {
+      commitEntity(item)
+    }
+
+    if (manager.isRecording()) {
+      for (const item of entitiesToAppend) {
+        manager.recordAppend(
+          { type: 'blockTableRecord', ownerId: this.objectId },
+          item
+        )
       }
-    } else {
-      commitEntity(entity)
     }
 
     // When creating one block, it will also go to this function. But we don't want `entityAppended` event
     // tiggered in this case. So check whether the block name is name of the model space.
-    if (this.isModelSapce || this.isPaperSapce) {
-      this.database.events.entityAppended.dispatch({
-        database: this.database,
-        entity: entity
-      })
+    if (
+      (this.isModelSapce || this.isPaperSapce) &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      this.database.notifyEntityAppended(entity)
     }
   }
 
@@ -314,20 +332,38 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord {
    * or false if the entity does not exist.
    */
   removeEntity(objectId: AcDbObjectId | AcDbObjectId[]) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot remove entities outside an active transaction.'
+      )
+    }
+
     const ids = Array.isArray(objectId) ? objectId : [objectId]
     const entities: AcDbEntity[] = []
     ids.forEach(id => {
       const entity = this._entities.get(id)
       if (entity) {
+        if (manager.isRecording()) {
+          manager.recordRemove(
+            { type: 'blockTableRecord', ownerId: this.objectId },
+            entity
+          )
+        }
         entities.push(entity)
       }
       this._entities.delete(id)
     })
-    if (entities.length > 0) {
-      this.database.events.entityErased.dispatch({
-        database: this.database,
-        entity: entities
-      })
+    if (
+      entities.length > 0 &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      this.database.notifyEntityErased(entities)
     }
     return entities.length > 0
   }

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -67,6 +67,7 @@ import { AcDbSystemVariables } from './AcDbSystemVariables'
 import { AcDbLayout } from '../object/layout/AcDbLayout'
 import { AcDbLayoutDictionary } from '../object/layout/AcDbLayoutDictionary'
 import { AcDbSymbolTable } from './AcDbSymbolTable'
+import { AcDbDatabaseTransactionManager } from './transaction/AcDbDatabaseTransactionManager'
 
 /**
  * Event arguments for object events in the dictionary.
@@ -409,6 +410,16 @@ export class AcDbDatabase extends AcDbObject {
   /** Current drawing file name (**DWGNAME**), including extension. */
   private _dwgname: string
 
+  /** Manages transactions and undo/redo for this database. */
+  readonly transactionManager: AcDbDatabaseTransactionManager
+
+  private _eventBatchDepth = 0
+  private readonly _pendingEntityModified = new Set<AcDbEntity>()
+  private _pendingEntityAppended: AcDbEntity[] = []
+  private _pendingEntityErased: AcDbEntity[] = []
+  private _pendingDictObjectSet: { object: AcDbObject; key: string }[] = []
+  private _pendingDictObjectErased: { object: AcDbObject; key: string }[] = []
+
   /**
    * Events that can be triggered by the database.
    *
@@ -494,6 +505,7 @@ export class AcDbDatabase extends AcDbObject {
       mlineStyle: new AcDbDictionary(this),
       xrecord: new AcDbDictionary(this)
     }
+    this.transactionManager = new AcDbDatabaseTransactionManager(this)
   }
 
   /**
@@ -525,6 +537,285 @@ export class AcDbDatabase extends AcDbObject {
    */
   get objects() {
     return this._objects
+  }
+
+  /**
+   * Looks up a database-resident object by its object ID.
+   *
+   * Search order: entities, symbol table records, dictionary objects
+   * (including nested dictionaries), then the database object itself.
+   *
+   * @param id - Object identifier to resolve
+   * @param _openErased - Reserved for erased-object support
+   * @returns The matching object, or undefined if not found
+   */
+  getObjectById(
+    id: AcDbObjectId,
+    _openErased = false
+  ): AcDbObject | undefined {
+    if (id === this.objectId) {
+      return this
+    }
+
+    const entity = this.tables.blockTable.getEntityById(id)
+    if (entity) {
+      return entity
+    }
+
+    const symbolTables: AcDbSymbolTable[] = [
+      this.tables.appIdTable,
+      this.tables.blockTable,
+      this.tables.dimStyleTable,
+      this.tables.linetypeTable,
+      this.tables.textStyleTable,
+      this.tables.viewTable,
+      this.tables.layerTable,
+      this.tables.viewportTable
+    ]
+    for (const table of symbolTables) {
+      const record = table.getIdAt(id)
+      if (record) {
+        return record
+      }
+    }
+
+    for (const dictionary of this.getRootDictionaries()) {
+      if (dictionary.objectId === id) {
+        return dictionary
+      }
+      const object = this.findObjectInDictionary(dictionary, id)
+      if (object) {
+        return object
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Returns the top-level named object dictionaries owned by this database.
+   */
+  getRootDictionaries(): AcDbDictionary[] {
+    return [
+      this.objects.dictionary,
+      this.objects.imageDefinition,
+      this.objects.layout,
+      this.objects.mleaderStyle,
+      this.objects.mlineStyle,
+      this.objects.xrecord
+    ]
+  }
+
+  /**
+   * Recursively searches a dictionary tree for an object with the given ID.
+   *
+   * @param dictionary - Root dictionary to search (including nested dictionaries)
+   * @param id - Object identifier to resolve
+   * @returns Matching object, or undefined when not found under `dictionary`
+   */
+  private findObjectInDictionary(
+    dictionary: AcDbDictionary,
+    id: AcDbObjectId
+  ): AcDbObject | undefined {
+    if (dictionary.objectId === id) {
+      return dictionary
+    }
+
+    const direct = dictionary.getIdAt(id)
+    if (direct) {
+      return direct
+    }
+
+    for (const [, entry] of dictionary.entries()) {
+      if (entry.objectId === id) {
+        return entry
+      }
+      if (entry instanceof AcDbDictionary) {
+        const nested = this.findObjectInDictionary(entry, id)
+        if (nested) {
+          return nested
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  /**
+   * Begins suppressing database events until {@link endEventBatch} is called.
+   */
+  beginEventBatch(): void {
+    this._eventBatchDepth++
+  }
+
+  /**
+   * Ends event batching and dispatches accumulated entity events when the outermost batch closes.
+   */
+  endEventBatch(): void {
+    if (this._eventBatchDepth <= 0) {
+      return
+    }
+    this._eventBatchDepth--
+    if (this._eventBatchDepth === 0) {
+      this.flushEventBatch()
+    }
+  }
+
+  /**
+   * Returns true when database events are being batched.
+   */
+  isEventBatched(): boolean {
+    return this._eventBatchDepth > 0
+  }
+
+  /**
+   * Dispatches or queues an entity-modified notification.
+   *
+   * When {@link isEventBatched} is true, the entity is deduplicated in a pending set
+   * and dispatched from {@link flushEventBatch} when the outermost batch closes.
+   *
+   * @param entity - Entity whose properties changed
+   */
+  notifyEntityModified(entity: AcDbEntity): void {
+    if (this.isEventBatched()) {
+      this._pendingEntityModified.add(entity)
+      return
+    }
+    this.events.entityModified.dispatch({
+      database: this,
+      entity
+    })
+  }
+
+  /**
+   * Dispatches or queues an entity-appended notification.
+   *
+   * @param entity - One entity or batch of entities added to model/paper space
+   */
+  notifyEntityAppended(entity: AcDbEntity | AcDbEntity[]): void {
+    if (this.isEventBatched()) {
+      const items = Array.isArray(entity) ? entity : [entity]
+      this._pendingEntityAppended.push(...items)
+      return
+    }
+    this.events.entityAppended.dispatch({
+      database: this,
+      entity
+    })
+  }
+
+  /**
+   * Dispatches or queues an entity-erased notification.
+   *
+   * @param entity - One entity or batch of entities removed from model/paper space
+   */
+  notifyEntityErased(entity: AcDbEntity | AcDbEntity[]): void {
+    if (this.isEventBatched()) {
+      const items = Array.isArray(entity) ? entity : [entity]
+      this._pendingEntityErased.push(...items)
+      return
+    }
+    this.events.entityErased.dispatch({
+      database: this,
+      entity
+    })
+  }
+
+  /**
+   * Dispatches or queues a dictionary-object-set notification.
+   *
+   * @param object - Object inserted or replaced in a named dictionary
+   * @param key - Dictionary key under which the object is stored
+   */
+  notifyDictObjectSet(object: AcDbObject, key: string): void {
+    if (this.isEventBatched()) {
+      this._pendingDictObjectSet.push({ object, key })
+      return
+    }
+    this.events.dictObjetSet.dispatch({
+      database: this,
+      object,
+      key
+    })
+  }
+
+  /**
+   * Dispatches or queues a dictionary-object-erased notification.
+   *
+   * @param object - Object removed from a named dictionary
+   * @param key - Dictionary key that previously referenced the object
+   */
+  notifyDictObjectErased(object: AcDbObject, key: string): void {
+    if (this.isEventBatched()) {
+      this._pendingDictObjectErased.push({ object, key })
+      return
+    }
+    this.events.dictObjectErased.dispatch({
+      database: this,
+      object,
+      key
+    })
+  }
+
+  /**
+   * Dispatches all notifications accumulated while event batching was active.
+   *
+   * Entity-modified events are deduplicated by entity; appended and erased
+   * entities are dispatched in batch arrays where applicable.
+   */
+  private flushEventBatch(): void {
+    if (this._pendingEntityModified.size > 0) {
+      const modified = [...this._pendingEntityModified]
+      this._pendingEntityModified.clear()
+      for (const entity of modified) {
+        this.events.entityModified.dispatch({
+          database: this,
+          entity
+        })
+      }
+    }
+
+    if (this._pendingEntityAppended.length > 0) {
+      const appended = this._pendingEntityAppended
+      this._pendingEntityAppended = []
+      this.events.entityAppended.dispatch({
+        database: this,
+        entity: appended
+      })
+    }
+
+    if (this._pendingEntityErased.length > 0) {
+      const erased = this._pendingEntityErased
+      this._pendingEntityErased = []
+      this.events.entityErased.dispatch({
+        database: this,
+        entity: erased
+      })
+    }
+
+    if (this._pendingDictObjectSet.length > 0) {
+      const dictSet = this._pendingDictObjectSet
+      this._pendingDictObjectSet = []
+      for (const { object, key } of dictSet) {
+        this.events.dictObjetSet.dispatch({
+          database: this,
+          object,
+          key
+        })
+      }
+    }
+
+    if (this._pendingDictObjectErased.length > 0) {
+      const dictErased = this._pendingDictObjectErased
+      this._pendingDictObjectErased = []
+      for (const { object, key } of dictErased) {
+        this.events.dictObjectErased.dispatch({
+          database: this,
+          object,
+          key
+        })
+      }
+    }
   }
 
   /**
@@ -2309,6 +2600,7 @@ export class AcDbDatabase extends AcDbObject {
    * ```
    */
   private clear() {
+    this.transactionManager.clearUndoStack()
     // Clear all tables and dictionaries
     this._tables.blockTable.removeAll()
     this._tables.dimStyleTable.removeAll()
@@ -2335,37 +2627,13 @@ export class AcDbDatabase extends AcDbObject {
     nextValue: T,
     setter: (nextValue: T) => void
   ) {
-    if (!this.hasSysVarValueChanged(currentValue, nextValue)) {
-      return
-    }
-
-    setter(nextValue)
-    this.triggerSysVarChangedEvent(sysVarName, currentValue, nextValue)
-  }
-
-  /**
-   * Determines whether two sysvar values are different.
-   */
-  private hasSysVarValueChanged(currentValue: unknown, nextValue: unknown) {
-    if (currentValue instanceof AcCmColor && nextValue instanceof AcCmColor) {
-      return !currentValue.equals(nextValue)
-    }
-
-    if (
-      currentValue instanceof AcCmTransparency &&
-      nextValue instanceof AcCmTransparency
-    ) {
-      return !currentValue.equals(nextValue)
-    }
-
-    if (
-      currentValue instanceof AcDbDwgVersion &&
-      nextValue instanceof AcDbDwgVersion
-    ) {
-      return currentValue.value !== nextValue.value
-    }
-
-    return !Object.is(currentValue, nextValue)
+    AcDbSysVarManager.instance().applyVarMutation(
+      sysVarName,
+      currentValue,
+      nextValue,
+      this,
+      () => setter(nextValue)
+    )
   }
 
   /**

--- a/packages/data-model/src/database/AcDbSymbolTable.ts
+++ b/packages/data-model/src/database/AcDbSymbolTable.ts
@@ -71,6 +71,19 @@ export class AcDbSymbolTable<
    * ```
    */
   add(record: RecordType) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot add symbol table records outside an active transaction.'
+      )
+    }
+
+    const tableName = manager.resolveSymbolTableName(this)
+
     record.database = this.database
     record.ownerId = this.objectId
 
@@ -81,6 +94,10 @@ export class AcDbSymbolTable<
       this._recordsByName.set(normalizedName, record)
     }
     this._recordsById.set(record.objectId, record)
+
+    if (manager.isRecording()) {
+      manager.recordAppend({ type: 'symbolTable', tableName }, record)
+    }
   }
 
   /**
@@ -101,8 +118,7 @@ export class AcDbSymbolTable<
     const normalizedName = this.normalizeName(name)
     const record = this._recordsByName.get(normalizedName)
     if (record) {
-      this._recordsById.delete(record.objectId)
-      this._recordsByName.delete(normalizedName)
+      this.removeRecord(record)
       return true
     }
     return false
@@ -125,11 +141,39 @@ export class AcDbSymbolTable<
   removeId(id: AcDbObjectId) {
     const record = this._recordsById.get(id)
     if (record) {
-      this._recordsByName.delete(this.normalizeName(record.name))
-      this._recordsById.delete(id)
+      this.removeRecord(record)
       return true
     }
     return false
+  }
+
+  /**
+   * Removes one symbol table record from internal maps and records the change when needed.
+   *
+   * Shared by {@link remove} and {@link removeId}. Enforces strict-mode transaction
+   * requirements before mutating table membership.
+   *
+   * @param record - Symbol table record to remove
+   */
+  private removeRecord(record: RecordType) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot remove symbol table records outside an active transaction.'
+      )
+    }
+
+    if (manager.isRecording()) {
+      const tableName = manager.resolveSymbolTableName(this)
+      manager.recordRemove({ type: 'symbolTable', tableName }, record)
+    }
+
+    this._recordsByName.delete(this.normalizeName(record.name))
+    this._recordsById.delete(record.objectId)
   }
 
   /**

--- a/packages/data-model/src/database/AcDbSysVarManager.ts
+++ b/packages/data-model/src/database/AcDbSysVarManager.ts
@@ -654,6 +654,56 @@ export class AcDbSysVarManager {
   }
 
   /**
+   * Applies one system variable mutation with shared transaction and event rules.
+   *
+   * Database-backed variables should mutate through {@link AcDbDatabase} property
+   * setters or {@link setVar}. Non-database variables mutate through the cache.
+   *
+   * @param name - System variable name (normalized internally)
+   * @param oldVal - Value before mutation; recorded for undo when a transaction is active
+   * @param newVal - Value after mutation; used for change detection and event dispatch
+   * @param db - Database whose transaction manager governs recording and strict mode
+   * @param mutate - Callback that performs the actual value write
+   */
+  public applyVarMutation<T>(
+    name: string,
+    oldVal: T,
+    newVal: T,
+    db: AcDbDatabase,
+    mutate: () => void
+  ): void {
+    const normalizedName = this.normalizeName(name)
+    if (!this.hasValueChanged(oldVal as AcDbSysVarType, newVal as AcDbSysVarType)) {
+      return
+    }
+
+    if (db.transactionManager.isRecording()) {
+      db.transactionManager.recordSysvar(normalizedName, oldVal)
+    } else if (
+      db.transactionManager.strictMode &&
+      !db.transactionManager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        `Cannot change system variable ${normalizedName} outside an active transaction.`
+      )
+    }
+
+    mutate()
+
+    if (
+      !db.transactionManager.isApplyingUndoRedo() &&
+      !db.transactionManager.isRecording()
+    ) {
+      this.events.sysVarChanged.dispatch({
+        database: db,
+        name: normalizedName,
+        newVal: newVal as AcDbSysVarType,
+        oldVal: oldVal as AcDbSysVarType
+      })
+    }
+  }
+
+  /**
    * Set system variable value.
    */
   public setVar(name: string, value: AcDbSysVarType, db: AcDbDatabase) {
@@ -698,17 +748,13 @@ export class AcDbSysVarManager {
         value = intVal
       }
       if (descriptor.isDbVar) {
-        ;(db as unknown as Record<string, unknown>)[name.toLowerCase()] = value
+        this.applyVarMutation(name, oldVal, value, db, () => {
+          ;(db as unknown as Record<string, unknown>)[name.toLowerCase()] = value
+        })
       } else {
-        this.cache.set(name, value)
-        if (this.hasValueChanged(oldVal, value)) {
-          this.events.sysVarChanged.dispatch({
-            database: db,
-            name,
-            newVal: value,
-            oldVal
-          })
-        }
+        this.applyVarMutation(name, oldVal, value, db, () => {
+          this.cache.set(name, value)
+        })
       }
     } else {
       throw new Error(`System variable ${name} not found!`)

--- a/packages/data-model/src/database/index.ts
+++ b/packages/data-model/src/database/index.ts
@@ -71,6 +71,24 @@ export type {
   AcDbSysVarType,
   AcDbSysVarTypeName
 } from './AcDbSysVarManager'
+export {
+  AcDbChangeApplier,
+  AcDbChangeRecorder,
+  AcDbDatabaseTransaction,
+  AcDbDatabaseTransactionManager,
+  AcDbTransaction,
+  AcDbTransactionManager,
+  AcDbUndoStack,
+  areChangeContainersEqual,
+  collectChangeEntities,
+  collectDictionaryChanges
+} from './transaction'
+export type {
+  AcDbChangeContainer,
+  AcDbDatabaseChange,
+  AcDbDictionaryChangeEntry,
+  AcDbUndoRecord
+} from './transaction'
 export { AcDbTextStyleTable } from './AcDbTextStyleTable'
 export { AcDbTextStyleTableRecord } from './AcDbTextStyleTableRecord'
 export { AcDbViewTable } from './AcDbViewTable'

--- a/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
+++ b/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
@@ -1,0 +1,322 @@
+import { AcDbObject } from '../../base'
+import { AcDbEntity } from '../../entity/AcDbEntity'
+import { AcDbDictionary } from '../../object/AcDbDictionary'
+import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbSymbolTable } from '../AcDbSymbolTable'
+import { AcDbSymbolTableRecord } from '../AcDbSymbolTableRecord'
+import { AcDbSysVarManager } from '../AcDbSysVarManager'
+import { AcDbChangeContainer, AcDbDatabaseChange } from './AcDbDatabaseChange'
+
+/**
+ * Applies forward or inverse database changes for undo/redo operations.
+ *
+ * Structural changes (append/remove) and property snapshots (modify/sysvar)
+ * are replayed against a live {@link AcDbDatabase} instance.
+ */
+export class AcDbChangeApplier {
+  /**
+   * Creates an applier bound to one database.
+   *
+   * @param database - Database whose containers and objects receive replayed changes
+   */
+  constructor(private readonly database: AcDbDatabase) {}
+
+  /**
+   * Replays changes in commit order.
+   *
+   * Used by redo and by applying the forward direction of an undo record.
+   *
+   * @param changes - Ordered list of changes recorded by {@link AcDbChangeRecorder}
+   */
+  applyForward(changes: AcDbDatabaseChange[]): void {
+    for (const change of changes) {
+      this.applyChange(change, true)
+    }
+  }
+
+  /**
+   * Replays the inverse of each change in reverse order.
+   *
+   * Used by undo and transaction abort to restore the prior database state.
+   *
+   * @param changes - Ordered list of changes recorded by {@link AcDbChangeRecorder}
+   */
+  applyInverse(changes: AcDbDatabaseChange[]): void {
+    for (let i = changes.length - 1; i >= 0; i--) {
+      this.applyChange(changes[i], false)
+    }
+  }
+
+  /**
+   * Dispatches one recorded change in the requested direction.
+   *
+   * @param change - Single entry from a transaction or undo record
+   * @param forward - When true, replay the original mutation; when false, apply its inverse
+   */
+  private applyChange(change: AcDbDatabaseChange, forward: boolean): void {
+    switch (change.kind) {
+      case 'modify':
+        this.applyModify(change, forward)
+        break
+      case 'append':
+        if (forward) {
+          this.applyAppend(change.container, change.object)
+        } else {
+          this.applyRemove(change.container, change.object)
+        }
+        break
+      case 'remove':
+        if (forward) {
+          this.applyRemove(change.container, change.object)
+        } else {
+          this.applyAppend(change.container, change.object)
+        }
+        break
+      case 'sysvar':
+        this.applySysvar(change, forward)
+        break
+    }
+  }
+
+  /**
+   * Restores object property state from a modify snapshot.
+   *
+   * @param change - Modify entry with before/after clones
+   * @param forward - When true, apply `after`; when false, apply `before`
+   */
+  private applyModify(
+    change: AcDbDatabaseChange & { kind: 'modify' },
+    forward: boolean
+  ): void {
+    const object = this.database.getObjectById(change.objectId)
+    if (!object) {
+      return
+    }
+
+    const snapshot = forward ? change.after : change.before
+    if (snapshot) {
+      object.restoreFrom(snapshot)
+    }
+  }
+
+  /**
+   * Restores a system variable from a sysvar snapshot.
+   *
+   * @param change - Sysvar entry with before/after values
+   * @param forward - When true, apply `after`; when false, apply `before`
+   */
+  private applySysvar(
+    change: AcDbDatabaseChange & { kind: 'sysvar' },
+    forward: boolean
+  ): void {
+    const value = forward ? change.after : change.before
+    if (value === undefined) {
+      return
+    }
+    AcDbSysVarManager.instance().setVar(
+      change.name,
+      value as Parameters<typeof AcDbSysVarManager.prototype.setVar>[1],
+      this.database
+    )
+  }
+
+  /**
+   * Re-inserts an object into the container described by `container`.
+   *
+   * @param container - Target block table record, symbol table, or dictionary entry
+   * @param object - Object snapshot to append
+   */
+  private applyAppend(container: AcDbChangeContainer, object: AcDbObject): void {
+    switch (container.type) {
+      case 'blockTableRecord': {
+        const btr = this.database.tables.blockTable.getIdAt(container.ownerId)
+        if (btr) {
+          btr.appendEntity(object as AcDbEntity)
+        }
+        break
+      }
+      case 'symbolTable': {
+        const table = this.getSymbolTable(container.tableName)
+        if (table) {
+          table.add(object as AcDbSymbolTableRecord)
+        }
+        break
+      }
+      case 'dictionary': {
+        const dictionary = this.database.getObjectById(
+          container.dictionaryId
+        ) as AcDbDictionary | undefined
+        if (dictionary) {
+          dictionary.setAt(container.key, object)
+        }
+        break
+      }
+    }
+  }
+
+  /**
+   * Removes an object from the container described by `container`.
+   *
+   * @param container - Source block table record, symbol table, or dictionary entry
+   * @param object - Object whose {@link AcDbObject.objectId} identifies the removal target
+   */
+  private applyRemove(container: AcDbChangeContainer, object: AcDbObject): void {
+    switch (container.type) {
+      case 'blockTableRecord': {
+        const btr = this.database.tables.blockTable.getIdAt(container.ownerId)
+        if (btr) {
+          btr.removeEntity(object.objectId)
+        }
+        break
+      }
+      case 'symbolTable': {
+        const table = this.getSymbolTable(container.tableName)
+        if (table) {
+          table.removeId(object.objectId)
+        }
+        break
+      }
+      case 'dictionary': {
+        const dictionary = this.database.getObjectById(
+          container.dictionaryId
+        ) as AcDbDictionary | undefined
+        if (dictionary) {
+          dictionary.removeId(object.objectId)
+        }
+        break
+      }
+    }
+  }
+
+  /**
+   * Resolves a symbol table instance from the stable name stored in undo records.
+   *
+   * @param tableName - Logical table name (for example, `"layerTable"`) or unknown fallback ID
+   * @returns Matching table on this applier's database, or undefined when unrecognized
+   */
+  private getSymbolTable(tableName: string): AcDbSymbolTable | undefined {
+    const tables = this.database.tables
+    switch (tableName) {
+      case 'appIdTable':
+        return tables.appIdTable
+      case 'blockTable':
+        return tables.blockTable
+      case 'dimStyleTable':
+        return tables.dimStyleTable
+      case 'linetypeTable':
+        return tables.linetypeTable
+      case 'textStyleTable':
+        return tables.textStyleTable
+      case 'viewTable':
+        return tables.viewTable
+      case 'layerTable':
+        return tables.layerTable
+      case 'viewportTable':
+        return tables.viewportTable
+      default:
+        return undefined
+    }
+  }
+}
+
+/**
+ * Collects entities affected by changes for post-commit/undo/redo event dispatch.
+ *
+ * Only block-table-record append/remove operations contribute to the
+ * appended and erased lists; modify entries always resolve through object IDs.
+ *
+ * @param database - Database used to resolve live entity references
+ * @param changes - Changes produced by a transaction or undo record
+ * @returns Entity buckets keyed by the kind of structural or property change
+ */
+export function collectChangeEntities(
+  database: AcDbDatabase,
+  changes: AcDbDatabaseChange[]
+): {
+  /** Entities whose properties were modified */
+  modified: AcDbEntity[]
+  /** Entities appended to a block table record */
+  appended: AcDbEntity[]
+  /** Entities removed from a block table record */
+  erased: AcDbEntity[]
+} {
+  const modified: AcDbEntity[] = []
+  const appended: AcDbEntity[] = []
+  const erased: AcDbEntity[] = []
+
+  for (const change of changes) {
+    if (change.kind === 'modify') {
+      const object = database.getObjectById(change.objectId)
+      if (object instanceof AcDbEntity) {
+        modified.push(object)
+      }
+    } else if (change.kind === 'append') {
+      if (change.container.type === 'blockTableRecord') {
+        const entity =
+          database.tables.blockTable.getEntityById(change.object.objectId) ??
+          (change.object instanceof AcDbEntity ? change.object : undefined)
+        if (entity) {
+          appended.push(entity)
+        }
+      }
+    } else if (change.kind === 'remove') {
+      if (change.container.type === 'blockTableRecord') {
+        if (change.object instanceof AcDbEntity) {
+          erased.push(change.object)
+        }
+      }
+    }
+  }
+
+  return { modified, appended, erased }
+}
+
+/**
+ * One dictionary entry referenced by an append or remove change.
+ */
+export interface AcDbDictionaryChangeEntry {
+  /** Dictionary object that was set or erased */
+  object: AcDbObject
+  /** Dictionary key associated with the object */
+  key: string
+}
+
+/**
+ * Collects dictionary entries affected by changes for post-commit/undo/redo dispatch.
+ *
+ * @param database - Database used to resolve live object references after replay
+ * @param changes - Changes produced by a transaction or undo record
+ * @returns Dictionary entries grouped by set and erase operations
+ */
+export function collectDictionaryChanges(
+  database: AcDbDatabase,
+  changes: AcDbDatabaseChange[]
+): {
+  /** Entries inserted or replaced in a dictionary */
+  set: AcDbDictionaryChangeEntry[]
+  /** Entries removed from a dictionary */
+  erased: AcDbDictionaryChangeEntry[]
+} {
+  const set: AcDbDictionaryChangeEntry[] = []
+  const erased: AcDbDictionaryChangeEntry[] = []
+
+  for (const change of changes) {
+    if (change.kind !== 'append' && change.kind !== 'remove') {
+      continue
+    }
+    if (change.container.type !== 'dictionary') {
+      continue
+    }
+
+    const key = change.container.key
+    if (change.kind === 'append') {
+      const object =
+        database.getObjectById(change.object.objectId) ?? change.object
+      set.push({ object, key })
+    } else if (change.kind === 'remove') {
+      erased.push({ object: change.object, key })
+    }
+  }
+
+  return { set, erased }
+}

--- a/packages/data-model/src/database/transaction/AcDbChangeRecorder.ts
+++ b/packages/data-model/src/database/transaction/AcDbChangeRecorder.ts
@@ -1,0 +1,237 @@
+import { AcDbObject } from '../../base'
+import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbSysVarManager } from '../AcDbSysVarManager'
+import {
+  AcDbChangeContainer,
+  AcDbDatabaseChange,
+  areChangeContainersEqual
+} from './AcDbDatabaseChange'
+
+/**
+ * Accumulates structured database changes during an active transaction.
+ *
+ * Append/remove pairs that cancel within the same transaction are coalesced,
+ * and duplicate modify/sysvar entries for the same target are ignored.
+ */
+export class AcDbChangeRecorder {
+  private readonly changes: AcDbDatabaseChange[] = []
+
+  /**
+   * Returns the changes recorded so far in this transaction.
+   *
+   * The returned array is the internal store; callers should treat it as read-only.
+   */
+  getChanges(): AcDbDatabaseChange[] {
+    return this.changes
+  }
+
+  /**
+   * Discards all recorded changes without applying them.
+   */
+  clear(): void {
+    this.changes.length = 0
+  }
+
+  /**
+   * Merges changes from a nested transaction into this recorder.
+   *
+   * Used when an inner transaction commits into its parent without touching
+   * the undo stack.
+   *
+   * @param other - Recorder from a child transaction being committed
+   */
+  mergeFrom(other: AcDbChangeRecorder): void {
+    for (const change of other.getChanges()) {
+      this.mergeChange(change)
+    }
+  }
+
+  /**
+   * Records the pre-modification snapshot of an opened-for-write object.
+   *
+   * Only the first modify entry per {@link AcDbObject.objectId} is kept.
+   *
+   * @param object - Object whose state should be restorable on abort/undo
+   */
+  recordModify(object: AcDbObject): void {
+    const objectId = object.objectId
+    const existing = this.changes.find(
+      c => c.kind === 'modify' && c.objectId === objectId
+    )
+    if (existing) {
+      return
+    }
+    this.changes.push({
+      kind: 'modify',
+      objectId,
+      before: object.clonePreservingIdentity()
+    })
+  }
+
+  /**
+   * Records insertion of an object into a database container.
+   *
+   * If a matching remove was recorded earlier in the same transaction,
+   * the pair cancels and neither change is retained.
+   *
+   * @param container - Container that received the object
+   * @param object - Object that was appended; stored as an identity-preserving clone
+   */
+  recordAppend(container: AcDbChangeContainer, object: AcDbObject): void {
+    this.recordStructuralChange({
+      kind: 'append',
+      container,
+      object: object.clonePreservingIdentity()
+    })
+  }
+
+  /**
+   * Records removal of an object from a database container.
+   *
+   * If a matching append was recorded earlier in the same transaction,
+   * the pair cancels and neither change is retained.
+   *
+   * @param container - Container that owned the removed object
+   * @param object - Object that was removed; stored as an identity-preserving clone
+   */
+  recordRemove(container: AcDbChangeContainer, object: AcDbObject): void {
+    this.recordStructuralChange({
+      kind: 'remove',
+      container,
+      object: object.clonePreservingIdentity()
+    })
+  }
+
+  /**
+   * Records the value of a system variable before mutation.
+   *
+   * Only the first sysvar entry per normalized name is kept.
+   *
+   * @param name - System variable name (case-insensitive)
+   * @param before - Value observed before the mutation
+   */
+  recordSysvar(name: string, before: unknown): void {
+    const normalizedName = name.toLowerCase()
+    const existing = this.changes.find(
+      c => c.kind === 'sysvar' && c.name === normalizedName
+    )
+    if (existing) {
+      return
+    }
+    this.changes.push({
+      kind: 'sysvar',
+      name: normalizedName,
+      before
+    })
+  }
+
+  /**
+   * Captures the post-change state for modify and sysvar entries at commit time.
+   *
+   * Append/remove entries are complete when recorded and do not require
+   * finalization.
+   *
+   * @param database - Database used to read live post-commit values
+   */
+  finalize(database: AcDbDatabase): void {
+    for (const change of this.changes) {
+      if (change.kind === 'modify') {
+        const object = database.getObjectById(change.objectId)
+        if (object) {
+          change.after = object.clonePreservingIdentity()
+        }
+      } else if (change.kind === 'sysvar') {
+        change.after = this.getSysvarValue(database, change.name)
+      }
+    }
+  }
+
+  /**
+   * Records or coalesces one append/remove change.
+   *
+   * When an opposite structural change for the same container and object ID
+   * already exists in this transaction, both entries cancel and neither is kept.
+   *
+   * @param change - Append or remove entry to merge into the recorder
+   */
+  private recordStructuralChange(
+    change: Extract<AcDbDatabaseChange, { kind: 'append' | 'remove' }>
+  ): void {
+    const oppositeKind = change.kind === 'append' ? 'remove' : 'append'
+    const cancelIndex = this.findStructuralChangeIndex(
+      oppositeKind,
+      change.container,
+      change.object.objectId
+    )
+    if (cancelIndex >= 0) {
+      this.changes.splice(cancelIndex, 1)
+      return
+    }
+
+    this.changes.push(change)
+  }
+
+  /**
+   * Merges one change from a nested transaction into this recorder.
+   *
+   * Modify and sysvar entries deduplicate by object ID or variable name;
+   * structural entries use the same cancel/coalesce rules as {@link recordAppend}.
+   *
+   * @param change - Change copied from a child transaction recorder
+   */
+  private mergeChange(change: AcDbDatabaseChange): void {
+    if (change.kind === 'modify') {
+      const existing = this.changes.find(
+        c => c.kind === 'modify' && c.objectId === change.objectId
+      )
+      if (!existing) {
+        this.changes.push(change)
+      }
+      return
+    }
+
+    if (change.kind === 'sysvar') {
+      const existing = this.changes.find(
+        c => c.kind === 'sysvar' && c.name === change.name
+      )
+      if (!existing) {
+        this.changes.push(change)
+      }
+      return
+    }
+
+    this.recordStructuralChange(change)
+  }
+
+  /**
+   * Finds the index of a structural change matching kind, container, and object ID.
+   *
+   * @param kind - Append or remove kind to search for
+   * @param container - Container descriptor that must match exactly
+   * @param objectId - Object identifier of the affected record
+   * @returns Index in {@link changes}, or `-1` when no match exists
+   */
+  private findStructuralChangeIndex(
+    kind: 'append' | 'remove',
+    container: AcDbChangeContainer,
+    objectId: string
+  ): number {
+    return this.changes.findIndex(
+      change =>
+        change.kind === kind &&
+        change.object.objectId === objectId &&
+        areChangeContainersEqual(change.container, container)
+    )
+  }
+
+  /**
+   * Reads the current value of a system variable from the database.
+   *
+   * @param database - Database passed to {@link AcDbSysVarManager.getVar}
+   * @param name - Normalized system variable name
+   * @returns Live variable value used to populate `after` during {@link finalize}
+   */
+  private getSysvarValue(database: AcDbDatabase, name: string): unknown {
+    return AcDbSysVarManager.instance().getVar(name, database)
+  }
+}

--- a/packages/data-model/src/database/transaction/AcDbDatabaseChange.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseChange.ts
@@ -1,0 +1,86 @@
+import { AcDbObject } from '../../base'
+
+/**
+ * Identifies the container that holds a database object for undo/redo recording.
+ *
+ * - `blockTableRecord` — entity membership in a block table record
+ * - `symbolTable` — symbol table record membership
+ * - `dictionary` — named entry in an {@link AcDbDictionary}
+ */
+export type AcDbChangeContainer =
+  | { type: 'blockTableRecord'; ownerId: string }
+  | { type: 'symbolTable'; tableName: string }
+  | { type: 'dictionary'; dictionaryId: string; key: string }
+
+/**
+ * A single recorded change within a transaction or undo record.
+ *
+ * Each variant stores enough information for {@link AcDbChangeApplier} to
+ * replay the change forward or in reverse.
+ */
+export type AcDbDatabaseChange =
+  | {
+      /** Property snapshot change for one database-resident object */
+      kind: 'modify'
+      /** Object whose properties changed */
+      objectId: string
+      /** State before the transaction or undoable operation */
+      before: AcDbObject
+      /** State after commit; populated by {@link AcDbChangeRecorder.finalize} */
+      after?: AcDbObject
+    }
+  | {
+      /** Object inserted into a container */
+      kind: 'append'
+      /** Container that received the object */
+      container: AcDbChangeContainer
+      /** Appended object snapshot */
+      object: AcDbObject
+    }
+  | {
+      /** Object removed from a container */
+      kind: 'remove'
+      /** Container that owned the object */
+      container: AcDbChangeContainer
+      /** Removed object snapshot */
+      object: AcDbObject
+    }
+  | {
+      /** System variable value change */
+      kind: 'sysvar'
+      /** Normalized system variable name */
+      name: string
+      /** Value before the mutation */
+      before: unknown
+      /** Value after commit; populated by {@link AcDbChangeRecorder.finalize} */
+      after?: unknown
+    }
+
+/**
+ * Returns true when two change containers refer to the same storage location.
+ *
+ * @param a - First container descriptor
+ * @param b - Second container descriptor
+ * @returns True when both descriptors identify the same append/remove target
+ */
+export function areChangeContainersEqual(
+  a: AcDbChangeContainer,
+  b: AcDbChangeContainer
+): boolean {
+  if (a.type !== b.type) {
+    return false
+  }
+
+  switch (a.type) {
+    case 'blockTableRecord':
+      return b.type === 'blockTableRecord' && a.ownerId === b.ownerId
+    case 'symbolTable':
+      return b.type === 'symbolTable' && a.tableName === b.tableName
+    case 'dictionary':
+      return (
+        b.type === 'dictionary' &&
+        a.dictionaryId === b.dictionaryId &&
+        a.key === b.key
+      )
+  }
+}

--- a/packages/data-model/src/database/transaction/AcDbDatabaseTransaction.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseTransaction.ts
@@ -1,0 +1,37 @@
+import { AcDbObject, AcDbObjectId } from '../../base'
+import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbTransaction } from './AcDbTransaction'
+
+/**
+ * Database-bound transaction with object lookup through {@link AcDbDatabase}.
+ *
+ * Created by {@link AcDbDatabaseTransactionManager.startTransaction} and
+ * returned from {@link AcDbDatabaseTransactionManager.runUndoable}.
+ */
+export class AcDbDatabaseTransaction extends AcDbTransaction {
+  /**
+   * @param database - Database whose objects are opened and recorded
+   */
+  constructor(private readonly database: AcDbDatabase) {
+    super()
+  }
+
+  /**
+   * Resolves an object ID through the owning database.
+   *
+   * @param objectId - Identifier of the object to open
+   * @param openErased - Reserved for erased-object support
+   * @returns The matching live object
+   * @throws Error when the object cannot be found
+   */
+  protected override lookupObject<T extends AcDbObject>(
+    objectId: AcDbObjectId,
+    openErased: boolean
+  ): T {
+    const obj = this.database.getObjectById(objectId, openErased)
+    if (!obj) {
+      throw new Error(`lookupObject(${objectId}) not found`)
+    }
+    return obj as T
+  }
+}

--- a/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
@@ -1,0 +1,499 @@
+import { AcDbObject } from '../../base'
+import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbSysVarManager, AcDbSysVarType } from '../AcDbSysVarManager'
+import {
+  AcDbChangeApplier,
+  collectChangeEntities,
+  collectDictionaryChanges
+} from './AcDbChangeApplier'
+import { AcDbChangeContainer } from './AcDbDatabaseChange'
+import { AcDbDatabaseTransaction } from './AcDbDatabaseTransaction'
+import { AcDbUndoStack } from './AcDbUndoStack'
+
+/**
+ * Pending undo-record payload collected between {@link startUndoMark} and {@link endUndoMark}.
+ */
+interface AcDbUndoMarkState {
+  /** Optional label shown in undo UI */
+  label?: string
+  /** Changes committed while this undo mark was active */
+  pendingChanges: import('./AcDbDatabaseChange').AcDbDatabaseChange[]
+}
+
+/**
+ * Manages database transactions and undo/redo history for one {@link AcDbDatabase}.
+ *
+ * Aligns with ObjectARX {@code AcDbTransactionManager} semantics and provides
+ * undo mark grouping for editor commands.
+ */
+export class AcDbDatabaseTransactionManager {
+  private readonly transactionStack: AcDbDatabaseTransaction[] = []
+  private readonly undoStack = new AcDbUndoStack()
+  private readonly changeApplier: AcDbChangeApplier
+  private readonly undoMarkStack: AcDbUndoMarkState[] = []
+  private _applyingUndoRedo = false
+
+  /**
+   * When true, mutations outside an active transaction throw an error.
+   *
+   * Undo/redo replay is exempt so {@link AcDbChangeApplier} can restore state.
+   */
+  strictMode = false
+
+  /**
+   * Creates a transaction manager for one database.
+   *
+   * @param database - Database whose mutations and undo history are managed
+   */
+  constructor(private readonly database: AcDbDatabase) {
+    this.changeApplier = new AcDbChangeApplier(database)
+  }
+
+  /**
+   * Starts a new database transaction and pushes it onto the stack.
+   *
+   * Equivalent to ObjectARX `AcDbTransactionManager::startTransaction()`.
+   *
+   * @returns The newly created transaction
+   */
+  startTransaction(): AcDbDatabaseTransaction {
+    const tr = new AcDbDatabaseTransaction(this.database)
+    this.transactionStack.push(tr)
+    return tr
+  }
+
+  /**
+   * Returns the top-most active transaction, if any.
+   */
+  currentTransaction(): AcDbDatabaseTransaction | undefined {
+    return this.transactionStack[this.transactionStack.length - 1]
+  }
+
+  /**
+   * Returns true when at least one transaction is active.
+   */
+  hasTransaction(): boolean {
+    return this.transactionStack.length > 0
+  }
+
+  /**
+   * Returns true when mutations should be recorded into the current transaction.
+   *
+   * Recording is disabled while undo/redo is being applied.
+   */
+  isRecording(): boolean {
+    return this.hasTransaction() && !this._applyingUndoRedo
+  }
+
+  /**
+   * Returns true while {@link AcDbChangeApplier} is replaying undo or redo changes.
+   */
+  isApplyingUndoRedo(): boolean {
+    return this._applyingUndoRedo
+  }
+
+  /**
+   * Commits the current transaction.
+   *
+   * Nested transactions merge their recorder into the parent. The outermost
+   * commit finalizes changes, dispatches events, and enqueues undo history
+   * when an undo mark is active.
+   *
+   * @throws Error if no transaction is active
+   */
+  commitTransaction(): void {
+    const tr = this.transactionStack.pop()
+    if (!tr) {
+      throw new Error('No active transaction to commit.')
+    }
+
+    if (this.transactionStack.length > 0) {
+      const parent = this.transactionStack[this.transactionStack.length - 1]
+      parent.recorder.mergeFrom(tr.recorder)
+      tr.commit()
+      return
+    }
+
+    tr.recorder.finalize(this.database)
+    const changes = tr.recorder.getChanges()
+    tr.commit()
+
+    if (changes.length > 0) {
+      this.dispatchCommitEvents(changes)
+      this.enqueueUndoChanges(changes)
+    }
+  }
+
+  /**
+   * Aborts the current transaction and rolls back all recorded changes.
+   *
+   * @throws Error if no transaction is active
+   */
+  abortTransaction(): void {
+    const tr = this.transactionStack.pop()
+    if (!tr) {
+      throw new Error('No active transaction to abort.')
+    }
+
+    const changes = [...tr.recorder.getChanges()]
+
+    this.database.beginEventBatch()
+    this._applyingUndoRedo = true
+    try {
+      tr.abort()
+      if (changes.length > 0) {
+        this.changeApplier.applyInverse(changes)
+      }
+    } finally {
+      this._applyingUndoRedo = false
+      this.database.endEventBatch()
+    }
+  }
+
+  /**
+   * Opens an undo-mark group.
+   *
+   * Commits performed before {@link endUndoMark} are merged into one
+   * {@link AcDbUndoRecord}.
+   *
+   * @param label - Optional label for undo UI (for example, `"Move"`)
+   */
+  startUndoMark(label?: string): void {
+    this.undoMarkStack.push({ label, pendingChanges: [] })
+  }
+
+  /**
+   * Closes the current undo mark and pushes a record when changes were committed.
+   *
+   * @throws Error if no undo mark is active
+   */
+  endUndoMark(): void {
+    const mark = this.undoMarkStack.pop()
+    if (!mark) {
+      throw new Error('No active undo mark to end.')
+    }
+
+    if (mark.pendingChanges.length === 0) {
+      return
+    }
+
+    this.undoStack.push({
+      label: mark.label,
+      changes: mark.pendingChanges
+    })
+  }
+
+  /**
+   * Discards the current undo mark without creating an undo record.
+   */
+  cancelUndoMark(): void {
+    if (this.undoMarkStack.length > 0) {
+      this.undoMarkStack.pop()
+    }
+  }
+
+  /**
+   * Undoes the most recent undo record.
+   *
+   * @returns True when an undo record was applied; false when the stack is empty
+   */
+  undo(): boolean {
+    const record = this.undoStack.popUndo()
+    if (!record) {
+      return false
+    }
+
+    this.database.beginEventBatch()
+    this._applyingUndoRedo = true
+    try {
+      this.changeApplier.applyInverse(record.changes)
+      this.dispatchUndoRedoEvents(record.changes, true)
+    } finally {
+      this._applyingUndoRedo = false
+      this.database.endEventBatch()
+    }
+
+    this.undoStack.pushRedo(record)
+    return true
+  }
+
+  /**
+   * Redoes the most recently undone record.
+   *
+   * @returns True when a redo record was applied; false when the redo stack is empty
+   */
+  redo(): boolean {
+    const record = this.undoStack.popRedo()
+    if (!record) {
+      return false
+    }
+
+    this.database.beginEventBatch()
+    this._applyingUndoRedo = true
+    try {
+      this.changeApplier.applyForward(record.changes)
+      this.dispatchUndoRedoEvents(record.changes, false)
+    } finally {
+      this._applyingUndoRedo = false
+      this.database.endEventBatch()
+    }
+
+    this.undoStack.push(record)
+    return true
+  }
+
+  /**
+   * Returns true when at least one undo record is available.
+   */
+  canUndo(): boolean {
+    return this.undoStack.canUndo()
+  }
+
+  /**
+   * Returns true when at least one redo record is available.
+   */
+  canRedo(): boolean {
+    return this.undoStack.canRedo()
+  }
+
+  /**
+   * Clears both undo and redo history for this database.
+   */
+  clearUndoStack(): void {
+    this.undoStack.clear()
+  }
+
+  /**
+   * Records append of an object into a container during the active transaction.
+   *
+   * No-op when {@link isRecording} is false.
+   *
+   * @param container - Container that received the object
+   * @param object - Object that was appended
+   */
+  recordAppend(container: AcDbChangeContainer, object: AcDbObject): void {
+    if (!this.isRecording()) {
+      return
+    }
+    this.currentTransaction()?.recorder.recordAppend(container, object)
+  }
+
+  /**
+   * Records removal of an object from a container during the active transaction.
+   *
+   * No-op when {@link isRecording} is false.
+   *
+   * @param container - Container that owned the removed object
+   * @param object - Object that was removed
+   */
+  recordRemove(container: AcDbChangeContainer, object: AcDbObject): void {
+    if (!this.isRecording()) {
+      return
+    }
+    this.currentTransaction()?.recorder.recordRemove(container, object)
+  }
+
+  /**
+   * Records the pre-change value of a system variable.
+   *
+   * No-op when {@link isRecording} is false.
+   *
+   * @param name - System variable name
+   * @param before - Value observed before mutation
+   */
+  recordSysvar(name: string, before: unknown): void {
+    if (!this.isRecording()) {
+      return
+    }
+    this.currentTransaction()?.recorder.recordSysvar(name, before)
+  }
+
+  /**
+   * Maps a symbol table instance to the stable name stored in undo records.
+   *
+   * @param table - Symbol table whose logical name is needed
+   * @returns Known table name, or the table's object ID as a fallback
+   */
+  resolveSymbolTableName(table: { objectId: string }): string {
+    const tables = this.database.tables
+    if (table === tables.appIdTable) return 'appIdTable'
+    if (table === tables.blockTable) return 'blockTable'
+    if (table === tables.dimStyleTable) return 'dimStyleTable'
+    if (table === tables.linetypeTable) return 'linetypeTable'
+    if (table === tables.textStyleTable) return 'textStyleTable'
+    if (table === tables.viewTable) return 'viewTable'
+    if (table === tables.layerTable) return 'layerTable'
+    if (table === tables.viewportTable) return 'viewportTable'
+    return table.objectId
+  }
+
+  /**
+   * Runs one undoable editor command inside a transaction and undo mark.
+   *
+   * On success the transaction is committed and the undo mark is closed.
+   * On failure the transaction is aborted and the undo mark is cancelled.
+   *
+   * @param label - Label stored on the resulting undo record
+   * @param fn - Callback that performs the command using the active transaction
+   * @returns The value returned by `fn`
+   */
+  runUndoable<T>(
+    label: string,
+    fn: (tr: AcDbDatabaseTransaction) => T
+  ): T {
+    this.startUndoMark(label)
+    this.startTransaction()
+    try {
+      const result = fn(this.currentTransaction()!)
+      this.commitTransaction()
+      this.endUndoMark()
+      return result
+    } catch (error) {
+      if (this.hasTransaction()) {
+        this.abortTransaction()
+      }
+      this.cancelUndoMark()
+      throw error
+    }
+  }
+
+  /**
+   * Appends committed changes to the active undo mark, if any.
+   *
+   * Called after the outermost transaction commit so multiple commits within
+   * one {@link startUndoMark} group merge into a single {@link AcDbUndoRecord}.
+   *
+   * @param changes - Finalized changes from the committed transaction
+   */
+  private enqueueUndoChanges(
+    changes: import('./AcDbDatabaseChange').AcDbDatabaseChange[]
+  ): void {
+    const activeMark = this.undoMarkStack[this.undoMarkStack.length - 1]
+    if (!activeMark) {
+      return
+    }
+
+    for (const change of changes) {
+      activeMark.pendingChanges.push(change)
+    }
+  }
+
+  /**
+   * Dispatches entity, dictionary, and sysvar events after a successful commit.
+   *
+   * @param changes - Finalized changes from the committed outermost transaction
+   */
+  private dispatchCommitEvents(
+    changes: import('./AcDbDatabaseChange').AcDbDatabaseChange[]
+  ): void {
+    const { modified, appended, erased } = collectChangeEntities(
+      this.database,
+      changes
+    )
+
+    for (const entity of modified) {
+      entity.triggerModifiedEvent()
+    }
+    if (appended.length > 0) {
+      this.database.notifyEntityAppended(appended)
+    }
+    if (erased.length > 0) {
+      this.database.notifyEntityErased(erased)
+    }
+
+    const { set: dictSet, erased: dictErased } = collectDictionaryChanges(
+      this.database,
+      changes
+    )
+    for (const { object, key } of dictSet) {
+      this.database.notifyDictObjectSet(object, key)
+    }
+    for (const { object, key } of dictErased) {
+      this.database.notifyDictObjectErased(object, key)
+    }
+
+    for (const change of changes) {
+      if (change.kind === 'sysvar' && change.after !== undefined) {
+        AcDbSysVarManager.instance().events.sysVarChanged.dispatch({
+          database: this.database,
+          name: change.name,
+          oldVal: change.before as AcDbSysVarType,
+          newVal: change.after as AcDbSysVarType
+        })
+      }
+    }
+  }
+
+  /**
+   * Dispatches entity, dictionary, and sysvar events after undo or redo replay.
+   *
+   * Append/remove and dictionary notifications are swapped when `inverse` is
+   * true so listeners observe the same semantics as the user-facing operation.
+   *
+   * @param changes - Changes from the undo record being applied
+   * @param inverse - True when undoing (inverse replay); false when redoing
+   */
+  private dispatchUndoRedoEvents(
+    changes: import('./AcDbDatabaseChange').AcDbDatabaseChange[],
+    inverse: boolean
+  ): void {
+    const { modified, appended, erased } = collectChangeEntities(
+      this.database,
+      changes
+    )
+
+    const { set: dictSet, erased: dictErased } = collectDictionaryChanges(
+      this.database,
+      changes
+    )
+
+    if (inverse) {
+      for (const entity of modified) {
+        entity.triggerModifiedEvent()
+      }
+      if (erased.length > 0) {
+        this.database.notifyEntityAppended(erased)
+      }
+      if (appended.length > 0) {
+        this.database.notifyEntityErased(appended)
+      }
+      for (const { object, key } of dictErased) {
+        this.database.notifyDictObjectSet(object, key)
+      }
+      for (const { object, key } of dictSet) {
+        this.database.notifyDictObjectErased(object, key)
+      }
+    } else {
+      for (const entity of modified) {
+        entity.triggerModifiedEvent()
+      }
+      if (appended.length > 0) {
+        this.database.notifyEntityAppended(appended)
+      }
+      if (erased.length > 0) {
+        this.database.notifyEntityErased(erased)
+      }
+      for (const { object, key } of dictSet) {
+        this.database.notifyDictObjectSet(object, key)
+      }
+      for (const { object, key } of dictErased) {
+        this.database.notifyDictObjectErased(object, key)
+      }
+    }
+
+    for (const change of changes) {
+      if (change.kind === 'sysvar') {
+        const oldVal = inverse ? change.after : change.before
+        const newVal = inverse ? change.before : change.after
+        if (newVal !== undefined) {
+          AcDbSysVarManager.instance().events.sysVarChanged.dispatch({
+            database: this.database,
+            name: change.name,
+            oldVal: oldVal as AcDbSysVarType,
+            newVal: newVal as AcDbSysVarType
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/data-model/src/database/transaction/AcDbTransaction.ts
+++ b/packages/data-model/src/database/transaction/AcDbTransaction.ts
@@ -1,4 +1,5 @@
 import { AcDbObject, AcDbObjectId, AcDbOpenMode } from '../../base'
+import { AcDbChangeRecorder } from './AcDbChangeRecorder'
 
 /**
  * Represents a single database transaction.
@@ -13,31 +14,41 @@ export class AcDbTransaction {
   private readonly openedObjects = new Map<AcDbObjectId, AcDbObject>()
 
   /** Snapshots of objects before modification */
-  private readonly originalStates = new Map<AcDbObjectId, unknown>()
+  private readonly originalStates = new Map<AcDbObjectId, AcDbObject>()
+
+  /** Structured changes recorded during this transaction for commit/undo integration */
+  readonly recorder = new AcDbChangeRecorder()
 
   /**
    * Records an object opening.
    *
+   * When the object is opened for write, a pre-modification snapshot is stored
+   * for abort rollback and a modify entry is added to {@link recorder}.
+   *
    * @param objectId - Object identifier
    * @param mode - Open mode
    * @param openErased - Whether erased objects are allowed
+   * @returns The opened object, or the cached instance if already opened in this transaction
    */
   getObject<T extends AcDbObject>(
     objectId: AcDbObjectId,
     mode: AcDbOpenMode,
     openErased = false
   ): T | undefined {
-    if (!this.openedObjects.has(objectId)) {
-      const obj = this.lookupObject<T>(objectId, openErased)
-      this.openedObjects.set(objectId, obj)
-
-      if (mode === AcDbOpenMode.kForWrite) {
-        // Deep snapshot for rollback
-        this.originalStates.set(obj.objectId, structuredClone(obj))
-      }
-      return obj
+    const opened = this.openedObjects.get(objectId)
+    if (opened) {
+      return opened as T
     }
-    return undefined
+
+    const obj = this.lookupObject<T>(objectId, openErased)
+    this.openedObjects.set(objectId, obj)
+
+    if (mode === AcDbOpenMode.kForWrite) {
+      const snapshot = obj.clonePreservingIdentity()
+      this.originalStates.set(obj.objectId, snapshot)
+      this.recorder.recordModify(obj)
+    }
+    return obj
   }
 
   /**
@@ -56,12 +67,13 @@ export class AcDbTransaction {
     for (const [id, snapshot] of this.originalStates) {
       const obj = this.openedObjects.get(id)
       if (obj) {
-        Object.assign(obj, snapshot)
+        obj.restoreFrom(snapshot)
       }
     }
 
     this.originalStates.clear()
     this.openedObjects.clear()
+    this.recorder.clear()
   }
 
   /**

--- a/packages/data-model/src/database/transaction/AcDbTransactionManager.ts
+++ b/packages/data-model/src/database/transaction/AcDbTransactionManager.ts
@@ -3,10 +3,9 @@ import { AcDbTransaction } from './AcDbTransaction'
 /**
  * Manages database transactions.
  *
- * This class is the TypeScript equivalent of ObjectARX AcDbTransactionManager.
- * It supports nested transactions and object open tracking.
- *
- * A transaction must be explicitly committed or aborted.
+ * @deprecated Use {@link AcDbDatabaseTransactionManager} via
+ * {@link AcDbDatabase.transactionManager} for database-bound transactions,
+ * undo/redo, and change recording.
  */
 export class AcDbTransactionManager {
   /** Stack of active transactions */

--- a/packages/data-model/src/database/transaction/AcDbUndoRecord.ts
+++ b/packages/data-model/src/database/transaction/AcDbUndoRecord.ts
@@ -1,0 +1,11 @@
+import { AcDbDatabaseChange } from './AcDbDatabaseChange'
+
+/**
+ * An immutable group of changes that can be undone or redone as one unit.
+ */
+export interface AcDbUndoRecord {
+  /** Optional label for UI display (for example, "Move", "Delete"). */
+  label?: string
+  /** Forward changes applied by the original operation. */
+  changes: AcDbDatabaseChange[]
+}

--- a/packages/data-model/src/database/transaction/AcDbUndoStack.ts
+++ b/packages/data-model/src/database/transaction/AcDbUndoStack.ts
@@ -1,0 +1,79 @@
+import { AcDbUndoRecord } from './AcDbUndoRecord'
+
+/**
+ * Manages undo and redo history for database changes.
+ *
+ * Stores committed {@link AcDbUndoRecord} entries and clears the redo stack
+ * whenever a new undo record is pushed.
+ */
+export class AcDbUndoStack {
+  private readonly undoRecords: AcDbUndoRecord[] = []
+  private readonly redoRecords: AcDbUndoRecord[] = []
+
+  /** Maximum number of undo records retained. */
+  maxDepth = 100
+
+  /**
+   * Pushes a new undo record and clears redo history.
+   *
+   * When {@link maxDepth} is exceeded, the oldest undo record is discarded.
+   *
+   * @param record - Undo record produced by {@link AcDbDatabaseTransactionManager}
+   */
+  push(record: AcDbUndoRecord): void {
+    this.undoRecords.push(record)
+    this.redoRecords.length = 0
+    if (this.undoRecords.length > this.maxDepth) {
+      this.undoRecords.shift()
+    }
+  }
+
+  /**
+   * Removes and returns the most recent undo record.
+   *
+   * @returns The record popped from the undo stack, or undefined when empty
+   */
+  popUndo(): AcDbUndoRecord | undefined {
+    return this.undoRecords.pop()
+  }
+
+  /**
+   * Stores an undo record on the redo stack after {@link popUndo}.
+   *
+   * @param record - Record that was just undone and may be redone
+   */
+  pushRedo(record: AcDbUndoRecord): void {
+    this.redoRecords.push(record)
+  }
+
+  /**
+   * Removes and returns the most recent redo record.
+   *
+   * @returns The record popped from the redo stack, or undefined when empty
+   */
+  popRedo(): AcDbUndoRecord | undefined {
+    return this.redoRecords.pop()
+  }
+
+  /**
+   * Returns true when at least one undo record is available.
+   */
+  canUndo(): boolean {
+    return this.undoRecords.length > 0
+  }
+
+  /**
+   * Returns true when at least one redo record is available.
+   */
+  canRedo(): boolean {
+    return this.redoRecords.length > 0
+  }
+
+  /**
+   * Discards all undo and redo records.
+   */
+  clear(): void {
+    this.undoRecords.length = 0
+    this.redoRecords.length = 0
+  }
+}

--- a/packages/data-model/src/database/transaction/index.ts
+++ b/packages/data-model/src/database/transaction/index.ts
@@ -1,2 +1,16 @@
+export { AcDbChangeApplier, collectChangeEntities, collectDictionaryChanges } from './AcDbChangeApplier'
+export { AcDbChangeRecorder } from './AcDbChangeRecorder'
+export {
+  areChangeContainersEqual
+} from './AcDbDatabaseChange'
+export type {
+  AcDbChangeContainer,
+  AcDbDatabaseChange
+} from './AcDbDatabaseChange'
+export type { AcDbDictionaryChangeEntry } from './AcDbChangeApplier'
+export { AcDbDatabaseTransaction } from './AcDbDatabaseTransaction'
+export { AcDbDatabaseTransactionManager } from './AcDbDatabaseTransactionManager'
 export { AcDbTransaction } from './AcDbTransaction'
 export { AcDbTransactionManager } from './AcDbTransactionManager'
+export type { AcDbUndoRecord } from './AcDbUndoRecord'
+export { AcDbUndoStack } from './AcDbUndoStack'

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -703,10 +703,10 @@ export abstract class AcDbEntity extends AcDbObject {
    * ```
    */
   triggerModifiedEvent() {
-    this.database.events.entityModified.dispatch({
-      database: this.database,
-      entity: this
-    })
+    if (this.database.transactionManager.isRecording()) {
+      return
+    }
+    this.database.notifyEntityModified(this)
   }
 
   /**

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -64,6 +64,14 @@ export {
   AcDbSymbolTableRecord,
   AcDbSysVarManager,
   AcDbSystemVariables,
+  AcDbChangeApplier,
+  AcDbChangeRecorder,
+  AcDbDatabaseTransaction,
+  AcDbDatabaseTransactionManager,
+  AcDbTransaction,
+  AcDbTransactionManager,
+  AcDbUndoStack,
+  collectChangeEntities,
   AcDbTextStyleTable,
   AcDbTextStyleTableRecord,
   AcDbViewTable,
@@ -102,7 +110,10 @@ export type {
   AcDbSysVarType,
   AcDbSysVarTypeName,
   AcDbSystemVariableName,
-  AcDbTables
+  AcDbTables,
+  AcDbChangeContainer,
+  AcDbDatabaseChange,
+  AcDbUndoRecord
 } from './database'
 export {
   AcDb2dPolyline,

--- a/packages/data-model/src/object/AcDbDictionary.ts
+++ b/packages/data-model/src/object/AcDbDictionary.ts
@@ -83,6 +83,29 @@ export class AcDbDictionary<
    * ```
    */
   setAt(key: string, value: TObjectType) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot modify dictionary entries outside an active transaction.'
+      )
+    }
+
+    const existing = this.getAt(key)
+    if (existing && manager.isRecording()) {
+      manager.recordRemove(
+        {
+          type: 'dictionary',
+          dictionaryId: this.objectId,
+          key
+        },
+        existing
+      )
+    }
+
     value.database = this.database
     value.ownerId = this.objectId
 
@@ -90,11 +113,21 @@ export class AcDbDictionary<
 
     this._recordsByName.set(key, value)
     this._recordsById.set(value.objectId, value)
-    this.database.events.dictObjetSet.dispatch({
-      database: this.database,
-      object: value,
-      key: key
-    })
+
+    if (manager.isRecording()) {
+      manager.recordAppend(
+        {
+          type: 'dictionary',
+          dictionaryId: this.objectId,
+          key
+        },
+        value
+      )
+    }
+
+    if (!manager.isRecording() && !manager.isApplyingUndoRedo()) {
+      this.database.notifyDictObjectSet(value, key)
+    }
   }
 
   /**
@@ -114,13 +147,7 @@ export class AcDbDictionary<
   remove(name: string) {
     const object = this.getAt(name)
     if (object) {
-      this._recordsByName.delete(name.toUpperCase())
-      this._recordsById.delete(this.objectId)
-      this.database.events.dictObjectErased.dispatch({
-        database: this.database,
-        object: object,
-        key: name
-      })
+      this.removeStoredObject(object, name)
       return true
     }
     return false
@@ -140,20 +167,64 @@ export class AcDbDictionary<
   removeId(id: string) {
     const object = this.getIdAt(id)
     if (object) {
-      this._recordsById.delete(this.objectId)
+      let removedKey = ''
       this._recordsByName.forEach((value, key) => {
         if (value === object) {
-          this._recordsByName.delete(key)
-          this.database.events.dictObjectErased.dispatch({
-            database: this.database,
-            object: object,
-            key: key
-          })
+          removedKey = key
         }
       })
+      this.removeStoredObject(object, removedKey)
       return true
     }
     return false
+  }
+
+  /**
+   * Removes one dictionary entry from internal maps and records the change when needed.
+   *
+   * Shared by {@link remove} and {@link removeId}. Enforces strict-mode transaction
+   * requirements and defers {@link AcDbDatabase.notifyDictObjectErased} while
+   * recording or applying undo/redo.
+   *
+   * @param object - Stored dictionary object to remove
+   * @param key - Dictionary key associated with the object (may be empty when resolved by ID)
+   */
+  private removeStoredObject(object: TObjectType, key: string) {
+    const manager = this.database.transactionManager
+    if (
+      manager.strictMode &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      throw new Error(
+        'Cannot remove dictionary entries outside an active transaction.'
+      )
+    }
+
+    if (manager.isRecording()) {
+      manager.recordRemove(
+        {
+          type: 'dictionary',
+          dictionaryId: this.objectId,
+          key
+        },
+        object
+      )
+    }
+
+    this._recordsById.delete(object.objectId)
+    this._recordsByName.forEach((value, entryKey) => {
+      if (value === object) {
+        this._recordsByName.delete(entryKey)
+      }
+    })
+    if (
+      key &&
+      !manager.isRecording() &&
+      !manager.isApplyingUndoRedo()
+    ) {
+      this.database.notifyDictObjectErased(object, key)
+    }
   }
 
   /**

--- a/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
@@ -1,4 +1,3 @@
-import { AcGeEllipseArc2d, AcGeSpline3d } from '../geometry'
 import {
   AcGeBox2d,
   AcGeMatrix2d,
@@ -8,7 +7,9 @@ import {
 } from '../math'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGeCurve2d } from './AcGeCurve2d'
+import { AcGeEllipseArc2d } from './AcGeEllipseArc2d'
 import { AcGeLine2d } from './AcGeLine2d'
+import { AcGeSpline3d } from './AcGeSpline3d'
 
 export type AcGeBoundaryEdgeType =
   | AcGeLine2d


### PR DESCRIPTION
## Summary

- Add `AcDbDatabaseTransactionManager` with ObjectARX-aligned transaction semantics: start/commit/abort, nested transactions, and undo mark grouping via `runUndoable`.
- Introduce change recording and replay (`AcDbChangeRecorder`, `AcDbChangeApplier`, `AcDbDatabaseChange`) for entities, symbol tables, dictionaries, and system variables.
- Add undo/redo stack (`AcDbUndoStack`) with deduplication, append/remove cancellation, and strict mode for mutations outside active transactions.
- Integrate transaction tracking into `AcDbObject`, `AcDbEntity`, `AcDbBlockTableRecord`, `AcDbSymbolTable`, `AcDbDictionary`, and `AcDbSysVarManager`.
- Add comprehensive unit tests covering rollback, undo/redo, nested transactions, events, and `restoreFrom`.

## Test plan

- [x] `pnpm test -- packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts packages/data-model/__tests__/AcDbTransaction.spec.ts` (27 tests passed)
- [ ] Verify entity append/modify/erase undo in an editor integration scenario
- [ ] Verify symbol table and dictionary changes undo correctly in UI workflows
- [ ] Confirm strict mode behavior when enabled for production editing paths

Made with [Cursor](https://cursor.com)