### PR TITLE
feat(data-model): enforce symbol table record write access and layerModified events

### DIFF
--- a/packages/data-model/__tests__/AcDbSymbolTableRecordWriteAccess.spec.ts
+++ b/packages/data-model/__tests__/AcDbSymbolTableRecordWriteAccess.spec.ts
@@ -1,0 +1,221 @@
+import { AcCmColor } from '@mlightcad/common'
+
+import { AcDbOpenMode } from '../src/base'
+import {
+  AcDbDatabase,
+  AcDbLayerModifiedEventArgs
+} from '../src/database/AcDbDatabase'
+import {
+  AcDbLayerTableRecord,
+  createLayerTableRecordDefaultAttrs,
+  LAYER_TABLE_RECORD_DIFF_ATTR_KEYS
+} from '../src/database/AcDbLayerTableRecord'
+import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+
+describe('AcDbSymbolTableRecord write access', () => {
+  it('derives layer diff keys from default attrs plus name', () => {
+    const expected = [
+      'name',
+      ...Object.keys(createLayerTableRecordDefaultAttrs())
+    ].sort()
+
+    expect([...LAYER_TABLE_RECORD_DIFF_ATTR_KEYS].sort()).toEqual(expected)
+  })
+
+  it('requires openObjectForWrite to modify an existing record in a transaction', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+
+    db.transactionManager.startTransaction()
+    expect(() => {
+      layer.isOff = true
+    }).toThrow('not open for write')
+
+    const opened = db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+    opened!.isOff = true
+    db.transactionManager.commitTransaction()
+
+    expect(layer.isOff).toBe(true)
+  })
+
+  it('allows modifying temporary records before they are added', () => {
+    const db = new AcDbDatabase()
+    const layer = new AcDbLayerTableRecord({ name: 'TempLayer' })
+
+    expect(() => {
+      layer.isOff = true
+    }).not.toThrow()
+
+    db.tables.layerTable.add(layer)
+    expect(layer.isOff).toBe(true)
+  })
+
+  it('dispatches layerModified on commit, not during editing', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+    let modifiedCount = 0
+
+    db.events.layerModified.addEventListener(() => {
+      modifiedCount++
+    })
+
+    db.transactionManager.runUndoable('Layer Off', () => {
+      const opened = db.openObjectForWrite<AcDbLayerTableRecord>(
+        layer.objectId
+      )
+      opened!.isOff = true
+      expect(modifiedCount).toBe(0)
+    })
+
+    expect(modifiedCount).toBe(1)
+    expect(layer.isOff).toBe(true)
+  })
+
+  it('dispatches layerModified with changed attributes on commit', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+    const nextColor = new AcCmColor()
+    nextColor.colorIndex = 1
+    let payload: { changes: Partial<{ isOff: boolean; color: AcCmColor }> } | undefined
+
+    db.events.layerModified.addEventListener(args => {
+      payload = args
+    })
+
+    db.transactionManager.runUndoable('Layer Color', () => {
+      const opened = db.openObjectForWrite<AcDbLayerTableRecord>(
+        layer.objectId
+      )
+      opened!.color = nextColor
+    })
+
+    expect(payload?.changes.color?.colorIndex).toBe(1)
+  })
+
+  it('upgrades read open to write open in the same transaction', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+
+    db.transactionManager.startTransaction()
+    const tr = db.transactionManager.currentTransaction()!
+    tr.getObject(layer.objectId, AcDbOpenMode.kForRead)
+    const opened = tr.getObject<AcDbLayerTableRecord>(
+      layer.objectId,
+      AcDbOpenMode.kForWrite
+    )
+
+    expect(() => {
+      opened!.isOff = true
+    }).not.toThrow()
+
+    db.transactionManager.commitTransaction()
+    expect(layer.isOff).toBe(true)
+  })
+
+  it('enforces strictMode for symbol table record mutations outside transactions', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    db.transactionManager.strictMode = true
+    const layer = db.tables.layerTable.getAt('0')!
+
+    expect(() => {
+      layer.isOff = true
+    }).toThrow('outside an active transaction')
+  })
+
+  it('requires openObjectForWrite to modify text style table records', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const style = db.tables.textStyleTable.getAt('Standard')!
+
+    db.transactionManager.startTransaction()
+    expect(() => {
+      style.xScale = 2
+    }).toThrow('not open for write')
+
+    const opened = db.openObjectForWrite<AcDbTextStyleTableRecord>(
+      style.objectId
+    )
+    opened!.xScale = 2
+    db.transactionManager.commitTransaction()
+
+    expect(style.xScale).toBe(2)
+  })
+
+  it('requires openObjectForWrite again after transaction abort', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+
+    db.transactionManager.startTransaction()
+    const opened = db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+    opened!.isOff = true
+    db.transactionManager.abortTransaction()
+
+    expect(layer.isOff).toBe(false)
+
+    db.transactionManager.startTransaction()
+    expect(() => {
+      layer.isOff = true
+    }).toThrow('not open for write')
+    db.transactionManager.abortTransaction()
+  })
+
+  it('defers layerModified until event batch ends', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+    let modifiedCount = 0
+
+    db.events.layerModified.addEventListener(() => {
+      modifiedCount++
+    })
+
+    db.beginEventBatch()
+    db.transactionManager.startTransaction()
+    const opened = db.openObjectForWrite<AcDbLayerTableRecord>(layer.objectId)
+    opened!.isOff = true
+    db.transactionManager.commitTransaction()
+    expect(modifiedCount).toBe(0)
+
+    db.endEventBatch()
+    expect(modifiedCount).toBe(1)
+    expect(layer.isOff).toBe(true)
+  })
+
+  it('dispatches layerModified with inverse changes on undo and redo', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    const layer = db.tables.layerTable.getAt('0')!
+    const wasOff = layer.isOff
+    const payloads: AcDbLayerModifiedEventArgs[] = []
+
+    db.events.layerModified.addEventListener(args => {
+      payloads.push(args)
+    })
+
+    db.transactionManager.runUndoable('Layer Off', () => {
+      const opened = db.openObjectForWrite<AcDbLayerTableRecord>(
+        layer.objectId
+      )
+      opened!.isOff = !wasOff
+    })
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].changes.isOff).toBe(!wasOff)
+
+    payloads.length = 0
+    db.transactionManager.undo()
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].changes.isOff).toBe(wasOff)
+
+    payloads.length = 0
+    db.transactionManager.redo()
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].changes.isOff).toBe(!wasOff)
+  })
+})

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -739,7 +739,7 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
-   * Ends event batching and dispatches accumulated entity events when the outermost batch closes.
+   * Ends event batching and dispatches accumulated entity and layer events when the outermost batch closes.
    */
   endEventBatch(): void {
     if (this._eventBatchDepth <= 0) {
@@ -748,6 +748,7 @@ export class AcDbDatabase extends AcDbObject {
     this._eventBatchDepth--
     if (this._eventBatchDepth === 0) {
       this.transactionManager.flushPendingEntityModifiedEvents()
+      this.transactionManager.flushPendingLayerModifiedEvents()
       this.flushEventBatch()
     }
   }

--- a/packages/data-model/src/database/AcDbLayerTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLayerTableRecord.ts
@@ -39,6 +39,43 @@ export interface AcDbLayerTableRecordAttrs extends AcDbSymbolTableRecordAttrs {
 }
 
 /**
+ * Creates default attribute values for a new layer table record.
+ *
+ * Also serves as the source of layer data attribute keys used when diffing
+ * records for {@link LAYER_TABLE_RECORD_DIFF_ATTR_KEYS}.
+ */
+export function createLayerTableRecordDefaultAttrs() {
+  return {
+    color: new AcCmColor(),
+    description: '',
+    standardFlags: 0,
+    isHidden: false,
+    isInUse: true,
+    isOff: false,
+    isPlottable: true,
+    transparency: new AcCmTransparency(),
+    linetype: '',
+    lineWeight: 1,
+    materialId: -1
+  } satisfies Omit<
+    Partial<AcDbLayerTableRecordAttrs>,
+    keyof import('../base/AcDbObject').AcDbObjectAttrs | 'name'
+  >
+}
+
+type LayerTableRecordDataAttrKey = keyof ReturnType<
+  typeof createLayerTableRecordDefaultAttrs
+>
+
+/** Layer attribute keys compared when emitting layer-modified events. */
+export const LAYER_TABLE_RECORD_DIFF_ATTR_KEYS = [
+  'name',
+  ...(Object.keys(
+    createLayerTableRecordDefaultAttrs()
+  ) as LayerTableRecordDataAttrKey[])
+] as const satisfies readonly (LayerTableRecordDataAttrKey | 'name')[]
+
+/**
  * Represents a record in the layer table.
  *
  * This class contains information about a layer in the drawing database,
@@ -67,27 +104,8 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
     defaultAttrs?: Partial<AcDbLayerTableRecordAttrs>
   ) {
     attrs = attrs || {}
-    defaults(attrs, {
-      color: new AcCmColor(),
-      description: '',
-      standardFlags: 0,
-      isHidden: false,
-      isInUse: true,
-      isOff: false,
-      isPlottable: true,
-      transparency: new AcCmTransparency(),
-      linetype: '',
-      lineWeight: 1,
-      materialId: -1
-    })
+    defaults(attrs, createLayerTableRecordDefaultAttrs())
     super(attrs, defaultAttrs)
-    this.attrs.events.attrChanged.addEventListener(args => {
-      this.database.events.layerModified.dispatch({
-        database: this.database,
-        layer: this,
-        changes: args.object.changedAttributes()
-      })
-    })
   }
 
   /**

--- a/packages/data-model/src/database/AcDbSymbolTableRecord.ts
+++ b/packages/data-model/src/database/AcDbSymbolTableRecord.ts
@@ -1,4 +1,4 @@
-import { defaults } from '@mlightcad/common'
+import { AcCmStringKey, defaults } from '@mlightcad/common'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbObject, AcDbObjectAttrs } from '../base/AcDbObject'
@@ -72,6 +72,59 @@ export class AcDbSymbolTableRecord<
   }
   set name(value: string) {
     this.setAttr('name', value)
+  }
+
+  /**
+   * Sets an attribute after verifying the record is open for write.
+   *
+   * Symbol table records follow ObjectARX semantics: existing database records
+   * must be opened with {@link AcDbDatabase.openObjectForWrite} before mutation.
+   */
+  override setAttr<A extends AcCmStringKey<ATTRS>>(attrName: A, val?: ATTRS[A]) {
+    this.assertOpenForWrite()
+    super.setAttr(attrName, val)
+  }
+
+  /**
+   * Ensures this record may be modified.
+   *
+   * Temporary records and undo/redo replay are exempt from the open-for-write check.
+   *
+   * @throws Error when an existing record is modified without being opened for write
+   */
+  protected assertOpenForWrite(): void {
+    if (this.isTemp) {
+      return
+    }
+
+    const db = this.database
+    if (!db) {
+      return
+    }
+
+    const manager = db.transactionManager
+    if (manager.isApplyingUndoRedo()) {
+      return
+    }
+
+    if (
+      manager.strictMode &&
+      !manager.isRecording()
+    ) {
+      throw new Error(
+        'Cannot modify symbol table records outside an active transaction.'
+      )
+    }
+
+    if (!manager.isRecording()) {
+      return
+    }
+
+    if (!manager.isOpenedForWriteInTransaction(this.objectId)) {
+      throw new Error(
+        `Symbol table record "${this.name || this.objectId}" is not open for write. Use openObjectForWrite().`
+      )
+    }
   }
 
   /**

--- a/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
+++ b/packages/data-model/src/database/transaction/AcDbChangeApplier.ts
@@ -1,7 +1,14 @@
+import { isEqual } from '@mlightcad/common'
+
 import { AcDbObject } from '../../base'
 import { AcDbEntity } from '../../entity/AcDbEntity'
 import { AcDbDictionary } from '../../object/AcDbDictionary'
-import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbDatabase, AcDbLayerModifiedEventArgs } from '../AcDbDatabase'
+import {
+  AcDbLayerTableRecord,
+  AcDbLayerTableRecordAttrs,
+  LAYER_TABLE_RECORD_DIFF_ATTR_KEYS
+} from '../AcDbLayerTableRecord'
 import { AcDbSymbolTable } from '../AcDbSymbolTable'
 import { AcDbSymbolTableRecord } from '../AcDbSymbolTableRecord'
 import { AcDbSysVarManager } from '../AcDbSysVarManager'
@@ -325,4 +332,80 @@ export function collectDictionaryChanges(
   }
 
   return { set, erased }
+}
+
+/**
+ * Compares two layer table record snapshots and returns changed attribute values.
+ *
+ * @param before - State before modification
+ * @param after - State after modification
+ * @returns Changed attributes mapped to their values in `after`
+ */
+export function diffLayerTableRecordAttrs(
+  before: AcDbLayerTableRecord,
+  after: AcDbLayerTableRecord
+): Partial<AcDbLayerTableRecordAttrs> {
+  const changes: Record<string, unknown> = {}
+
+  for (const key of LAYER_TABLE_RECORD_DIFF_ATTR_KEYS) {
+    const beforeVal = before.getAttrWithoutException(
+      key as keyof AcDbLayerTableRecordAttrs & string
+    )
+    const afterVal = after.getAttrWithoutException(
+      key as keyof AcDbLayerTableRecordAttrs & string
+    )
+    if (!isEqual(beforeVal, afterVal)) {
+      changes[key] = afterVal
+    }
+  }
+
+  return changes as Partial<AcDbLayerTableRecordAttrs>
+}
+
+/**
+ * Collects layer modification events from transaction or undo record changes.
+ *
+ * @param database - Database used to resolve live layer references
+ * @param changes - Changes produced by a transaction or undo record
+ * @param inverse - When true, compute diffs for undo replay
+ * @returns Layer-modified event payloads for dispatch
+ */
+export function collectLayerModifications(
+  database: AcDbDatabase,
+  changes: AcDbDatabaseChange[],
+  inverse = false
+): AcDbLayerModifiedEventArgs[] {
+  const results: AcDbLayerModifiedEventArgs[] = []
+
+  for (const change of changes) {
+    if (change.kind !== 'modify') {
+      continue
+    }
+
+    const layer = database.getObjectById(change.objectId)
+    if (!(layer instanceof AcDbLayerTableRecord)) {
+      continue
+    }
+
+    const before = change.before as AcDbLayerTableRecord | undefined
+    const after = change.after as AcDbLayerTableRecord | undefined
+    if (!before || !after) {
+      continue
+    }
+
+    const attrChanges = inverse
+      ? diffLayerTableRecordAttrs(after, before)
+      : diffLayerTableRecordAttrs(before, after)
+    if (Object.keys(attrChanges).length === 0) {
+      continue
+    }
+
+    results.push({
+      database,
+      layer,
+      changes: attrChanges
+    })
+  }
+
+  return results
 }

--- a/packages/data-model/src/database/transaction/AcDbChangeRecorder.ts
+++ b/packages/data-model/src/database/transaction/AcDbChangeRecorder.ts
@@ -69,6 +69,21 @@ export class AcDbChangeRecorder {
   }
 
   /**
+   * Returns true when a modify entry exists for the given object ID.
+   *
+   * Used by {@link AcDbDatabaseTransactionManager.isOpenedForWriteInTransaction}
+   * to determine whether a symbol table record was opened for write within the
+   * active transaction stack.
+   *
+   * @param objectId - Object identifier to look up
+   */
+  hasModify(objectId: string): boolean {
+    return this.changes.some(
+      c => c.kind === 'modify' && c.objectId === objectId
+    )
+  }
+
+  /**
    * Records insertion of an object into a database container.
    *
    * If a matching remove was recorded earlier in the same transaction,

--- a/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
+++ b/packages/data-model/src/database/transaction/AcDbDatabaseTransactionManager.ts
@@ -1,11 +1,12 @@
 import { AcDbObject } from '../../base'
 import { AcDbEntity } from '../../entity/AcDbEntity'
-import { AcDbDatabase } from '../AcDbDatabase'
+import { AcDbDatabase, AcDbLayerModifiedEventArgs } from '../AcDbDatabase'
 import { AcDbSysVarManager, AcDbSysVarType } from '../AcDbSysVarManager'
 import {
   AcDbChangeApplier,
   collectChangeEntities,
-  collectDictionaryChanges
+  collectDictionaryChanges,
+  collectLayerModifications
 } from './AcDbChangeApplier'
 import { AcDbChangeContainer } from './AcDbDatabaseChange'
 import { AcDbDatabaseTransaction } from './AcDbDatabaseTransaction'
@@ -34,6 +35,10 @@ export class AcDbDatabaseTransactionManager {
   private readonly undoMarkStack: AcDbUndoMarkState[] = []
   private _applyingUndoRedo = false
   private readonly _pendingEntityModified = new Set<AcDbEntity>()
+  private readonly _pendingLayerModified = new Map<
+    string,
+    AcDbLayerModifiedEventArgs
+  >()
 
   /**
    * When true, mutations outside an active transaction throw an error.
@@ -92,6 +97,25 @@ export class AcDbDatabaseTransactionManager {
    */
   isApplyingUndoRedo(): boolean {
     return this._applyingUndoRedo
+  }
+
+  /**
+   * Returns true when the object was opened for write in an active transaction.
+   *
+   * Used by {@link AcDbSymbolTableRecord.assertOpenForWrite} to enforce ObjectARX
+   * write semantics. A modify entry in a transaction recorder indicates the object
+   * was opened with {@link AcDbOpenMode.kForWrite}, including entries merged from
+   * nested transactions.
+   *
+   * @param objectId - Object identifier to check
+   */
+  isOpenedForWriteInTransaction(objectId: string): boolean {
+    for (const tr of this.transactionStack) {
+      if (tr.recorder.hasModify(objectId)) {
+        return true
+      }
+    }
+    return false
   }
 
   /**
@@ -421,6 +445,10 @@ export class AcDbDatabaseTransactionManager {
         })
       }
     }
+
+    for (const args of collectLayerModifications(this.database, changes)) {
+      this.dispatchLayerModified(args)
+    }
   }
 
   /**
@@ -494,6 +522,34 @@ export class AcDbDatabaseTransactionManager {
         }
       }
     }
+
+    for (const args of collectLayerModifications(
+      this.database,
+      changes,
+      inverse
+    )) {
+      this.dispatchLayerModified(args)
+    }
+  }
+
+  /**
+   * Dispatches or queues a layer-modified notification after commit or undo/redo.
+   */
+  private dispatchLayerModified(args: AcDbLayerModifiedEventArgs): void {
+    if (this.database.isEventBatched()) {
+      const existing = this._pendingLayerModified.get(args.layer.objectId)
+      if (existing) {
+        existing.changes = { ...existing.changes, ...args.changes }
+        return
+      }
+      this._pendingLayerModified.set(args.layer.objectId, {
+        database: args.database,
+        layer: args.layer,
+        changes: { ...args.changes }
+      })
+      return
+    }
+    this.database.events.layerModified.dispatch(args)
   }
 
   /**
@@ -508,6 +564,23 @@ export class AcDbDatabaseTransactionManager {
       database: this.database,
       entity
     })
+  }
+
+  /**
+   * Dispatches layer-modified notifications accumulated during event batching.
+   *
+   * Called from {@link AcDbDatabase.endEventBatch} when the outermost batch closes.
+   */
+  flushPendingLayerModifiedEvents(): void {
+    if (this._pendingLayerModified.size === 0) {
+      return
+    }
+
+    const pending = [...this._pendingLayerModified.values()]
+    this._pendingLayerModified.clear()
+    for (const args of pending) {
+      this.database.events.layerModified.dispatch(args)
+    }
   }
 
   /**

--- a/packages/data-model/src/database/transaction/AcDbTransaction.ts
+++ b/packages/data-model/src/database/transaction/AcDbTransaction.ts
@@ -37,6 +37,14 @@ export class AcDbTransaction {
   ): T | undefined {
     const opened = this.openedObjects.get(objectId)
     if (opened) {
+      if (
+        mode === AcDbOpenMode.kForWrite &&
+        !this.originalStates.has(objectId)
+      ) {
+        const snapshot = opened.clonePreservingIdentity()
+        this.originalStates.set(objectId, snapshot)
+        this.recorder.recordModify(opened)
+      }
       return opened as T
     }
 


### PR DESCRIPTION
## Summary

- Enforce ObjectARX-style write access for symbol table records: existing records must be opened with `openObjectForWrite()` before mutation; temporary records and undo/redo replay are exempt.
- Upgrade read opens to write opens within the same transaction by snapshotting and recording modify entries when `kForWrite` is requested.
- Dispatch `layerModified` events on transaction commit, undo, and redo with attribute diffs derived from `LAYER_TABLE_RECORD_DIFF_ATTR_KEYS`; defer notifications during event batching (mirroring entity modified behavior).
- Add comprehensive tests covering write access, strict mode, event timing, batching, and undo/redo.

## Test plan

- [ ] Run `packages/data-model` unit tests, especially `AcDbSymbolTableRecordWriteAccess.spec.ts`
- [ ] Verify layer property edits inside `runUndoable` dispatch `layerModified` only on commit
- [ ] Verify undo/redo emit inverse `layerModified` payloads
- [ ] Confirm modifying a layer without `openObjectForWrite` throws in an active transaction