### PR TITLE
refactor(data-model): replace AcDbObject attribute bag with explicit fields

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseTransactionManager.spec.ts
@@ -78,6 +78,26 @@ describe('AcDbDatabaseTransactionManager', () => {
     expect(eraseCount).toBe(1)
   })
 
+  it('dispatches layerModified on commit and undo for layer property edits', () => {
+    const db = new AcDbDatabase()
+    const layer = new AcDbLayerTableRecord({ name: 'Layer-A' })
+    db.tables.layerTable.add(layer)
+
+    const modified: Array<{ isOff?: boolean }> = []
+    db.events.layerModified.addEventListener(args => {
+      modified.push(args.changes)
+    })
+
+    db.transactionManager.runUndoable('Layer Off', () => {
+      layer.isOff = true
+    })
+    expect(modified).toEqual([{ isOff: true }])
+
+    db.transactionManager.undo()
+    expect(modified).toEqual([{ isOff: true }, { isOff: false }])
+    expect(layer.isOff).toBe(false)
+  })
+
   it('supports undo and redo for entity append and remove', () => {
     const db = new AcDbDatabase()
     const line = createLine(new AcGePoint3d(1, 2, 3), new AcGePoint3d(4, 5, 6))

--- a/packages/data-model/__tests__/AcDbLayerTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbLayerTableRecord.spec.ts
@@ -1,8 +1,57 @@
+import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
+
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 describe('AcDbLayerTableRecord', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbLayerTableRecord())
+  })
+
+  it('dispatches layerModified on transaction commit', () => {
+    const db = new AcDbDatabase()
+    const layer = new AcDbLayerTableRecord({ name: 'Layer-A' })
+    db.tables.layerTable.add(layer)
+
+    const modified: Array<{
+      name: string
+      changes: Record<string, unknown>
+    }> = []
+    db.events.layerModified.addEventListener(args => {
+      modified.push({
+        name: args.layer.name,
+        changes: args.changes as Record<string, unknown>
+      })
+    })
+
+    db.transactionManager.runUndoable('Layer Edit', () => {
+      layer.isOff = true
+      layer.isOff = true
+      layer.color = new AcCmColor(AcCmColorMethod.ByACI, 1)
+    })
+
+    expect(modified).toEqual([
+      {
+        name: 'Layer-A',
+        changes: {
+          isOff: true,
+          color: layer.color
+        }
+      }
+    ])
+  })
+
+  it('does not dispatch layerModified for edits outside a transaction', () => {
+    const db = new AcDbDatabase()
+    const layer = new AcDbLayerTableRecord({ name: 'Layer-A' })
+    db.tables.layerTable.add(layer)
+
+    const modified: unknown[] = []
+    db.events.layerModified.addEventListener(args => modified.push(args))
+
+    layer.isOff = true
+
+    expect(modified).toEqual([])
   })
 })

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -1,4 +1,3 @@
-import { AcCmAttributes, AcCmObject, AcCmStringKey } from '@mlightcad/common'
 import { uid } from 'uid'
 
 import type { AcDbDatabase } from '../database/AcDbDatabase'
@@ -11,6 +10,19 @@ export type AcDbObjectId = string
 
 /** Prefix for temporary object IDs that are not yet committed to the database */
 export const TEMP_OBJECT_ID_PREFIX = 'TEMP_'
+
+/** Attributes that can be associated with an {@link AcDbObject}. */
+export interface AcDbObjectAttrs {
+  /** Unique identifier for the object */
+  objectId?: AcDbObjectId
+  /** Identifier of the object that owns this object */
+  ownerId?: AcDbObjectId
+  /**
+   * The objectId of the extension dictionary owned by the object. If the object does
+   * not own an extension dictionary, then the returned objectId is set to undefined.
+   */
+  extensionDictionary?: AcDbObjectId
+}
 
 let hostApplicationServicesProvider:
   | (() => { workingDatabase: AcDbDatabase })
@@ -30,46 +42,30 @@ export function acdbGetWorkingDatabase(): AcDbDatabase {
 }
 
 /**
- * Interface defining the attributes that can be associated with an AcDbObject.
- *
- * Extends the base AcCmAttributes interface and adds object-specific attributes
- * like objectId and ownerId.
- */
-export interface AcDbObjectAttrs extends AcCmAttributes {
-  /** Unique identifier for the object */
-  objectId?: AcDbObjectId
-  /** Identifier of the object that owns this object */
-  ownerId?: AcDbObjectId
-  /**
-   * The objectId of the extension dictionary owned by the object. If the object does
-   * not own an extension dictionary, then the returned objectId is set to undefined.
-   */
-  extensionDictionary?: AcDbObjectId
-}
-
-/**
  * The base class for all objects that reside in a drawing database.
  *
  * This class provides the fundamental functionality for all database objects,
- * including attribute management, object identification, and database association.
+ * including object identification and database association.
  * It serves as the foundation for entities, tables, and other database objects.
- *
- * @template ATTRS - The type of attributes this object can have
  *
  * @example
  * ```typescript
- * class MyEntity extends AcDbObject<MyEntityAttrs> {
- *   constructor(attrs?: Partial<MyEntityAttrs>) {
+ * class MyEntity extends AcDbObject {
+ *   constructor(attrs?: AcDbObjectAttrs) {
  *     super(attrs);
  *   }
  * }
  * ```
  */
