### PR TITLE
feat(data-model,dxf-json-converter): add edit shortcuts and binary DXF parsing

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabaseEditShortcuts.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseEditShortcuts.spec.ts
@@ -1,0 +1,92 @@
+import { AcDbOpenMode } from '../src/base/AcDbOpenMode'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+
+function createDatabase(options?: {
+  isRecording?: boolean
+  transactionEntity?: unknown
+  fallbackEntity?: unknown
+}) {
+  const transaction = {
+    getObject: jest.fn((_id: string, mode: AcDbOpenMode) => {
+      if (options?.transactionEntity && mode === AcDbOpenMode.kForWrite) {
+        return options.transactionEntity
+      }
+      if (options?.transactionEntity && mode === AcDbOpenMode.kForRead) {
+        return options.transactionEntity
+      }
+      return undefined
+    })
+  }
+
+  const db = new AcDbDatabase()
+  db.getObjectById = jest.fn(() => options?.fallbackEntity) as never
+  db.transactionManager.isRecording = jest.fn(
+    () => options?.isRecording ?? false
+  ) as never
+  db.transactionManager.currentTransaction = jest.fn(() =>
+    options?.transactionEntity || options?.isRecording ? transaction : null
+  ) as never
+  db.transactionManager.runUndoable = jest.fn(
+    (_label: string, fn: () => void) => {
+      fn()
+    }
+  ) as never
+
+  return { db, transaction }
+}
+
+describe('AcDbDatabase edit shortcuts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('openEntityForWrite prefers the active transaction', () => {
+    const entity = { objectId: 'line-1' }
+    const { db } = createDatabase({ transactionEntity: entity })
+
+    expect(db.openEntityForWrite('line-1')).toBe(entity)
+    expect(db.getObjectById).not.toHaveBeenCalled()
+  })
+
+  test('openEntityForRead opens with kForRead through the active transaction', () => {
+    const entity = { objectId: 'line-1' }
+    const { db, transaction } = createDatabase({ transactionEntity: entity })
+
+    expect(db.openEntityForRead('line-1')).toBe(entity)
+    expect(transaction.getObject).toHaveBeenCalledWith(
+      'line-1',
+      AcDbOpenMode.kForRead
+    )
+  })
+
+  test('openEntityForWrite falls back to database lookup', () => {
+    const entity = { objectId: 'line-1' }
+    const { db } = createDatabase({ fallbackEntity: entity })
+
+    expect(db.openEntityForWrite('line-1')).toBe(entity)
+    expect(db.getObjectById).toHaveBeenCalled()
+  })
+
+  test('runDatabaseEdit skips nested undo marks while recording', () => {
+    const { db } = createDatabase({ isRecording: true })
+    const fn = jest.fn()
+
+    db.runDatabaseEdit('Color', fn)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(db.transactionManager.runUndoable).not.toHaveBeenCalled()
+  })
+
+  test('runDatabaseEdit creates an undo mark', () => {
+    const { db } = createDatabase({ isRecording: false })
+    const fn = jest.fn()
+
+    db.runDatabaseEdit('Color', fn)
+
+    expect(db.transactionManager.runUndoable).toHaveBeenCalledWith(
+      'Color',
+      expect.any(Function)
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -8,6 +8,7 @@ import {
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject, AcDbObjectId } from '../base/AcDbObject'
+import { AcDbOpenMode } from '../base/AcDbOpenMode'
 import { AcDbRegenerator } from '../converter/AcDbRegenerator'
 import {
   AcDbConverterType,
@@ -590,6 +591,99 @@ export class AcDbDatabase extends AcDbObject {
     }
 
     return undefined
+  }
+
+  /**
+   * Returns true when the transaction manager is actively recording changes.
+   *
+   * Shortcut for {@link AcDbDatabaseTransactionManager.isRecording}.
+   */
+  isUndoRecording(): boolean {
+    return this.transactionManager.isRecording()
+  }
+
+  /**
+   * Opens a database object, preferring the active transaction when present.
+   *
+   * Editor shortcut: when a transaction is active, objects are opened through it
+   * so mutations are tracked for undo. Otherwise falls back to {@link getObjectById}.
+   */
+  private openObject<T extends AcDbObject>(
+    objectId: AcDbObjectId,
+    mode: AcDbOpenMode
+  ): T | undefined {
+    const tr = this.transactionManager.currentTransaction()
+    if (tr) {
+      const opened = tr.getObject<T>(objectId, mode)
+      if (opened) {
+        return opened
+      }
+    }
+    return this.getObjectById(objectId) as T | undefined
+  }
+
+  /**
+   * Opens a database object for read through the active transaction when present.
+   *
+   * Editor shortcut; see {@link openObject}.
+   */
+  openObjectForRead<T extends AcDbObject>(
+    objectId: AcDbObjectId
+  ): T | undefined {
+    return this.openObject<T>(objectId, AcDbOpenMode.kForRead)
+  }
+
+  /**
+   * Opens a database object for write through the active transaction when present.
+   *
+   * Editor shortcut; see {@link openObject}.
+   */
+  openObjectForWrite<T extends AcDbObject>(
+    objectId: AcDbObjectId
+  ): T | undefined {
+    return this.openObject<T>(objectId, AcDbOpenMode.kForWrite)
+  }
+
+  /**
+   * Opens an entity for read through the active transaction when present.
+   *
+   * Editor shortcut; see {@link openObject}.
+   */
+  openEntityForRead(
+    entityOrId: AcDbObjectId | AcDbEntity
+  ): AcDbEntity | undefined {
+    const objectId =
+      typeof entityOrId === 'string' ? entityOrId : entityOrId.objectId
+    return this.openObjectForRead<AcDbEntity>(objectId)
+  }
+
+  /**
+   * Opens an entity for write through the active transaction when present.
+   *
+   * Editor shortcut; see {@link openObject}.
+   */
+  openEntityForWrite(
+    entityOrId: AcDbObjectId | AcDbEntity
+  ): AcDbEntity | undefined {
+    const objectId =
+      typeof entityOrId === 'string' ? entityOrId : entityOrId.objectId
+    return this.openObjectForWrite<AcDbEntity>(objectId)
+  }
+
+  /**
+   * Runs a database mutation as one undoable operation.
+   *
+   * Editor shortcut: skips creating a new undo mark when the transaction manager
+   * is already recording (nested editor operations). Otherwise wraps `fn` in
+   * {@link AcDbDatabaseTransactionManager.runUndoable}.
+   */
+  runDatabaseEdit(label: string, fn: () => void): void {
+    if (this.isUndoRecording()) {
+      fn()
+      return
+    }
+
+    this.transactionManager.runUndoable(label, fn)
   }
 
   /**

--- a/packages/dxf-json-converter/__tests__/AcDbDxfParser.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfParser.spec.ts
@@ -1,6 +1,11 @@
+import { DxfParser, ParsedDxf } from '@mlightcad/dxf-json'
+
 import { AcDbDxfParser } from '../src/AcDbDxfParser'
 
 describe('AcDbDxfParser', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
   it('parses minimal valid dxf content', () => {
     const parser = new AcDbDxfParser()
     const content = [
@@ -27,6 +32,26 @@ describe('AcDbDxfParser', () => {
     const data = new TextEncoder().encode(content).buffer
     const parsed = parser.parse(data as ArrayBuffer)
     expect(parsed).toBeTruthy()
+    expect(parsed.header.$ACADVER).toBe('AC1032')
+  })
+
+  it('routes binary DXF to parseBuffer instead of parseSync', () => {
+    const parser = new AcDbDxfParser()
+    const binarySentinel = new Uint8Array([
+      0x41, 0x75, 0x74, 0x6f, 0x43, 0x41, 0x44, 0x20, 0x42, 0x69, 0x6e, 0x61,
+      0x72, 0x79, 0x20, 0x44, 0x58, 0x46, 0x0d, 0x0a, 0x1a, 0x00
+    ])
+    const parseBuffer = jest
+      .spyOn(DxfParser.prototype, 'parseBuffer')
+      .mockReturnValue({
+        header: { $ACADVER: 'AC1032' }
+      } as unknown as ParsedDxf)
+    const parseSync = jest.spyOn(DxfParser.prototype, 'parseSync')
+
+    const parsed = parser.parse(binarySentinel.buffer)
+
+    expect(parseBuffer).toHaveBeenCalledWith(binarySentinel)
+    expect(parseSync).not.toHaveBeenCalled()
     expect(parsed.header.$ACADVER).toBe('AC1032')
   })
 })

--- a/packages/dxf-json-converter/package.json
+++ b/packages/dxf-json-converter/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/dxf-json": "^1.2.4"
+    "@mlightcad/dxf-json": "^1.2.5"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/dxf-json-converter/src/AcDbDxfParser.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfParser.ts
@@ -3,7 +3,7 @@ import {
   AcDbDwgVersion,
   dwgCodePageToEncoding
 } from '@mlightcad/data-model'
-import { DxfParser, ParsedDxf } from '@mlightcad/dxf-json'
+import { DxfParser, isBinaryDxf, ParsedDxf } from '@mlightcad/dxf-json'
 
 /**
  * Extracts DXF version and code page from an ArrayBuffer containing the DXF data.
@@ -20,7 +20,13 @@ export interface AcDbDxfHeaderInfo {
  */
 export class AcDbDxfParser {
   parse(data: ArrayBuffer): ParsedDxf {
+    const bytes = new Uint8Array(data)
     const parser = new DxfParser()
+
+    if (isBinaryDxf(bytes)) {
+      return parser.parseBuffer(bytes)
+    }
+
     // Use our own parser to parse version and code page information only to avoid
     // parsing the whole dxf file in order to imporve performance
     const headerInfo = this.getDxfInfoFromBuffer(data)

--- a/packages/dxf-json-converter/verify-build.profile.json
+++ b/packages/dxf-json-converter/verify-build.profile.json
@@ -12,6 +12,7 @@
   "requiredInWorker": [
     "encodingFailureFatal",
     "thumbnailImageFormat",
+    "parseBuffer",
     "parseSync"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/dxf-json-converter:
     dependencies:
       '@mlightcad/dxf-json':
-        specifier: ^1.2.4
-        version: 1.2.4
+        specifier: ^1.2.5
+        version: 1.2.5
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1403,8 +1403,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.2.4':
-    resolution: {integrity: sha512-pPPJiwjimfjsgNNjigOjUcGprXds02l/QIita5Dg1E/Yx20c81KvyE0w0diQkpUpmEuFIzAOAyHr5psDlPYSkQ==}
+  '@mlightcad/dxf-json@1.2.5':
+    resolution: {integrity: sha512-yUwYrRP321Pzjun4h69KFz5YnGoqA7iKZvP+Y93F4yMe2avko5yd/iaNxAZxCdrO6JeOsi3rcEaYBtg6UDiK8Q==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -6353,7 +6353,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.2.4':
+  '@mlightcad/dxf-json@1.2.5':
     dependencies:
       '@fxts/core': 1.26.0
 


### PR DESCRIPTION
Add transaction-aware entity/object open helpers and runDatabaseEdit on AcDbDatabase so editor mutations participate in undo. Route binary DXF through parseBuffer and bump @mlightcad/dxf-json to 1.2.5.
