### PR TITLE
fix(data-model): correct transforms for dimensions, proxy entities, and block attributes

### DIFF
--- a/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
+++ b/packages/data-model/__tests__/AcDbAlignedDimension.spec.ts
@@ -1,4 +1,4 @@
-import { AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
+import { AcGeMatrix3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 import { acdbHostApplicationServices } from '../src/base'
 import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
 import { AcDbAlignedDimension, AcDbLine } from '../src/entity'
@@ -91,6 +91,38 @@ describe('AcDbAlignedDimension', () => {
     expect(extents.isEmpty()).toBe(false)
     expect(extents.min).toMatchObject({ x: 11, y: 22, z: 0 })
     expect(extents.max).toMatchObject({ x: 14, y: 26, z: 0 })
+  })
+
+  it('rotates dimension block geometry with transformBy', () => {
+    const db = createDb()
+
+    const dimBlock = new AcDbBlockTableRecord()
+    dimBlock.name = '*D_ROTATE'
+    dimBlock.appendEntity(
+      new AcDbLine(new AcGePoint3d(1, 2, 0), new AcGePoint3d(4, 2, 0))
+    )
+    db.tables.blockTable.add(dimBlock)
+
+    const dim = new AcDbAlignedDimension(
+      new AcGePoint3d(0, 0, 0),
+      new AcGePoint3d(5, 0, 0),
+      new AcGePoint3d(5, 1, 0)
+    )
+    dim.dimBlockId = '*D_ROTATE'
+    dim.dimBlockPosition = new AcGePoint3d(10, 20, 0)
+    db.tables.blockTable.modelSpace.appendEntity(dim)
+
+    const before = dim.geometricExtents
+    expect(before.min).toMatchObject({ x: 11, y: 22, z: 0 })
+    expect(before.max).toMatchObject({ x: 14, y: 22, z: 0 })
+
+    dim.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+
+    const after = dim.geometricExtents
+    expect(after.min.x).toBeCloseTo(-22, 8)
+    expect(after.min.y).toBeCloseTo(11, 8)
+    expect(after.max.x).toBeCloseTo(-22, 8)
+    expect(after.max.y).toBeCloseTo(14, 8)
   })
 
   it('updates geometricExtents when dimBlockPosition changes', () => {

--- a/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbProxyEntity.spec.ts
@@ -1,4 +1,4 @@
-import { AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
 
 import { AcDbProxyEntity } from '../src/entity/AcDbProxyEntity'
 import {
@@ -159,5 +159,59 @@ describe('AcDbProxyEntity', () => {
     expect(grips).toHaveLength(2)
     expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
     expect(grips[1]).toMatchObject({ x: 10, y: 20, z: 0 })
+  })
+
+  it('transformBy applies a world transform when entity origins are absent', () => {
+    setupWorkingDatabase()
+    const entity = new AcDbProxyEntity()
+    entity.setProxyGraphic(
+      buildPolylineProxyGraphic([
+        [0, 0, 0],
+        [10, 0, 0]
+      ])
+    )
+
+    entity.transformBy(new AcGeMatrix3d().makeTranslation(5, 0, 0))
+
+    const renderer = {
+      subEntityTraits: {
+        color: { clone: () => ({}) },
+        lineType: { name: 'Continuous', definitionLines: [] },
+        lineTypeScale: 1,
+        lineWeight: -3,
+        layer: '0',
+        thickness: 0
+      },
+      lines: jest.fn(() => ({ id: 'line', applyMatrix: jest.fn() })),
+      group: jest.fn(entities => ({
+        id: 'group',
+        applyMatrix: jest.fn(function (this: { applyMatrix: jest.Mock }, matrix) {
+          entities.forEach((child: { applyMatrix?: jest.Mock }) =>
+            child.applyMatrix?.(matrix)
+          )
+        })
+      }))
+    }
+
+    entity.subWorldDraw(renderer as never)
+    const points = (renderer.lines as jest.Mock).mock
+      .calls[0][0] as AcGePoint3d[]
+    expect(points[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(points[1]).toMatchObject({ x: 10, y: 0, z: 0 })
+    expect(renderer.group).toHaveBeenCalled()
+    const group = (renderer.group as jest.Mock).mock.results[0].value
+    expect(group.applyMatrix).toHaveBeenCalledTimes(1)
+  })
+
+  it('transformBy updates geometric extents when entity origins are absent', () => {
+    setupWorkingDatabase()
+    const entity = new AcDbProxyEntity()
+    entity.setProxyGraphic(buildExtentsProxyGraphic([0, 0, 0], [10, 20, 0]))
+
+    entity.transformBy(new AcGeMatrix3d().makeTranslation(5, 0, 0))
+
+    const extents = entity.geometricExtents
+    expect(extents.min).toMatchObject({ x: 5, y: 0, z: 0 })
+    expect(extents.max).toMatchObject({ x: 15, y: 20, z: 0 })
   })
 })

--- a/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
+++ b/packages/data-model/__tests__/AcDbRenderingCache.spec.ts
@@ -7,6 +7,7 @@ jest.mock('../src/entity', () => ({
 }))
 
 import { AcCmColor } from '@mlightcad/common'
+import { AcGeMatrix3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 
 import { AcDbRenderingCache } from '../src/misc/AcDbRenderingCache'
 
@@ -45,5 +46,65 @@ describe('AcDbRenderingCache', () => {
 
     cache.clear()
     expect(cache.has(key)).toBe(false)
+  })
+
+  it('converts WCS attributes to block-local space instead of baking block transform', () => {
+    const cache = new AcDbRenderingCache()
+    const blockTransform = new AcGeMatrix3d().makeTranslation(10, 20, 0)
+    const normal = new AcGeVector3d(0, 0, 1)
+    const blockGeometry = { id: 'line' }
+    const attribute = {
+      id: 'attr',
+      applyMatrix: jest.fn(),
+      addChild: jest.fn(),
+      fastDeepClone: jest.fn()
+    }
+
+    const blockGroup = {
+      applyMatrix: jest.fn(),
+      addChild: jest.fn(),
+      fastDeepClone() {
+        return { ...this }
+      }
+    }
+
+    const renderer = {
+      group: jest.fn((items: unknown[]) => {
+        expect(items).toEqual([blockGeometry])
+        return blockGroup
+      })
+    }
+
+    const blockRecord = {
+      name: 'ATTR_BLOCK',
+      newIterator: function* () {
+        yield {
+          visibility: true,
+          color: new AcCmColor().setRGBValue(0xffffff),
+          worldDraw: () => blockGeometry
+        }
+      }
+    }
+
+    cache.draw(
+      renderer as never,
+      blockRecord as never,
+      new AcCmColor().setRGBValue(0xffffff),
+      [attribute as never],
+      false,
+      blockTransform,
+      normal
+    )
+
+    expect(blockGroup.applyMatrix).toHaveBeenCalledTimes(1)
+    const appliedTransform = blockGroup.applyMatrix.mock
+      .calls[0][0] as AcGeMatrix3d
+    expect(appliedTransform.elements).toEqual(blockTransform.elements)
+    expect(attribute.applyMatrix).toHaveBeenCalledTimes(1)
+
+    const inverse = attribute.applyMatrix.mock.calls[0][0] as AcGeMatrix3d
+    const localPoint = new AcGePoint3d(15, 25, 0).applyMatrix4(inverse)
+    expect(localPoint).toMatchObject({ x: 5, y: 5, z: 0 })
+    expect(blockGroup.addChild).toHaveBeenCalledWith(attribute)
   })
 })

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -20,7 +20,6 @@ const createGiEntity = () => {
     layerName: '',
     visible: true,
     applyMatrix: jest.fn(),
-    bakeTransformToChildren: jest.fn(),
     addChild: jest.fn(),
     fastDeepClone: jest.fn()
   }

--- a/packages/data-model/src/entity/AcDbProxyEntity.ts
+++ b/packages/data-model/src/entity/AcDbProxyEntity.ts
@@ -112,6 +112,14 @@ export class AcDbProxyEntity extends AcDbEntity {
   private _entityOrigins: AcGePoint3d[] = []
 
   /**
+   * Cumulative world-space transform applied at draw time.
+   *
+   * The proxy-graphic byte stream is left unchanged; editor operations such as
+   * MOVE, COPY, and ROTATE update this matrix instead of rewriting the stream.
+   */
+  private _worldTransform = new AcGeMatrix3d()
+
+  /**
    * Gets the original DXF name of the proxied entity class.
    *
    * Mirrors the ObjectARX original-class DXF name and corresponds to DXF
@@ -277,7 +285,11 @@ export class AcDbProxyEntity extends AcDbEntity {
     })
     const extents = parser.scanExtents()
     if (extents) {
-      return new AcGeBox3d().setFromPoints(extents)
+      const box = new AcGeBox3d().setFromPoints(extents)
+      if (!this._worldTransform.equals(new AcGeMatrix3d())) {
+        box.applyMatrix4(this._worldTransform)
+      }
+      return box
     }
     return new AcGeBox3d()
   }
@@ -329,16 +341,18 @@ export class AcDbProxyEntity extends AcDbEntity {
   /**
    * Transforms this proxy entity by the specified matrix.
    *
-   * Only {@link entityOrigins} are modified. The proxy-graphic byte stream is
-   * left unchanged because transforms are encoded as {@link AcDbProxyGraphicType.PushMatrix}
-   * / {@link AcDbProxyGraphicType.PopMatrix} commands inside the stream and
-   * applied at render time by {@link AcDbProxyGraphic}.
+   * {@link entityOrigins} and the cumulative {@link _worldTransform} are
+   * updated. The proxy-graphic byte stream is left unchanged; stream-local
+   * transforms remain encoded as {@link AcDbProxyGraphicType.PushMatrix} /
+   * {@link AcDbProxyGraphicType.PopMatrix} commands and are applied by
+   * {@link AcDbProxyGraphic} before {@link _worldTransform}.
    *
-   * @param matrix - Transformation matrix to apply to entity origins.
+   * @param matrix - World-space transformation matrix to apply.
    * @returns This entity for chaining.
    */
   transformBy(matrix: AcGeMatrix3d) {
     this._entityOrigins.forEach(origin => origin.applyMatrix4(matrix))
+    this._worldTransform.premultiply(matrix)
     return this
   }
 
@@ -364,7 +378,11 @@ export class AcDbProxyEntity extends AcDbEntity {
       database: this.database,
       defaultLayer: this.layer
     })
-    return parser.worldDraw(renderer)
+    const drawable = parser.worldDraw(renderer)
+    if (drawable && !this._worldTransform.equals(new AcGeMatrix3d())) {
+      drawable.applyMatrix(this._worldTransform)
+    }
+    return drawable
   }
 
   /**

--- a/packages/data-model/src/entity/dimension/AcDbDimension.ts
+++ b/packages/data-model/src/entity/dimension/AcDbDimension.ts
@@ -89,6 +89,13 @@ export abstract class AcDbDimension extends AcDbEntity {
   private _dimStyle?: AcDbDimStyleTableRecord
   /** The normal vector of the plane containing the block reference */
   private _normal: AcGeVector3d
+  /**
+   * Additional rotation (radians) applied when placing the anonymous dimension
+   * block. Block geometry is authored at a fixed orientation; this accumulates
+   * rigid-body rotations from {@link transformBy} so the block rotates with the
+   * dimension definition points.
+   */
+  private _dimBlockRotation: number
 
   /**
    * Creates a new dimension entity.
@@ -114,6 +121,7 @@ export abstract class AcDbDimension extends AcDbEntity {
     this._textPosition = new AcGePoint3d()
     this._textRotation = 0
     this._normal = new AcGeVector3d(0, 0, 1)
+    this._dimBlockRotation = 0
   }
 
   /**
@@ -379,6 +387,16 @@ export abstract class AcDbDimension extends AcDbEntity {
     this._dimBlockPosition.applyMatrix4(matrix)
     this._textPosition.applyMatrix4(matrix)
     this._normal.transformDirection(matrix)
+
+    const dimBlockRotationAxis = new AcGeVector3d(1, 0, 0).transformDirection(
+      matrix
+    )
+    if (dimBlockRotationAxis.lengthSq() > 0) {
+      this._dimBlockRotation += Math.atan2(
+        dimBlockRotationAxis.y,
+        dimBlockRotationAxis.x
+      )
+    }
 
     origin.applyMatrix4(matrix)
     rotationPoint.applyMatrix4(matrix)
@@ -889,15 +907,16 @@ export abstract class AcDbDimension extends AcDbEntity {
    * ```
    * dimBlockTransform =
    *   T(dimBlockPosition)
+   * · R(dimBlockRotation)
    * · T(-blockBasePoint)
    * ```
    *
    * ### Notes
    *
    * - The returned matrix operates entirely in dimension OCS
-   * - No scaling or rotation is applied here
+   * - {@link transformBy} accumulates extra block rotation so cached anonymous
+   *   block geometry rotates with the dimension definition points
    * - {@link normal} is applied later as a final orientation step
-   * - This mirrors the internal behavior of `AcDbDimension` in ObjectARX
    *
    * @returns A transformation matrix that positions the anonymous dimension
    *          block in OCS space, excluding extrusion.
@@ -934,18 +953,24 @@ export abstract class AcDbDimension extends AcDbEntity {
       this._dimBlockPosition.z
     )
 
+    const mRot = new AcGeMatrix3d().makeRotationZ(this._dimBlockRotation)
+
     // ------------------------------------------------------------
     // Final matrix (OCS space only):
     //
     // dimBlockTransform =
     //   T(dimBlockPosition)
+    // · R(dimBlockRotation)
     // · T(-blockBasePoint)
     //
     // NOTE:
     // - This matrix operates entirely in dimension OCS
     // - The extrusion / normal is intentionally excluded
     // ------------------------------------------------------------
-    return new AcGeMatrix3d().multiplyMatrices(mInsert, mBase)
+    return new AcGeMatrix3d().multiplyMatrices(
+      mInsert,
+      new AcGeMatrix3d().multiplyMatrices(mRot, mBase)
+    )
   }
 
   /**

--- a/packages/data-model/src/misc/AcDbRenderingCache.ts
+++ b/packages/data-model/src/misc/AcDbRenderingCache.ts
@@ -226,18 +226,27 @@ export class AcDbRenderingCache {
       }
 
       if (block && transform) {
-        block.applyMatrix(transform)
+        _tmpWorldTransform.copy(transform)
+        block.applyMatrix(_tmpWorldTransform)
         if (normal && (normal.x != 0 || normal.y != 0 || normal.z != 1)) {
-          transform.setFromExtrusionDirection(normal)
-          block.applyMatrix(transform)
+          _tmpExtrusion.setFromExtrusionDirection(normal)
+          block.applyMatrix(_tmpExtrusion)
+          _tmpWorldTransform.premultiply(_tmpExtrusion)
         }
       }
       if (block && attributes && attributes.length > 0) {
-        // Geometry information in attribute are in WCS. So we need to bake the block
-        // reference's transformation into all of its children and resets the block
-        // reference itself to an identity transform.
-        block.bakeTransformToChildren()
-        attributes.forEach(attrib => block.addChild(attrib))
+        // Attribute geometry is emitted in WCS. Convert it to block-local space so
+        // the block reference transform applied above places it correctly.
+        const inverse =
+          transform != null
+            ? _tmpInverse.copy(_tmpWorldTransform).invert()
+            : undefined
+        attributes.forEach(attrib => {
+          if (inverse) {
+            attrib.applyMatrix(inverse)
+          }
+          block.addChild(attrib)
+        })
       }
       return block
     } else {
@@ -269,3 +278,6 @@ export class AcDbRenderingCache {
 }
 
 const _tmpColor = /*@__PURE__*/ new AcCmColor()
+const _tmpWorldTransform = /*@__PURE__*/ new AcGeMatrix3d()
+const _tmpExtrusion = /*@__PURE__*/ new AcGeMatrix3d()
+const _tmpInverse = /*@__PURE__*/ new AcGeMatrix3d()

--- a/packages/graphic-interface/src/AcGiEntity.ts
+++ b/packages/graphic-interface/src/AcGiEntity.ts
@@ -49,20 +49,6 @@ export interface AcGiEntity {
   applyMatrix(matrix: AcGeMatrix3d): void
 
   /**
-   * Bakes the current object's transformation into all of its children and
-   * resets the object itself to an identity transform.
-   *
-   * After calling this function:
-   * - All children preserve their world-space appearance.
-   * - The object's local matrix and world matrix become identity.
-   * - The scene hierarchy remains unchanged.
-   *
-   * This is useful for freezing transforms, flattening transform hierarchies,
-   * or ensuring newly added children are not affected by previous transforms.
-   */
-  bakeTransformToChildren(): void
-
-  /**
    * Highlight this entity.
    */
   highlight(): void


### PR DESCRIPTION
## Summary

- Accumulate dimension block rotation in `AcDbDimension.transformBy` so anonymous dimension block geometry rotates with definition points after MOVE/ROTATE operations.
- Track a cumulative world transform on `AcDbProxyEntity` for proxy graphics without entity origins, applying it at draw time and when computing geometric extents.
- Fix block attribute rendering in `AcDbRenderingCache` by converting WCS attribute geometry to block-local space instead of baking the block reference transform into children; remove unused `bakeTransformToChildren` from `AcGiEntity`.

## Test plan

- [x] `AcDbAlignedDimension` — dimension block rotates with `transformBy`
- [x] `AcDbProxyEntity` — world transform applied when entity origins are absent
- [x] `AcDbRenderingCache` — attributes placed correctly via inverse block transform
- [x] `AcDbTable` — existing tests pass after `AcGiEntity` interface change