-export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
+export class AcDbObject {
   /** Reference to the database this object belongs to */
   private _database?: AcDbDatabase
-  /** The attributes object that stores all object properties */
-  private _attrs: AcCmObject<ATTRS>
+  /** Unique identifier for the object */
+  private _objectId: AcDbObjectId
+  /** Identifier of the object that owns this object */
+  private _ownerId?: AcDbObjectId
+  /** Object ID of the extension dictionary owned by this object */
+  private _extensionDictionary?: AcDbObjectId
   /** XData attached to this object */
   private _xDataMap: Map<string, AcDbResultBuffer>
 
@@ -77,26 +73,32 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * Creates a new AcDbObject instance.
    *
    * @param attrs - Input attribute values for this object
-   * @param defaultAttrs - Default values for attributes of this object
    *
    * @example
    * ```typescript
    * const obj = new AcDbObject({ objectId: '123' });
    * ```
    */
-  constructor(attrs?: Partial<ATTRS>, defaultAttrs?: Partial<ATTRS>) {
+  constructor(attrs?: AcDbObjectAttrs) {
     attrs = attrs || {}
-    this._attrs = new AcCmObject<ATTRS>(attrs, defaultAttrs)
     this._xDataMap = new Map()
 
-    // Generate objectId from database if not provided
-    if (!this._attrs.get('objectId')) {
+    if (attrs.objectId) {
+      this._objectId = attrs.objectId
+    } else {
       try {
-        this._attrs.set('objectId', this.database.generateHandle())
+        this._objectId = this.database.generateHandle()
       } catch {
         // Fallback: generate a temporary handle, will be reassigned when added to database
-        this._attrs.set('objectId', this.generateTemporaryHandle())
+        this._objectId = this.generateTemporaryHandle()
       }
+    }
+
+    if (attrs.ownerId !== undefined) {
+      this._ownerId = attrs.ownerId
+    }
+    if (attrs.extensionDictionary !== undefined) {
+      this._extensionDictionary = attrs.extensionDictionary
     }
   }
 
@@ -107,86 +109,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    */
   private generateTemporaryHandle(): AcDbObjectId {
     return TEMP_OBJECT_ID_PREFIX + uid()
-  }
-
-  /**
-   * Gets the attributes object for this AcDbObject.
-   *
-   * @returns The AcCmObject instance containing all attributes
-   *
-   * @example
-   * ```typescript
-   * const attrs = obj.attrs;
-   * const value = attrs.get('someAttribute');
-   * ```
-   */
-  get attrs() {
-    return this._attrs
-  }
-
-  /**
-   * Gets the value of the specified attribute.
-   *
-   * This method will throw an exception if the specified attribute doesn't exist.
-   * Use getAttrWithoutException() if you want to handle missing attributes gracefully.
-   *
-   * @param attrName - The name of the attribute to retrieve
-   * @returns The value of the specified attribute
-   * @throws {Error} When the specified attribute doesn't exist
-   *
-   * @example
-   * ```typescript
-   * try {
-   *   const value = obj.getAttr('objectId');
-   * } catch (error) {
-   *   console.error('Attribute not found');
-   * }
-   * ```
-   */
-  getAttr(attrName: AcCmStringKey<ATTRS>) {
-    const value = this._attrs.get(attrName)
-    if (value === undefined) {
-      throw new Error(
-        `[AcDbObject] Attribute name '${attrName}' does't exist in this object!`
-      )
-    }
-    return value
-  }
-
-  /**
-   * Gets the value of the specified attribute without throwing an exception.
-   *
-   * This method returns undefined if the specified attribute doesn't exist,
-   * making it safer for optional attributes.
-   *
-   * @param attrName - The name of the attribute to retrieve
-   * @returns The value of the specified attribute, or undefined if it doesn't exist
-   *
-   * @example
-   * ```typescript
-   * const value = obj.getAttrWithoutException('optionalAttribute');
-   * if (value !== undefined) {
-   *   // Use the value
-   * }
-   * ```
-   */
-  getAttrWithoutException(attrName: AcCmStringKey<ATTRS>) {
-    return this._attrs.get(attrName)
-  }
-
-  /**
-   * Sets the value of an attribute.
-   *
-   * @param attrName - The name of the attribute to set
-   * @param val - The value to assign to the attribute
-   *
-   * @example
-   * ```typescript
-   * obj.setAttr('objectId', 'new-id-123');
-   * ```
-   */
-  setAttr<A extends AcCmStringKey<ATTRS>>(attrName: A, val?: ATTRS[A]) {
-    this._attrs.set(attrName, val)
   }
 
   /**
@@ -204,7 +126,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   get objectId(): AcDbObjectId {
-    return this.getAttr('objectId')
+    return this._objectId
   }
 
   /**
@@ -218,7 +140,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   set objectId(value: AcDbObjectId) {
-    this._attrs.set('objectId', value)
+    this._objectId = value
 
     // Update the database's maxHandle if the new objectId is a valid hex handle
     if (value && !value.startsWith(TEMP_OBJECT_ID_PREFIX)) {
@@ -232,14 +154,13 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * A temporary object is identified by its objectId starting with the TEMP prefix.
    */
   get isTemp() {
-    const id = this.getAttrWithoutException('objectId')
-    return !!id && id.startsWith(TEMP_OBJECT_ID_PREFIX)
+    return this._objectId.startsWith(TEMP_OBJECT_ID_PREFIX)
   }
 
   /**
    * Gets the object ID of the owner of this object.
    *
-   * @returns The owner object ID
+   * @returns The owner object ID, or undefined when not assigned
    *
    * @example
    * ```typescript
@@ -247,7 +168,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   get ownerId(): AcDbObjectId {
-    return this.getAttr('ownerId')
+    return this._ownerId ?? ''
   }
 
   /**
@@ -260,8 +181,8 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * obj.ownerId = 'parent-object-id';
    * ```
    */
-  set ownerId(value: AcDbObjectId) {
-    this._attrs.set('ownerId', value)
+  set ownerId(value: AcDbObjectId | undefined) {
+    this._ownerId = value
   }
 
   /**
@@ -282,7 +203,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   get extensionDictionary(): AcDbObjectId | undefined {
-    return this.getAttrWithoutException('extensionDictionary')
+    return this._extensionDictionary
   }
 
   /**
@@ -301,7 +222,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   set extensionDictionary(value: AcDbObjectId | undefined) {
-    this._attrs.set('extensionDictionary', value)
+    this._extensionDictionary = value
   }
 
   /**
@@ -450,27 +371,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * ```
    */
   createExtensionDictionary(): AcDbObjectId | undefined {
-    // If already exists, behave like ObjectARX: do nothing
-    // const existingId = this.extensionDictionary
-    // if (existingId) {
-    //   return existingId
-    // }
-
-    // const db = this.database
-    // if (db) {
-    //   // Create a new extension dictionary
-    //   const dict = new AcDbDictionary(db)
-
-    //   // Ensure dictionary lives in the same database
-    //   dict.database = db
-
-    //   // Add dictionary to database
-    //   db.objects.dictionary.setAt(dict.objectId, dict)
-
-    //   // Establish ownership relationship
-    //   this.extensionDictionary = dict.objectId
-    //   return dict.objectId
-    // }
     return undefined
   }
 
@@ -494,11 +394,8 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
     'transactionManager'
   ])
 
-  /** Own-property keys restored through dedicated attribute/xdata helpers instead of generic copy. */
-  private static readonly SNAPSHOT_INTERNAL_KEYS = new Set([
-    '_attrs',
-    '_xDataMap'
-  ])
+  /** Own-property keys restored through dedicated helpers instead of generic copy. */
+  private static readonly SNAPSHOT_INTERNAL_KEYS = new Set(['_xDataMap'])
 
   /**
    * Returns own string property names that participate in generic snapshot copy.
@@ -513,40 +410,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
         !AcDbObject.SNAPSHOT_EXCLUDED_KEYS.has(key)
       )
     })
-  }
-
-  /**
-   * Deep-clones attribute storage into a new {@link AcCmObject} instance.
-   *
-   * @param source - Attribute container to copy
-   * @returns Detached attribute object with the same values as `source`
-   */
-  private cloneAttrs(source: AcCmObject<ATTRS>): AcCmObject<ATTRS> {
-    const attrs = this.cloneValue(source.attributes) as Partial<ATTRS>
-    return new AcCmObject<ATTRS>(attrs)
-  }
-
-  /**
-   * Replaces this object's attributes from a snapshot, removing keys absent in the source.
-   *
-   * Updates are applied silently so restore does not trigger attribute observers.
-   *
-   * @param source - Attribute container captured before modification
-   */
-  private restoreAttrsFrom(source: AcCmObject<ATTRS>): void {
-    const nextAttrs = this.cloneValue(source.attributes) as Partial<ATTRS>
-    const current = this._attrs.attributes as Record<string, unknown>
-
-    for (const key of Object.keys(current)) {
-      if (!(key in nextAttrs)) {
-        this._attrs.set(key as AcCmStringKey<ATTRS>, undefined, {
-          unset: true,
-          silent: true
-        })
-      }
-    }
-
-    this._attrs.set(nextAttrs, { silent: true })
   }
 
   /**
@@ -570,7 +433,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * @param target - Newly created instance receiving the copied state
    */
   private copySnapshotStateTo(target: this): void {
-    target._attrs = this.cloneAttrs(this._attrs)
     target._xDataMap = this.cloneValue(this._xDataMap) as Map<
       string,
       AcDbResultBuffer
@@ -608,14 +470,9 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    */
   clonePreservingIdentity(): this {
     const cloned = this.clone()
-    const objectId = this.getAttrWithoutException('objectId')
-    if (objectId) {
-      cloned._attrs.set('objectId', objectId)
-    }
-    const ownerId = this.getAttrWithoutException('ownerId')
-    if (ownerId !== undefined) {
-      cloned._attrs.set('ownerId', ownerId)
-    }
+    cloned._objectId = this._objectId
+    cloned._ownerId = this._ownerId
+    cloned._extensionDictionary = this._extensionDictionary
     if (this._database) {
       cloned._database = this._database
     }
@@ -628,10 +485,9 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
    * @param snapshot - Clone produced by {@link clone} or {@link clonePreservingIdentity}.
    */
   restoreFrom(snapshot: this): void {
-    const preservedObjectId = this.objectId
+    const preservedObjectId = this._objectId
     const preservedDatabase = this._database
 
-    this.restoreAttrsFrom(snapshot._attrs)
     this.restoreXDataMapFrom(snapshot._xDataMap)
 
     const source = snapshot as unknown as Record<string, unknown>
@@ -659,7 +515,7 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
       delete target[key]
     }
 
-    this.objectId = preservedObjectId
+    this._objectId = preservedObjectId
     if (preservedDatabase) {
       this.database = preservedDatabase
     }
@@ -743,14 +599,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
   }
 
   /**
-   * Writes the common DXF wrapper for this object and then delegates the
-   * object-specific payload to {@link dxfOutFields}.
-   *
-   * @param filer - DXF output writer.
-   * @param allXdata - When true, emits all XData attached to this object.
-   * @returns The object instance (for chaining).
-   */
-  /**
    * Writes this object to the DXF output.
    *
    * @returns The instance (for chaining).
@@ -774,15 +622,6 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
     return this
   }
 
-  /**
-   * Writes object-specific DXF fields.
-   *
-   * Subclasses should override this method and call `super.dxfOutFields(filer)`
-   * first so the subclass markers remain consistent.
-   *
-   * @param _filer - DXF output writer.
-   * @returns The object instance (for chaining).
-   */
   /**
    * Writes DXF fields for this object.
    *

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -943,7 +943,7 @@ export class AcDbDatabase extends AcDbObject {
     object: AcDbObject,
     hasId?: (id: AcDbObjectId) => boolean
   ) {
-    const objectId = object.getAttrWithoutException('objectId')
+    const objectId = object.objectId
     if (!objectId || object.isTemp || (hasId && hasId(objectId))) {
       object.objectId = this.generateHandle()
     } else {

--- a/packages/data-model/src/database/AcDbDimStyleTableRecord.ts
+++ b/packages/data-model/src/database/AcDbDimStyleTableRecord.ts
@@ -1,5 +1,3 @@
-import { defaults } from '@mlightcad/common'
-
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { DEFAULT_TEXT_STYLE } from '../misc/AcDbConstants'
 import {
@@ -237,7 +235,7 @@ export interface AcDbDimStyleTableRecordAttrs
  * above, in, or below the line; arrows, slashes, or dots at the end of the dimension line, and
  * so on) for dimensions that reference it.
  */
-export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleTableRecordAttrs> {
+export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord {
   static DEFAULT_DIM_VALUES: AcDbDimStyleTableRecordAttrs = {
     name: '',
     dimpost: '',
@@ -320,14 +318,142 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
     dimlwe: -2
   }
 
-  constructor(
-    attrs?: Partial<AcDbDimStyleTableRecordAttrs>,
-    defaultAttrs?: Partial<AcDbDimStyleTableRecordAttrs>
-  ) {
-    attrs = attrs || {}
-    defaults(attrs, AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES)
-    super(attrs, defaultAttrs)
+  constructor(attrs?: Partial<AcDbDimStyleTableRecordAttrs>) {
+    attrs = { ...AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES, ...attrs }
+    super(attrs)
+    this._dimpost = attrs.dimpost!
+    this._dimapost = attrs.dimapost!
+    this._dimscale = attrs.dimscale!
+    this._dimasz = attrs.dimasz!
+    this._dimexo = attrs.dimexo!
+    this._dimdli = attrs.dimdli!
+    this._dimexe = attrs.dimexe!
+    this._dimrnd = attrs.dimrnd!
+    this._dimdle = attrs.dimdle!
+    this._dimtp = attrs.dimtp!
+    this._dimtm = attrs.dimtm!
+    this._dimtxt = attrs.dimtxt!
+    this._dimcen = attrs.dimcen!
+    this._dimtsz = attrs.dimtsz!
+    this._dimaltf = attrs.dimaltf!
+    this._dimlfac = attrs.dimlfac!
+    this._dimtvp = attrs.dimtvp!
+    this._dimtfac = attrs.dimtfac!
+    this._dimgap = attrs.dimgap!
+    this._dimaltrnd = attrs.dimaltrnd!
+    this._dimtol = attrs.dimtol!
+    this._dimlim = attrs.dimlim!
+    this._dimtih = attrs.dimtih!
+    this._dimtoh = attrs.dimtoh!
+    this._dimse1 = attrs.dimse1!
+    this._dimse2 = attrs.dimse2!
+    this._dimtad = attrs.dimtad!
+    this._dimzin = attrs.dimzin!
+    this._dimazin = attrs.dimazin!
+    this._dimalt = attrs.dimalt!
+    this._dimaltd = attrs.dimaltd!
+    this._dimtofl = attrs.dimtofl!
+    this._dimsah = attrs.dimsah!
+    this._dimtix = attrs.dimtix!
+    this._dimsoxd = attrs.dimsoxd!
+    this._dimclrd = attrs.dimclrd!
+    this._dimclre = attrs.dimclre!
+    this._dimclrt = attrs.dimclrt!
+    this._dimadec = attrs.dimadec!
+    this._dimunit = attrs.dimunit!
+    this._dimdec = attrs.dimdec!
+    this._dimtdec = attrs.dimtdec!
+    this._dimaltu = attrs.dimaltu!
+    this._dimalttd = attrs.dimalttd!
+    this._dimaunit = attrs.dimaunit!
+    this._dimfrac = attrs.dimfrac!
+    this._dimlunit = attrs.dimlunit!
+    this._dimdsep = attrs.dimdsep!
+    this._dimtmove = attrs.dimtmove!
+    this._dimjust = attrs.dimjust!
+    this._dimsd1 = attrs.dimsd1!
+    this._dimsd2 = attrs.dimsd2!
+    this._dimtolj = attrs.dimtolj!
+    this._dimtzin = attrs.dimtzin!
+    this._dimaltz = attrs.dimaltz!
+    this._dimalttz = attrs.dimalttz!
+    this._dimfit = attrs.dimfit!
+    this._dimupt = attrs.dimupt!
+    this._dimatfit = attrs.dimatfit!
+    this._dimtxsty = attrs.dimtxsty!
+    this._dimldrblk = attrs.dimldrblk!
+    this._dimblk = attrs.dimblk!
+    this._dimblk1 = attrs.dimblk1!
+    this._dimblk2 = attrs.dimblk2!
+    this._dimlwd = attrs.dimlwd!
+    this._dimlwe = attrs.dimlwe!
   }
+  private _dimpost!: string
+  private _dimapost!: string
+  private _dimscale!: number
+  private _dimasz!: number
+  private _dimexo!: number
+  private _dimdli!: number
+  private _dimexe!: number
+  private _dimrnd!: number
+  private _dimdle!: number
+  private _dimtp!: number
+  private _dimtm!: number
+  private _dimtxt!: number
+  private _dimcen!: number
+  private _dimtsz!: number
+  private _dimaltf!: number
+  private _dimlfac!: number
+  private _dimtvp!: number
+  private _dimtfac!: number
+  private _dimgap!: number
+  private _dimaltrnd!: number
+  private _dimtol!: number
+  private _dimlim!: number
+  private _dimtih!: number
+  private _dimtoh!: number
+  private _dimse1!: number
+  private _dimse2!: number
+  private _dimtad!: AcDbDimTextVertical
+  private _dimzin!: AcDbDimZeroSuppression
+  private _dimazin!: AcDbDimZeroSuppressionAngular
+  private _dimalt!: number
+  private _dimaltd!: number
+  private _dimtofl!: number
+  private _dimsah!: number
+  private _dimtix!: number
+  private _dimsoxd!: number
+  private _dimclrd!: number
+  private _dimclre!: number
+  private _dimclrt!: number
+  private _dimadec!: number
+  private _dimunit!: number
+  private _dimdec!: number
+  private _dimtdec!: number
+  private _dimaltu!: number
+  private _dimalttd!: number
+  private _dimaunit!: number
+  private _dimfrac!: number
+  private _dimlunit!: number
+  private _dimdsep!: string
+  private _dimtmove!: number
+  private _dimjust!: AcDbDimTextHorizontal
+  private _dimsd1!: number
+  private _dimsd2!: number
+  private _dimtolj!: AcDbDimVerticalJustification
+  private _dimtzin!: AcDbDimZeroSuppression
+  private _dimaltz!: AcDbDimZeroSuppression
+  private _dimalttz!: AcDbDimZeroSuppression
+  private _dimfit!: number
+  private _dimupt!: number
+  private _dimatfit!: number
+  private _dimtxsty!: string
+  private _dimldrblk!: string
+  private _dimblk!: string
+  private _dimblk1!: string
+  private _dimblk2!: string
+  private _dimlwd!: number
+  private _dimlwe!: number
 
   /**
    * Dimension postfix. This property specifies a text prefix or suffix (or both) to the dimension
@@ -341,10 +467,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * dimensions.
    */
   get dimpost() {
-    return this.getAttr('dimpost')
+    return this._dimpost
   }
   set dimpost(value: string) {
-    this.setAttr('dimpost', value)
+    this._dimpost = value
   }
 
   /**
@@ -356,10 +482,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * To turn off an established prefix or suffix (or both), set it to a single period (.).
    */
   get dimapost() {
-    return this.getAttr('dimapost')
+    return this._dimapost
   }
   set dimapost(value: string) {
-    this.setAttr('dimapost', value)
+    this._dimapost = value
   }
 
   /**
@@ -368,10 +494,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * scale.
    */
   get dimscale() {
-    return this.getAttr('dimscale')
+    return this._dimscale
   }
   set dimscale(value: number) {
-    this.setAttr('dimscale', value)
+    this._dimscale = value
   }
 
   /**
@@ -379,10 +505,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * can modify this value to adjust the size of arrowheads based on your drawing's requirements.
    */
   get dimasz() {
-    return this.getAttr('dimasz')
+    return this._dimasz
   }
   set dimasz(value: number) {
-    this.setAttr('dimasz', value)
+    this._dimasz = value
   }
 
   /**
@@ -391,10 +517,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * back from the object being dimensioned.
    */
   get dimexo() {
-    return this.getAttr('dimexo')
+    return this._dimexo
   }
   set dimexo(value: number) {
-    this.setAttr('dimexo', value)
+    this._dimexo = value
   }
 
   /**
@@ -402,10 +528,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * create multiple parallel dimensions using the baseline dimensioning method.
    */
   get dimdli() {
-    return this.getAttr('dimdli')
+    return this._dimdli
   }
   set dimdli(value: number) {
-    this.setAttr('dimdli', value)
+    this._dimdli = value
   }
 
   /**
@@ -414,10 +540,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * past the dimension line.
    */
   get dimexe() {
-    return this.getAttr('dimexe')
+    return this._dimexe
   }
   set dimexe(value: number) {
-    this.setAttr('dimexe', value)
+    this._dimexe = value
   }
 
   /**
@@ -426,10 +552,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * set it to a non-zero value to round dimensions to a specific increment.
    */
   get dimrnd() {
-    return this.getAttr('dimrnd')
+    return this._dimrnd
   }
   set dimrnd(value: number) {
-    this.setAttr('dimrnd', value)
+    this._dimrnd = value
   }
 
   /**
@@ -438,10 +564,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * adjust this value to extend the dimension line beyond them.
    */
   get dimdle() {
-    return this.getAttr('dimdle')
+    return this._dimdle
   }
   set dimdle(value: number) {
-    this.setAttr('dimdle', value)
+    this._dimdle = value
   }
 
   /**
@@ -450,10 +576,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * that no additional tolerance is applied by default.
    */
   get dimtp() {
-    return this.getAttr('dimtp')
+    return this._dimtp
   }
   set dimtp(value: number) {
-    this.setAttr('dimtp', value)
+    this._dimtp = value
   }
 
   /**
@@ -462,10 +588,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * you need to specify a negative tolerance for your dimensions.
    */
   get dimtm() {
-    return this.getAttr('dimtm')
+    return this._dimtm
   }
   set dimtm(value: number) {
-    this.setAttr('dimtm', value)
+    this._dimtm = value
   }
 
   /**
@@ -474,10 +600,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * your drawing.
    */
   get dimtxt() {
-    return this.getAttr('dimtxt')
+    return this._dimtxt
   }
   set dimtxt(value: number) {
-    this.setAttr('dimtxt', value)
+    this._dimtxt = value
   }
 
   /**
@@ -487,10 +613,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * centerline is drawn.
    */
   get dimcen() {
-    return this.getAttr('dimcen')
+    return this._dimcen
   }
   set dimcen(value: number) {
-    this.setAttr('dimcen', value)
+    this._dimcen = value
   }
 
   /**
@@ -499,10 +625,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * of arrowheads, with the value controlling the size of the ticks.
    */
   get dimtsz() {
-    return this.getAttr('dimtsz')
+    return this._dimtsz
   }
   set dimtsz(value: number) {
-    this.setAttr('dimtsz', value)
+    this._dimtsz = value
   }
 
   /**
@@ -513,10 +639,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * depending on how you want the alternate dimensions to be displayed.
    */
   get dimaltf() {
-    return this.getAttr('dimaltf')
+    return this._dimaltf
   }
   set dimaltf(value: number) {
-    this.setAttr('dimaltf', value)
+    this._dimaltf = value
   }
 
   /**
@@ -526,10 +652,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * displayed at their actual size.
    */
   get dimlfac() {
-    return this.getAttr('dimlfac')
+    return this._dimlfac
   }
   set dimlfac(value: number) {
-    this.setAttr('dimlfac', value)
+    this._dimlfac = value
   }
 
   /**
@@ -539,10 +665,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * text above or below the dimension line.
    */
   get dimtvp() {
-    return this.getAttr('dimtvp')
+    return this._dimtvp
   }
   set dimtvp(value: number) {
-    this.setAttr('dimtvp', value)
+    this._dimtvp = value
   }
 
   /**
@@ -552,10 +678,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * 1.0 will make the text smaller.
    */
   get dimtfac() {
-    return this.getAttr('dimtfac')
+    return this._dimtfac
   }
   set dimtfac(value: number) {
-    this.setAttr('dimtfac', value)
+    this._dimtfac = value
   }
 
   /**
@@ -564,20 +690,20 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * your dimensions.
    */
   get dimgap() {
-    return this.getAttr('dimgap')
+    return this._dimgap
   }
   set dimgap(value: number) {
-    this.setAttr('dimgap', value)
+    this._dimgap = value
   }
 
   /**
    * Dimension alternate rounding. This property controls rounds off the alternate dimension units.
    */
   get dimaltrnd() {
-    return this.getAttr('dimaltrnd')
+    return this._dimaltrnd
   }
   set dimaltrnd(value: number) {
-    this.setAttr('dimaltrnd', value)
+    this._dimaltrnd = value
   }
 
   /**
@@ -585,10 +711,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * Setting DIMTOL to on (1) turns DIMLIM off (0).
    */
   get dimtol() {
-    return this.getAttr('dimtol')
+    return this._dimtol
   }
-  set dimtol(value: 0 | 1) {
-    this.setAttr('dimtol', value)
+  set dimtol(value: number) {
+    this._dimtol = value
   }
 
   /**
@@ -598,10 +724,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Dimension limits are generated as default text
    */
   get dimlim() {
-    return this.getAttr('dimlim')
+    return this._dimlim
   }
-  set dimlim(value: 0 | 1) {
-    this.setAttr('dimlim', value)
+  set dimlim(value: number) {
+    this._dimlim = value
   }
 
   /**
@@ -611,10 +737,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Draws text horizontally
    */
   get dimtih() {
-    return this.getAttr('dimtih')
+    return this._dimtih
   }
-  set dimtih(value: 0 | 1) {
-    this.setAttr('dimtih', value)
+  set dimtih(value: number) {
+    this._dimtih = value
   }
 
   /**
@@ -624,10 +750,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Draws text horizontally
    */
   get dimtoh() {
-    return this.getAttr('dimtoh')
+    return this._dimtoh
   }
-  set dimtoh(value: 0 | 1) {
-    this.setAttr('dimtoh', value)
+  set dimtoh(value: number) {
+    this._dimtoh = value
   }
 
   /**
@@ -637,10 +763,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Extension line is suppressed
    */
   get dimse1() {
-    return this.getAttr('dimse1')
+    return this._dimse1
   }
-  set dimse1(value: 0 | 1) {
-    this.setAttr('dimse1', value)
+  set dimse1(value: number) {
+    this._dimse1 = value
   }
 
   /**
@@ -650,10 +776,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Extension line is suppressed
    */
   get dimse2() {
-    return this.getAttr('dimse2')
+    return this._dimse2
   }
-  set dimse2(value: 0 | 1) {
-    this.setAttr('dimse2', value)
+  set dimse2(value: number) {
+    this._dimse2 = value
   }
 
   /**
@@ -669,10 +795,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 4: Places the dimension text below the dimension line.
    */
   get dimtad() {
-    return this.getAttr('dimtad')
+    return this._dimtad
   }
   set dimtad(value: AcDbDimTextVertical) {
-    this.setAttr('dimtad', value)
+    this._dimtad = value
   }
 
   /**
@@ -686,10 +812,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 12: Suppresses both leading and trailing zeros (for example, 0.5000 becomes .5)
    */
   get dimzin() {
-    return this.getAttr('dimzin')
+    return this._dimzin
   }
   set dimzin(value: AcDbDimZeroSuppression) {
-    this.setAttr('dimzin', value)
+    this._dimzin = value
   }
 
   /**
@@ -700,10 +826,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 3: Suppresses leading and trailing zeros (for example, 0.5000 becomes .5)
    */
   get dimazin() {
-    return this.getAttr('dimazin')
+    return this._dimazin
   }
   set dimazin(value: AcDbDimZeroSuppressionAngular) {
-    this.setAttr('dimazin', value)
+    this._dimazin = value
   }
 
   /**
@@ -712,10 +838,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Enables alternate units
    */
   get dimalt() {
-    return this.getAttr('dimalt')
+    return this._dimalt
   }
-  set dimalt(value: 0 | 1) {
-    this.setAttr('dimalt', value)
+  set dimalt(value: number) {
+    this._dimalt = value
   }
 
   /**
@@ -724,10 +850,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * decimal point in the alternate measurement.
    */
   get dimaltd() {
-    return this.getAttr('dimaltd')
+    return this._dimaltd
   }
   set dimaltd(value: number) {
-    this.setAttr('dimaltd', value)
+    this._dimaltd = value
   }
 
   /**
@@ -741,10 +867,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * outside the measured points
    */
   get dimtofl() {
-    return this.getAttr('dimtofl')
+    return this._dimtofl
   }
-  set dimtofl(value: 0 | 1) {
-    this.setAttr('dimtofl', value)
+  set dimtofl(value: number) {
+    this._dimtofl = value
   }
 
   /**
@@ -753,10 +879,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Use arrowhead blocks set by DIMBLK1 and DIMBLK2
    */
   get dimsah() {
-    return this.getAttr('dimsah')
+    return this._dimsah
   }
-  set dimsah(value: 0 | 1) {
-    this.setAttr('dimsah', value)
+  set dimsah(value: number) {
+    this._dimsah = value
   }
 
   /**
@@ -769,10 +895,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * text outside the circle or arc.
    */
   get dimtix() {
-    return this.getAttr('dimtix')
+    return this._dimtix
   }
-  set dimtix(value: 0 | 1) {
-    this.setAttr('dimtix', value)
+  set dimtix(value: number) {
+    this._dimtix = value
   }
 
   /**
@@ -784,10 +910,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Arrowheads are suppressed
    */
   get dimsoxd() {
-    return this.getAttr('dimsoxd')
+    return this._dimsoxd
   }
-  set dimsoxd(value: 0 | 1) {
-    this.setAttr('dimsoxd', value)
+  set dimsoxd(value: number) {
+    this._dimsoxd = value
   }
 
   /**
@@ -795,10 +921,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * lines. For BYBLOCK, enter 0. For BYLAYER, enter 256.
    */
   get dimclrd() {
-    return this.getAttr('dimclrd')
+    return this._dimclrd
   }
   set dimclrd(value: number) {
-    this.setAttr('dimclrd', value)
+    this._dimclrd = value
   }
 
   /**
@@ -806,10 +932,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * and centerlines. For BYBLOCK, enter 0. For BYLAYER, enter 256.
    */
   get dimclre() {
-    return this.getAttr('dimclre')
+    return this._dimclre
   }
   set dimclre(value: number) {
-    this.setAttr('dimclre', value)
+    this._dimclre = value
   }
 
   /**
@@ -817,10 +943,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * For BYLAYER, enter 256.
    */
   get dimclrt() {
-    return this.getAttr('dimclrt')
+    return this._dimclrt
   }
   set dimclrt(value: number) {
-    this.setAttr('dimclrt', value)
+    this._dimclrt = value
   }
 
   /**
@@ -830,10 +956,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 0-8: Specifies the number of decimal places displayed in angular dimensions (independent of DIMDEC)
    */
   get dimadec() {
-    return this.getAttr('dimadec')
+    return this._dimadec
   }
   set dimadec(value: number) {
-    this.setAttr('dimadec', value)
+    this._dimadec = value
   }
 
   /**
@@ -848,10 +974,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * and number grouping symbols)
    */
   get dimunit() {
-    return this.getAttr('dimunit')
+    return this._dimunit
   }
   set dimunit(value: number) {
-    this.setAttr('dimunit', value)
+    this._dimunit = value
   }
 
   /**
@@ -861,10 +987,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * to angular dimensions when DIMADEC is set to -1.
    */
   get dimdec() {
-    return this.getAttr('dimdec')
+    return this._dimdec
   }
   set dimdec(value: number) {
-    this.setAttr('dimdec', value)
+    this._dimdec = value
   }
 
   /**
@@ -873,10 +999,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * is set to On. The default for DIMTOL is Off.
    */
   get dimtdec() {
-    return this.getAttr('dimtdec')
+    return this._dimtdec
   }
   set dimtdec(value: number) {
-    this.setAttr('dimtdec', value)
+    this._dimtdec = value
   }
 
   /**
@@ -893,10 +1019,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * and number grouping symbols)
    */
   get dimaltu() {
-    return this.getAttr('dimaltu')
+    return this._dimaltu
   }
   set dimaltu(value: number) {
-    this.setAttr('dimaltu', value)
+    this._dimaltu = value
   }
 
   /**
@@ -904,10 +1030,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * for the tolerance values in the alternate units of a dimension.
    */
   get dimalttd() {
-    return this.getAttr('dimalttd')
+    return this._dimalttd
   }
   set dimalttd(value: number) {
-    this.setAttr('dimalttd', value)
+    this._dimalttd = value
   }
 
   /**
@@ -918,10 +1044,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 3: Radians
    */
   get dimaunit() {
-    return this.getAttr('dimaunit')
+    return this._dimaunit
   }
   set dimaunit(value: number) {
-    this.setAttr('dimaunit', value)
+    this._dimaunit = value
   }
 
   /**
@@ -932,10 +1058,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 2: Not stacked (for example, 1/2)
    */
   get dimfrac() {
-    return this.getAttr('dimfrac')
+    return this._dimfrac
   }
   set dimfrac(value: number) {
-    this.setAttr('dimfrac', value)
+    this._dimfrac = value
   }
 
   /**
@@ -950,10 +1076,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * and number grouping symbols)
    */
   get dimlunit() {
-    return this.getAttr('dimlunit')
+    return this._dimlunit
   }
   set dimlunit(value: number) {
-    this.setAttr('dimlunit', value)
+    this._dimlunit = value
   }
 
   /**
@@ -961,10 +1087,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * to use when creating dimensions whose unit format is decimal.
    */
   get dimdsep() {
-    return this.getAttr('dimdsep')
+    return this._dimdsep
   }
   set dimdsep(value: string) {
-    this.setAttr('dimdsep', value)
+    this._dimdsep = value
   }
 
   /**
@@ -974,10 +1100,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 2: Allows text to be moved freely without a leader
    */
   get dimtmove() {
-    return this.getAttr('dimtmove')
+    return this._dimtmove
   }
   set dimtmove(value: number) {
-    this.setAttr('dimtmove', value)
+    this._dimtmove = value
   }
 
   /**
@@ -989,10 +1115,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 4: Positions the text above and aligned with the second extension line
    */
   get dimjust() {
-    return this.getAttr('dimjust')
+    return this._dimjust
   }
   set dimjust(value: number) {
-    this.setAttr('dimjust', value)
+    this._dimjust = value
   }
 
   /**
@@ -1003,10 +1129,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: First dimension line is suppressed
    */
   get dimsd1() {
-    return this.getAttr('dimsd1')
+    return this._dimsd1
   }
-  set dimsd1(value: 0 | 1) {
-    this.setAttr('dimsd1', value)
+  set dimsd1(value: number) {
+    this._dimsd1 = value
   }
 
   /**
@@ -1017,10 +1143,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Second dimension line is suppressed
    */
   get dimsd2() {
-    return this.getAttr('dimsd2')
+    return this._dimsd2
   }
-  set dimsd2(value: 0 | 1) {
-    this.setAttr('dimsd2', value)
+  set dimsd2(value: number) {
+    this._dimsd2 = value
   }
 
   /**
@@ -1032,10 +1158,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 2: Top
    */
   get dimtolj() {
-    return this.getAttr('dimtolj')
+    return this._dimtolj
   }
   set dimtolj(value: AcDbDimVerticalJustification) {
-    this.setAttr('dimtolj', value)
+    this._dimtolj = value
   }
 
   /**
@@ -1050,10 +1176,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 12: Suppresses both leading and trailing zeros (for example, 0.5000 becomes .5)
    */
   get dimtzin() {
-    return this.getAttr('dimtzin')
+    return this._dimtzin
   }
   set dimtzin(value: AcDbDimZeroSuppression) {
-    this.setAttr('dimtzin', value)
+    this._dimtzin = value
   }
 
   /**
@@ -1068,10 +1194,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 12: Suppresses both leading and trailing zeros (for example, 0.5000 becomes .5)
    */
   get dimaltz() {
-    return this.getAttr('dimaltz')
+    return this._dimaltz
   }
   set dimaltz(value: AcDbDimZeroSuppression) {
-    this.setAttr('dimaltz', value)
+    this._dimaltz = value
   }
 
   /**
@@ -1087,10 +1213,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 8: Suppresses trailing zeros
    */
   get dimalttz() {
-    return this.getAttr('dimalttz')
+    return this._dimalttz
   }
   set dimalttz(value: AcDbDimZeroSuppression) {
-    this.setAttr('dimalttz', value)
+    this._dimalttz = value
   }
 
   /**
@@ -1103,10 +1229,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * available space.
    */
   get dimfit() {
-    return this.getAttr('dimfit')
+    return this._dimfit
   }
   set dimfit(value: number) {
-    this.setAttr('dimfit', value)
+    this._dimfit = value
   }
 
   /**
@@ -1115,10 +1241,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * - 1: Cursor controls both the text position and the dimension line location
    */
   get dimupt() {
-    return this.getAttr('dimupt')
+    return this._dimupt
   }
   set dimupt(value: number) {
-    this.setAttr('dimupt', value)
+    this._dimupt = value
   }
 
   /**
@@ -1131,20 +1257,20 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * A leader is added to moved dimension text when DIMTMOVE is set to 1.
    */
   get dimatfit() {
-    return this.getAttr('dimatfit')
+    return this._dimatfit
   }
   set dimatfit(value: number) {
-    this.setAttr('dimatfit', value)
+    this._dimatfit = value
   }
 
   /**
    * Dimension text style. This property specifies the text style of the dimension.
    */
   get dimtxsty() {
-    return this.getAttr('dimtxsty')
+    return this._dimtxsty
   }
   set dimtxsty(value: string) {
-    this.setAttr('dimtxsty', value)
+    this._dimtxsty = value
   }
 
   /**
@@ -1154,10 +1280,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * Note: Annotative blocks cannot be used as custom arrowheads for dimensions or leaders.
    */
   get dimldrblk() {
-    return this.getAttr('dimldrblk')
+    return this._dimldrblk
   }
   set dimldrblk(value: string) {
-    this.setAttr('dimldrblk', value)
+    this._dimldrblk = value
   }
 
   /**
@@ -1165,10 +1291,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * dimension lines.
    */
   get dimblk() {
-    return this.getAttr('dimblk')
+    return this._dimblk
   }
   set dimblk(value: string) {
-    this.setAttr('dimblk', value)
+    this._dimblk = value
   }
 
   /**
@@ -1176,10 +1302,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * first end of the dimension line when DIMSAH is on.
    */
   get dimblk1() {
-    return this.getAttr('dimblk1')
+    return this._dimblk1
   }
   set dimblk1(value: string) {
-    this.setAttr('dimblk1', value)
+    this._dimblk1 = value
   }
 
   /**
@@ -1187,10 +1313,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * second end of the dimension line when DIMSAH is on.
    */
   get dimblk2() {
-    return this.getAttr('dimblk2')
+    return this._dimblk2
   }
   set dimblk2(value: string) {
-    this.setAttr('dimblk2', value)
+    this._dimblk2 = value
   }
 
   /**
@@ -1204,10 +1330,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * values from inches to hundredths of millimeters.)
    */
   get dimlwd() {
-    return this.getAttr('dimlwd')
+    return this._dimlwd
   }
   set dimlwd(value: number) {
-    this.setAttr('dimlwd', value)
+    this._dimlwd = value
   }
 
   /**
@@ -1221,10 +1347,10 @@ export class AcDbDimStyleTableRecord extends AcDbSymbolTableRecord<AcDbDimStyleT
    * values from inches to hundredths of millimeters.)
    */
   get dimlwe() {
-    return this.getAttr('dimlwe')
+    return this._dimlwe
   }
   set dimlwe(value: number) {
-    this.setAttr('dimlwe', value)
+    this._dimlwe = value
   }
 
   /**

--- a/packages/data-model/src/database/AcDbLayerTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLayerTableRecord.ts
@@ -1,4 +1,4 @@
-import { AcCmColor, AcCmTransparency, defaults } from '@mlightcad/common'
+import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
 import { AcGiLineStyle, AcGiLineWeight } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
@@ -55,39 +55,51 @@ export interface AcDbLayerTableRecordAttrs extends AcDbSymbolTableRecordAttrs {
  * });
  * ```
  */
-export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRecordAttrs> {
+export class AcDbLayerTableRecord extends AcDbSymbolTableRecord {
+  private _color: AcCmColor
+  private _description: string = ''
+  private _standardFlags: number = 0
+  private _isHidden: boolean = false
+  private _isInUse: boolean = true
+  private _isOff: boolean = false
+  private _isPlottable: boolean = true
+  private _transparency: AcCmTransparency
+  private _linetype: string = ''
+  private _lineWeight: AcGiLineWeight = -1 as AcGiLineWeight
+  private _materialId: string = -1 as unknown as string
+
   /**
    * Creates a new AcDbLayerTableRecord instance.
    *
-   * @param attrs - Input attribute values for this layer table record
-   * @param defaultAttrs - Default values for attributes of this layer table record
+   * @param init - Input values for this layer table record
    */
-  constructor(
-    attrs?: Partial<AcDbLayerTableRecordAttrs>,
-    defaultAttrs?: Partial<AcDbLayerTableRecordAttrs>
-  ) {
+  constructor(attrs?: Partial<AcDbLayerTableRecordAttrs>) {
     attrs = attrs || {}
-    defaults(attrs, {
-      color: new AcCmColor(),
-      description: '',
-      standardFlags: 0,
-      isHidden: false,
-      isInUse: true,
-      isOff: false,
-      isPlottable: true,
-      transparency: new AcCmTransparency(),
-      linetype: '',
-      lineWeight: 1,
-      materialId: -1
-    })
-    super(attrs, defaultAttrs)
-    this.attrs.events.attrChanged.addEventListener(args => {
-      this.database.events.layerModified.dispatch({
-        database: this.database,
-        layer: this,
-        changes: args.object.changedAttributes()
-      })
-    })
+    super(attrs)
+
+    this._color = (attrs.color ?? new AcCmColor()).clone()
+    this._description = attrs.description ?? ''
+    this._standardFlags = attrs.standardFlags ?? 0
+    this._isHidden = attrs.isHidden ?? false
+    this._isInUse = attrs.isInUse ?? true
+    this._isOff = attrs.isOff ?? false
+    this._isPlottable = attrs.isPlottable ?? true
+    this._transparency = (attrs.transparency ?? new AcCmTransparency()).clone()
+    this._linetype = attrs.linetype ?? ''
+    this._lineWeight = attrs.lineWeight ?? (-1 as AcGiLineWeight)
+    this._materialId = attrs.materialId ?? (-1 as unknown as string)
+  }
+
+  /**
+   * Records this layer for transaction commit when a property changes inside an
+   * active transaction.
+   */
+  private markModified(): void {
+    try {
+      this.database.transactionManager.recordModify(this)
+    } catch {
+      // Layer is not associated with a database yet.
+    }
   }
 
   /**
@@ -102,10 +114,15 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get color() {
-    return this.getAttr('color')
+    return this._color
   }
   set color(value: AcCmColor) {
-    this.setAttr('color', value.clone())
+    const next = value.clone()
+    if (this._color.equals(next)) {
+      return
+    }
+    this.markModified()
+    this._color = next
   }
 
   /**
@@ -120,10 +137,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get description() {
-    return this.getAttr('description')
+    return this._description
   }
   set description(value: string) {
-    this.setAttr('description', value)
+    if (this._description === value) {
+      return
+    }
+    this.markModified()
+    this._description = value
   }
 
   /**
@@ -146,10 +167,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get standardFlags() {
-    return this.getAttr('standardFlags')
+    return this._standardFlags
   }
   set standardFlags(value: number) {
-    this.setAttr('standardFlags', value)
+    if (this._standardFlags === value) {
+      return
+    }
+    this.markModified()
+    this._standardFlags = value
   }
 
   /**
@@ -192,10 +217,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get isHidden() {
-    return this.getAttr('isHidden')
+    return this._isHidden
   }
   set isHidden(value: boolean) {
-    this.setAttr('isHidden', value)
+    if (this._isHidden === value) {
+      return
+    }
+    this.markModified()
+    this._isHidden = value
   }
 
   /**
@@ -214,10 +243,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get isInUse() {
-    return this.getAttr('isInUse')
+    return this._isInUse
   }
   set isInUse(value: boolean) {
-    this.setAttr('isInUse', value)
+    if (this._isInUse === value) {
+      return
+    }
+    this.markModified()
+    this._isInUse = value
   }
 
   /**
@@ -259,10 +292,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get isOff() {
-    return this.getAttr('isOff')
+    return this._isOff
   }
   set isOff(value: boolean) {
-    this.setAttr('isOff', value)
+    if (this._isOff === value) {
+      return
+    }
+    this.markModified()
+    this._isOff = value
   }
 
   /**
@@ -281,10 +318,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get isPlottable() {
-    return this.getAttr('isPlottable')
+    return this._isPlottable
   }
   set isPlottable(value: boolean) {
-    this.setAttr('isPlottable', value)
+    if (this._isPlottable === value) {
+      return
+    }
+    this.markModified()
+    this._isPlottable = value
   }
 
   /**
@@ -295,10 +336,15 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * @returns The transparency level
    */
   get transparency() {
-    return this.getAttr('transparency')
+    return this._transparency
   }
   set transparency(value: AcCmTransparency) {
-    this.setAttr('transparency', value.clone())
+    const next = value.clone()
+    if (this._transparency.equals(next)) {
+      return
+    }
+    this.markModified()
+    this._transparency = next
   }
 
   /**
@@ -316,10 +362,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get linetype() {
-    return this.getAttr('linetype')
+    return this._linetype
   }
   set linetype(value: string) {
-    this.setAttr('linetype', value)
+    if (this._linetype === value) {
+      return
+    }
+    this.markModified()
+    this._linetype = value
   }
 
   /**
@@ -348,10 +398,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * @returns The line weight value
    */
   get lineWeight() {
-    return this.getAttr('lineWeight')
+    return this._lineWeight
   }
   set lineWeight(value: AcGiLineWeight) {
-    this.setAttr('lineWeight', value)
+    if (this._lineWeight === value) {
+      return
+    }
+    this.markModified()
+    this._lineWeight = value
   }
 
   /**
@@ -368,10 +422,14 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
    * ```
    */
   get materialId() {
-    return this.getAttr('materialId')
+    return this._materialId
   }
   set materialId(value: string) {
-    this.setAttr('materialId', value)
+    if (this._materialId === value) {
+      return
+    }
+    this.markModified()
+    this._materialId = value
   }
 
   /**

--- a/packages/data-model/src/database/AcDbLayerTableRecordChanges.ts
+++ b/packages/data-model/src/database/AcDbLayerTableRecordChanges.ts
@@ -1,0 +1,112 @@
+import { AcCmColor, AcCmTransparency } from '@mlightcad/common'
+
+import {
+  AcDbLayerTableRecord,
+  AcDbLayerTableRecordAttrs
+} from './AcDbLayerTableRecord'
+
+/**
+ * Captures the layer-table-record fields that participate in modification events.
+ *
+ * @param layer - Layer whose current property values should be snapshotted
+ * @returns Attribute bag comparable across before/after states
+ */
+export function snapshotLayerTableRecordAttrs(
+  layer: AcDbLayerTableRecord
+): AcDbLayerTableRecordAttrs {
+  return {
+    name: layer.name,
+    color: layer.color.clone(),
+    description: layer.description,
+    standardFlags: layer.standardFlags,
+    isHidden: layer.isHidden,
+    isInUse: layer.isInUse,
+    isOff: layer.isOff,
+    isPlottable: layer.isPlottable,
+    transparency: layer.transparency.clone(),
+    linetype: layer.linetype,
+    lineWeight: layer.lineWeight,
+    materialId: layer.materialId
+  }
+}
+
+/**
+ * Computes the attribute delta between two layer snapshots.
+ *
+ * @param before - State before a mutation
+ * @param after - State after a mutation
+ * @returns Changed properties from `before` to `after`, omitting unchanged fields
+ */
+export function diffLayerTableRecordAttrs(
+  before: AcDbLayerTableRecordAttrs,
+  after: AcDbLayerTableRecordAttrs
+): Partial<AcDbLayerTableRecordAttrs> {
+  const changes: Partial<AcDbLayerTableRecordAttrs> = {}
+
+  if (before.name !== after.name) {
+    changes.name = after.name
+  }
+  if (!colorsEqual(before.color, after.color)) {
+    changes.color = after.color.clone()
+  }
+  if (before.description !== after.description) {
+    changes.description = after.description
+  }
+  if (before.standardFlags !== after.standardFlags) {
+    changes.standardFlags = after.standardFlags
+  }
+  if (before.isHidden !== after.isHidden) {
+    changes.isHidden = after.isHidden
+  }
+  if (before.isInUse !== after.isInUse) {
+    changes.isInUse = after.isInUse
+  }
+  if (before.isOff !== after.isOff) {
+    changes.isOff = after.isOff
+  }
+  if (before.isPlottable !== after.isPlottable) {
+    changes.isPlottable = after.isPlottable
+  }
+  if (!transparenciesEqual(before.transparency, after.transparency)) {
+    changes.transparency = after.transparency.clone()
+  }
+  if (before.linetype !== after.linetype) {
+    changes.linetype = after.linetype
+  }
+  if (before.lineWeight !== after.lineWeight) {
+    changes.lineWeight = after.lineWeight
+  }
+  if (before.materialId !== after.materialId) {
+    changes.materialId = after.materialId
+  }
+
+  return changes
+}
+
+/**
+ * Computes the attribute delta between two layer table records.
+ *
+ * @param before - Layer state before a mutation
+ * @param after - Layer state after a mutation
+ * @returns Changed properties from `before` to `after`
+ */
+export function diffLayerTableRecords(
+  before: AcDbLayerTableRecord,
+  after: AcDbLayerTableRecord
+): Partial<AcDbLayerTableRecordAttrs> {
+  return diffLayerTableRecordAttrs(
+    snapshotLayerTableRecordAttrs(before),
+    snapshotLayerTableRecordAttrs(after)
+  )
+}
+
+function colorsEqual(a: AcCmColor, b: AcCmColor): boolean {
+  return a.equals(b)
+}
+
+function transparenciesEqual(
+  a: AcCmTransparency,
+  b: AcCmTransparency
+): boolean {
+  return a.equals(b)
+}

--- a/packages/data-model/src/database/AcDbSymbolTableRecord.ts
+++ b/packages/data-model/src/database/AcDbSymbolTableRecord.ts
@@ -1,5 +1,3 @@
-import { defaults } from '@mlightcad/common'
-
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject, AcDbObjectAttrs } from '../base/AcDbObject'
 
@@ -18,39 +16,36 @@ export interface AcDbSymbolTableRecordAttrs extends AcDbObjectAttrs {
  * Base class for all symbol table records.
  *
  * This class provides the fundamental functionality for all symbol table records,
- * including name management and common attributes. Symbol table records represent
- * entries in various symbol tables such as layer tables, linetype tables, text
- * style tables, etc.
- *
- * @template ATTRS - The type of attributes this symbol table record can have
+ * including name management. Symbol table records represent entries in various
+ * symbol tables such as layer tables, linetype tables, text style tables, etc.
  *
  * @example
  * ```typescript
- * class MySymbolTableRecord extends AcDbSymbolTableRecord<MySymbolTableRecordAttrs> {
- *   constructor(attrs?: Partial<MySymbolTableRecordAttrs>) {
+ * class MySymbolTableRecord extends AcDbSymbolTableRecord {
+ *   constructor(attrs?: Partial<AcDbSymbolTableRecordAttrs>) {
  *     super(attrs);
  *   }
  * }
  * ```
  */
-export class AcDbSymbolTableRecord<
-  ATTRS extends AcDbSymbolTableRecordAttrs = AcDbSymbolTableRecordAttrs
-> extends AcDbObject<ATTRS> {
+export class AcDbSymbolTableRecord extends AcDbObject {
+  /** The name of the symbol table record */
+  private _name: string = ''
+
   /**
    * Creates a new AcDbSymbolTableRecord instance.
    *
    * @param attrs - Input attribute values for this symbol table record
-   * @param defaultAttrs - Default values for attributes of this symbol table record
    *
    * @example
    * ```typescript
    * const record = new AcDbSymbolTableRecord({ name: 'MyRecord' });
    * ```
    */
-  constructor(attrs?: Partial<ATTRS>, defaultAttrs?: Partial<ATTRS>) {
+  constructor(attrs?: Partial<AcDbSymbolTableRecordAttrs>) {
     attrs = attrs || {}
-    defaults(attrs, { name: '' })
-    super(attrs, defaultAttrs)
+    super(attrs)
+    this._name = attrs.name ?? ''
   }
 
   /**
@@ -68,10 +63,10 @@ export class AcDbSymbolTableRecord<
    * ```
    */
   get name(): string {
-    return this.getAttr('name')
+    return this._name
   }
   set name(value: string) {
-    this.setAttr('name', value)
+    this._name = value
   }
 
   /**

--- a/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
+++ b/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
@@ -2,6 +2,11 @@ import { AcDbObject } from '../../base'
 import { AcDbEntity } from '../../entity/AcDbEntity'
 import { AcDbDictionary } from '../../object/AcDbDictionary'
 import { AcDbDatabase } from '../AcDbDatabase'
+import {
+  AcDbLayerTableRecord,
+  AcDbLayerTableRecordAttrs
+} from '../AcDbLayerTableRecord'
+import { diffLayerTableRecords } from '../AcDbLayerTableRecordChanges'
 import { AcDbSymbolTable } from '../AcDbSymbolTable'
 import { AcDbSymbolTableRecord } from '../AcDbSymbolTableRecord'
 import { AcDbSysVarManager } from '../AcDbSysVarManager'
@@ -269,6 +274,56 @@ export function collectChangeEntities(
   }
 
   return { modified, appended, erased }
+}
+
+/**
+ * Resolves layer-modification notifications from recorded modify changes.
+ *
+ * @param database - Database used to resolve the live layer table record
+ * @param changes - Changes produced by a transaction or undo record
+ * @param inverse - When true, diff from `after` back to `before` (undo replay)
+ * @returns Layer modification payloads for {@link AcDbDatabase.events.layerModified}
+ */
+export function collectLayerModifications(
+  database: AcDbDatabase,
+  changes: AcDbDatabaseChange[],
+  inverse = false
+): Array<{
+  layer: AcDbLayerTableRecord
+  changes: Partial<AcDbLayerTableRecordAttrs>
+}> {
+  const modified: Array<{
+    layer: AcDbLayerTableRecord
+    changes: Partial<AcDbLayerTableRecordAttrs>
+  }> = []
+
+  for (const change of changes) {
+    if (change.kind !== 'modify' || !change.before || !change.after) {
+      continue
+    }
+    if (
+      !(change.before instanceof AcDbLayerTableRecord) ||
+      !(change.after instanceof AcDbLayerTableRecord)
+    ) {
+      continue
+    }
+
+    const layer = database.getObjectById(change.objectId)
+    if (!(layer instanceof AcDbLayerTableRecord)) {
+      continue
+    }
+
+    const attrChanges = inverse
+      ? diffLayerTableRecords(change.after, change.before)
+      : diffLayerTableRecords(change.before, change.after)
+    if (Object.keys(attrChanges).length === 0) {
+      continue
+    }
+
+    modified.push({ layer, changes: attrChanges })
+  }
+
+  return modified
 }
 
 /**

--- a/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
@@ -5,7 +5,8 @@ import { AcDbSysVarManager, AcDbSysVarType } from '../AcDbSysVarManager'
 import {
   AcDbChangeApplier,
   collectChangeEntities,
-  collectDictionaryChanges
+  collectDictionaryChanges,
+  collectLayerModifications
 } from './AcDbChangeApplier'
 import { AcDbChangeContainer } from './AcDbDatabaseChange'
 import { AcDbDatabaseTransaction } from './AcDbDatabaseTransaction'
@@ -311,6 +312,21 @@ export class AcDbDatabaseTransactionManager {
   }
 
   /**
+   * Records the pre-modification snapshot of an object opened for write or
+   * mutated while a transaction is active.
+   *
+   * No-op when {@link isRecording} is false.
+   *
+   * @param object - Object whose state should be restorable on abort/undo
+   */
+  recordModify(object: AcDbObject): void {
+    if (!this.isRecording()) {
+      return
+    }
+    this.currentTransaction()?.recorder.recordModify(object)
+  }
+
+  /**
    * Maps a symbol table instance to the stable name stored in undo records.
    *
    * @param table - Symbol table whose logical name is needed
@@ -414,6 +430,8 @@ export class AcDbDatabaseTransactionManager {
       this.database.notifyDictObjectErased(object, key)
     }
 
+    this.dispatchLayerModifiedEvents(changes)
+
     for (const change of changes) {
       if (change.kind === 'sysvar' && change.after !== undefined) {
         AcDbSysVarManager.instance().events.sysVarChanged.dispatch({
@@ -483,6 +501,8 @@ export class AcDbDatabaseTransactionManager {
       }
     }
 
+    this.dispatchLayerModifiedEvents(changes, inverse)
+
     for (const change of changes) {
       if (change.kind === 'sysvar') {
         const oldVal = inverse ? change.after : change.before
@@ -496,6 +516,29 @@ export class AcDbDatabaseTransactionManager {
           })
         }
       }
+    }
+  }
+
+  /**
+   * Dispatches layer-modified notifications derived from recorded modify changes.
+   *
+   * @param changes - Finalized transaction or undo-record changes
+   * @param inverse - When true, diff from `after` back to `before`
+   */
+  private dispatchLayerModifiedEvents(
+    changes: import('./AcDbDatabaseChange').AcDbDatabaseChange[],
+    inverse = false
+  ): void {
+    for (const { layer, changes: layerChanges } of collectLayerModifications(
+      this.database,
+      changes,
+      inverse
+    )) {
+      this.database.events.layerModified.dispatch({
+        database: this.database,
+        layer,
+        changes: layerChanges
+      })
     }
   }
 

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -895,7 +895,7 @@ export abstract class AcDbEntity extends AcDbObject {
   private attachEntityInfo(target: AcGiEntity | null | undefined) {
     if (target) {
       target.objectId = this.objectId
-      if (this.attrs.has('ownerId')) {
+      if (this.ownerId) {
         target.ownerId = this.ownerId
       }
       target.layerName = this.layer

--- a/packages/dxf-json-converter/__tests__/AcDbObjectConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbObjectConverter.spec.ts
@@ -157,7 +157,7 @@ describe('AcDbObjectConverter', () => {
     } as any)
 
     expect(image.objectId).toBe('30')
-    expect(image.getAttrWithoutException('ownerId')).toBeUndefined()
+    expect(image.ownerId).toBe('')
   })
 
   it('decodes MLEADERSTYLE raw colors (ACI/true color/ByLayer) to AcCmColor', () => {


### PR DESCRIPTION
## Summary

- Remove `AcCmObject`-backed generic `getAttr` / `setAttr` storage from `AcDbObject` and store `objectId`, `ownerId`, and `extensionDictionary` as explicit private fields.
- Migrate `AcDbSymbolTableRecord`, `AcDbLayerTableRecord`, and `AcDbDimStyleTableRecord` to typed private fields with direct getters/setters.
- Simplify clone/restore snapshot logic now that attribute containers are no longer copied separately; update DXF converter test for `ownerId` returning empty string when unset.

## Review notes

- `layerModified` is no longer dispatched from `AcDbLayerTableRecord` (previously wired through `AcCmObject` attribute change events). Consider follow-up if consumers rely on this event.
- Default layer `lineWeight` changed from `1` to `-1` (BYLAYER), which aligns better with AutoCAD semantics.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test -- packages/data-model packages/dxf-json-converter/__tests__/AcDbObjectConverter.spec.ts` (650 tests passed)
- [ ] Smoke-test layer/dimstyle edits in the example app
