### PR TITLE
fix(data-model): dispatch entityModified on transaction commit and fix MLine grips

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
@@ -114,6 +114,64 @@ describe('AcDbDatabaseTransactionManager', () => {
     expect(line.endPoint.x).toBe(30)
   })
 
+  it('dispatches entityModified on commit without manual event notification', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    let modifiedCount = 0
+    db.events.entityModified.addEventListener(args => {
+      modifiedCount++
+      expect(args.entity).toBe(line)
+    })
+
+    db.transactionManager.runUndoable('Move', tr => {
+      const opened = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+      opened!.endPoint = new AcGePoint3d(30, 0, 0)
+    })
+
+    expect(modifiedCount).toBe(1)
+  })
+
+  it('dispatches entityModified on undo and redo for entity modification', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    let modifiedCount = 0
+    db.events.entityModified.addEventListener(args => {
+      modifiedCount++
+      expect(args.entity).toBe(line)
+    })
+
+    db.transactionManager.runUndoable('Move', tr => {
+      const opened = tr.getObject<AcDbLine>(line.objectId, AcDbOpenMode.kForWrite)
+      opened!.endPoint = new AcGePoint3d(30, 0, 0)
+    })
+    expect(modifiedCount).toBe(1)
+
+    db.transactionManager.undo()
+    expect(modifiedCount).toBe(2)
+
+    db.transactionManager.redo()
+    expect(modifiedCount).toBe(3)
+  })
+
+  it('does not dispatch entityModified when entity is mutated outside a transaction', () => {
+    const db = new AcDbDatabase()
+    const line = createLine()
+    db.tables.blockTable.modelSpace.appendEntity(line)
+
+    let modifiedCount = 0
+    db.events.entityModified.addEventListener(() => {
+      modifiedCount++
+    })
+
+    line.endPoint = new AcGePoint3d(25, 0, 0)
+
+    expect(modifiedCount).toBe(0)
+  })
+
   it('merges nested transaction changes into one undo record', () => {
     const db = new AcDbDatabase()
     const line = createLine()

--- a/packages/data-model/__tests__/AcDbMLine.spec.ts
+++ b/packages/data-model/__tests__/AcDbMLine.spec.ts
@@ -2,6 +2,8 @@ import { AcCmColor } from '@mlightcad/common'
 
 import { acdbHostApplicationServices } from '../src/base'
 import { AcDbDatabase, AcDbLinetypeTableRecord } from '../src/database'
+import { AcGeVector3d } from '@mlightcad/geometry-engine'
+
 import { AcDbMLine, AcDbMLineJustification } from '../src/entity'
 import { AcDbOsnapMode } from '../src/misc'
 import { AcDbMlineStyle } from '../src/object'
@@ -743,8 +745,33 @@ describe('AcDbMLine', () => {
     const grips = mline.subGetGripPoints()
 
     expect(grips).toHaveLength(3)
-    expect(grips[0]).toBe(mline.startPosition)
+    expect(grips[0]).toMatchObject({ x: 0, y: 0, z: 0 })
     expect(grips[1]).toMatchObject({ x: 10, y: 0, z: 0 })
     expect(grips[2]).toMatchObject({ x: 20, y: 0, z: 0 })
+  })
+
+  it('moves only the selected reference-path grip via subMoveGripPointsAt', () => {
+    const db = createDb()
+    const style = new AcDbMlineStyle()
+    style.styleName = 'GRIP_MOVE_STYLE'
+    style.elements = [
+      { offset: 0.5, color: createAciColor(3), lineType: 'BYLAYER' },
+      { offset: -0.5, color: createAciColor(5), lineType: 'BYLAYER' }
+    ]
+    db.objects.mlineStyle.setAt(style.styleName, style)
+
+    const mline = createBasicMline(style)
+
+    mline.subMoveGripPointsAt([1], new AcGeVector3d(0, 5, 0))
+
+    expect(mline.startPosition).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(mline.segments[0].position).toMatchObject({ x: 10, y: 5, z: 0 })
+    expect(mline.segments[1].position).toMatchObject({ x: 20, y: 0, z: 0 })
+
+    mline.subMoveGripPointsAt([0], new AcGeVector3d(2, 0, 0))
+
+    expect(mline.startPosition).toMatchObject({ x: 2, y: 0, z: 0 })
+    expect(mline.segments[0].position).toMatchObject({ x: 10, y: 5, z: 0 })
+    expect(mline.segments[1].position).toMatchObject({ x: 20, y: 0, z: 0 })
   })
 })

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -415,7 +415,6 @@ export class AcDbDatabase extends AcDbObject {
   readonly transactionManager: AcDbDatabaseTransactionManager
 
   private _eventBatchDepth = 0
-  private readonly _pendingEntityModified = new Set<AcDbEntity>()
   private _pendingEntityAppended: AcDbEntity[] = []
   private _pendingEntityErased: AcDbEntity[] = []
   private _pendingDictObjectSet: { object: AcDbObject; key: string }[] = []
@@ -751,6 +750,7 @@ export class AcDbDatabase extends AcDbObject {
     }
     this._eventBatchDepth--
     if (this._eventBatchDepth === 0) {
+      this.transactionManager.flushPendingEntityModifiedEvents()
       this.flushEventBatch()
     }
   }
@@ -760,25 +760,6 @@ export class AcDbDatabase extends AcDbObject {
    */
   isEventBatched(): boolean {
     return this._eventBatchDepth > 0
-  }
-
-  /**
-   * Dispatches or queues an entity-modified notification.
-   *
-   * When {@link isEventBatched} is true, the entity is deduplicated in a pending set
-   * and dispatched from {@link flushEventBatch} when the outermost batch closes.
-   *
-   * @param entity - Entity whose properties changed
-   */
-  notifyEntityModified(entity: AcDbEntity): void {
-    if (this.isEventBatched()) {
-      this._pendingEntityModified.add(entity)
-      return
-    }
-    this.events.entityModified.dispatch({
-      database: this,
-      entity
-    })
   }
 
   /**
@@ -854,21 +835,9 @@ export class AcDbDatabase extends AcDbObject {
   /**
    * Dispatches all notifications accumulated while event batching was active.
    *
-   * Entity-modified events are deduplicated by entity; appended and erased
-   * entities are dispatched in batch arrays where applicable.
+   * Appended and erased entities are dispatched in batch arrays where applicable.
    */
   private flushEventBatch(): void {
-    if (this._pendingEntityModified.size > 0) {
-      const modified = [...this._pendingEntityModified]
-      this._pendingEntityModified.clear()
-      for (const entity of modified) {
-        this.events.entityModified.dispatch({
-          database: this,
-          entity
-        })
-      }
-    }
-
     if (this._pendingEntityAppended.length > 0) {
       const appended = this._pendingEntityAppended
       this._pendingEntityAppended = []

--- a/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
@@ -1,4 +1,5 @@
 import { AcDbObject } from '../../base'
+import { AcDbEntity } from '../../entity/AcDbEntity'
 import { AcDbDatabase } from '../AcDbDatabase'
 import { AcDbSysVarManager, AcDbSysVarType } from '../AcDbSysVarManager'
 import {
@@ -32,6 +33,7 @@ export class AcDbDatabaseTransactionManager {
   private readonly changeApplier: AcDbChangeApplier
   private readonly undoMarkStack: AcDbUndoMarkState[] = []
   private _applyingUndoRedo = false
+  private readonly _pendingEntityModified = new Set<AcDbEntity>()
 
   /**
    * When true, mutations outside an active transaction throw an error.
@@ -392,7 +394,7 @@ export class AcDbDatabaseTransactionManager {
     )
 
     for (const entity of modified) {
-      entity.triggerModifiedEvent()
+      this.dispatchEntityModified(entity)
     }
     if (appended.length > 0) {
       this.database.notifyEntityAppended(appended)
@@ -449,7 +451,7 @@ export class AcDbDatabaseTransactionManager {
 
     if (inverse) {
       for (const entity of modified) {
-        entity.triggerModifiedEvent()
+        this.dispatchEntityModified(entity)
       }
       if (erased.length > 0) {
         this.database.notifyEntityAppended(erased)
@@ -465,7 +467,7 @@ export class AcDbDatabaseTransactionManager {
       }
     } else {
       for (const entity of modified) {
-        entity.triggerModifiedEvent()
+        this.dispatchEntityModified(entity)
       }
       if (appended.length > 0) {
         this.database.notifyEntityAppended(appended)
@@ -494,6 +496,40 @@ export class AcDbDatabaseTransactionManager {
           })
         }
       }
+    }
+  }
+
+  /**
+   * Dispatches or queues an entity-modified notification after commit or undo/redo.
+   */
+  private dispatchEntityModified(entity: AcDbEntity): void {
+    if (this.database.isEventBatched()) {
+      this._pendingEntityModified.add(entity)
+      return
+    }
+    this.database.events.entityModified.dispatch({
+      database: this.database,
+      entity
+    })
+  }
+
+  /**
+   * Dispatches entity-modified notifications accumulated during event batching.
+   *
+   * Called from {@link AcDbDatabase.endEventBatch} when the outermost batch closes.
+   */
+  flushPendingEntityModifiedEvents(): void {
+    if (this._pendingEntityModified.size === 0) {
+      return
+    }
+
+    const modified = [...this._pendingEntityModified]
+    this._pendingEntityModified.clear()
+    for (const entity of modified) {
+      this.database.events.entityModified.dispatch({
+        database: this.database,
+        entity
+      })
     }
   }
 }

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -693,23 +693,6 @@ export abstract class AcDbEntity extends AcDbObject {
   }
 
   /**
-   * Triggers a modified event for this entity.
-   *
-   * This method notifies listeners that the entity has been modified.
-   *
-   * @example
-   * ```typescript
-   * entity.triggerModifiedEvent();
-   * ```
-   */
-  triggerModifiedEvent() {
-    if (this.database.transactionManager.isRecording()) {
-      return
-    }
-    this.database.notifyEntityModified(this)
-  }
-
-  /**
    * Creates the "General" property group for this entity.
    *
    * This group contains common metadata attributes shared by all CAD entities

--- a/packages/data-model/src/entity/AcDbMLine.ts
+++ b/packages/data-model/src/entity/AcDbMLine.ts
@@ -22,7 +22,10 @@ import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbMlineStyle } from '../object/AcDbMlineStyle'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
-import { acdbForEachGripIndex } from './AcDbGripHelpers'
+import {
+  acdbForEachGripIndex,
+  acdbMovePointArrayGripAt
+} from './AcDbGripHelpers'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
@@ -585,22 +588,22 @@ export class AcDbMLine extends AcDbEntity {
    */
   subGetGripPoints() {
     const gripPoints = new Array<AcGePoint3d>()
-    gripPoints.push(this._startPosition)
-    this._segments.forEach(segment => gripPoints.push(segment.position))
+    gripPoints.push(this._startPosition.clone())
+    this._segments.forEach(segment =>
+      gripPoints.push(segment.position.clone())
+    )
     return gripPoints
   }
 
   /** @inheritdoc */
   subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    const gripPoints = [
+      this._startPosition,
+      ...this._segments.map(segment => segment.position)
+    ]
+    acdbMovePointArrayGripAt(indices, offset, gripPoints)
     acdbForEachGripIndex(indices, index => {
-      if (index === 0) {
-        this._startPosition.add(offset)
-      } else {
-        const segment = this._segments[index - 1]
-        if (segment) {
-          segment.position.add(offset)
-        }
-      }
+      this.updateReferencePathDirectionsAfterGripMove(index)
     })
     return this
   }
@@ -781,6 +784,47 @@ export class AcDbMLine extends AcDbEntity {
    * @param segment Segment-like payload.
    * @returns Normalized segment.
    */
+  /**
+   * Recomputes segment direction vectors affected by moving one reference-path grip.
+   *
+   * @param gripIndex Zero-based index into {@link subGetGripPoints}.
+   */
+  private updateReferencePathDirectionsAfterGripMove(gripIndex: number) {
+    const updateDirectionAtSegment = (segmentIndex: number) => {
+      const segment = this._segments[segmentIndex]
+      if (!segment) return
+
+      const previousPoint =
+        segmentIndex === 0
+          ? this._startPosition
+          : this._segments[segmentIndex - 1].position
+      const direction = new AcGeVector3d().subVectors(
+        segment.position,
+        previousPoint
+      )
+      if (direction.lengthSq() > 0) {
+        segment.direction.copy(direction.normalize())
+      }
+    }
+
+    if (gripIndex === 0) {
+      if (this._segments.length > 0) {
+        updateDirectionAtSegment(0)
+      }
+      return
+    }
+
+    const segmentIndex = gripIndex - 1
+    if (segmentIndex < 0 || segmentIndex >= this._segments.length) {
+      return
+    }
+
+    updateDirectionAtSegment(segmentIndex)
+    if (segmentIndex + 1 < this._segments.length) {
+      updateDirectionAtSegment(segmentIndex + 1)
+    }
+  }
+
   private createSegment(segment: AcDbMLineSegmentLike): AcDbMLineSegment {
     return {
       position: new AcGePoint3d().copy(segment.position),


### PR DESCRIPTION
## Summary

- Route entityModified notifications through AcDbDatabaseTransactionManager so they fire only after commit, undo, or redo (not on direct mutations outside a transaction)
- Remove notifyEntityModified from AcDbDatabase and triggerModifiedEvent from AcDbEntity
- Fix AcDbMLine grip editing: clone grip points in subGetGripPoints, use acdbMovePointArrayGripAt in subMoveGripPointsAt, and recompute reference-path directions after grip moves

## Test plan

- [x] AcDbDatabaseTransactionManager.spec.ts (entityModified on commit/undo/redo, no event outside transaction)
- [x] AcDbMLine.spec.ts (grip move and cloned grip points)