### PR TITLE
fix(data-model): render leader hook lines using MTEXT extents and oriented bounds

### DIFF
--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -1,10 +1,12 @@
-import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+import { AcGeMatrix3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
+import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
 import { AcDbDatabase } from '../src/database'
 import {
   AcDbLeader,
   AcDbLeaderAnnotationType,
+  AcDbMText,
   AcDbPolyline
 } from '../src/entity'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
@@ -146,6 +148,187 @@ describe('AcDbLeader', () => {
     leaderC.isSplined = true
     leaderC.subWorldDraw(rendererC as never)
     expect((rendererC.lines.mock.calls[0] as unknown[][])[0]).toHaveLength(100)
+  })
+
+  it('extends straight leaders with a horizontal hook line segment', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = true
+    leader.textWidth = 4
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points).toHaveLength(3)
+    expect(points[2]).toMatchObject({ x: 15, y: 5, z: 0 })
+  })
+
+  it('prefers associated MTEXT extents width for hook line length', () => {
+    const db = createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(10, 8, 0)
+    mtext.height = 5
+    mtext.extentsWidth = 18
+    db.tables.blockTable.modelSpace.appendEntity(mtext)
+
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = true
+    leader.textWidth = 9.51
+    leader.annoType = AcDbLeaderAnnotationType.MText
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points[2]).toMatchObject({ x: 28, y: 5, z: 0 })
+  })
+
+  it('draws hook line when textWidth is zero but MTEXT bounds define the span', () => {
+    const db = createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(10, 8, 0)
+    mtext.height = 5
+    mtext.extentsWidth = 20
+    db.tables.blockTable.modelSpace.appendEntity(mtext)
+
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 6, 0))
+    leader.hasHookLine = true
+    leader.textWidth = 0
+    leader.isHookLineSameDirection = true
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points).toHaveLength(3)
+    expect(points[2]).toMatchObject({ x: 30, y: 6, z: 0 })
+  })
+
+  it('draws hook line from associated MTEXT bounds when hasHookLine is false', () => {
+    const db = createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.location = new AcGePoint3d(10, 8, 0)
+    mtext.height = 5
+    mtext.extentsWidth = 16
+    db.tables.blockTable.modelSpace.appendEntity(mtext)
+
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 6, 0))
+    leader.hasHookLine = false
+    leader.textWidth = 0
+    leader.isHookLineSameDirection = true
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points).toHaveLength(3)
+    expect(points[2]).toMatchObject({ x: 26, y: 6, z: 0 })
+  })
+
+  it('extends hook line in the negative horizontal direction', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = false
+    leader.textWidth = 4
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points[2]).toMatchObject({ x: 5, y: 5, z: 0 })
+  })
+
+  it('resolves MTEXT by associatedAnnotation handle before spatial search', () => {
+    const db = createWorkingDb()
+    const farMtext = new AcDbMText()
+    farMtext.location = new AcGePoint3d(100, 100, 0)
+    farMtext.height = 5
+    farMtext.extentsWidth = 50
+    db.tables.blockTable.modelSpace.appendEntity(farMtext)
+
+    const nearMtext = new AcDbMText()
+    nearMtext.location = new AcGePoint3d(10, 8, 0)
+    nearMtext.height = 5
+    nearMtext.extentsWidth = 10
+    db.tables.blockTable.modelSpace.appendEntity(nearMtext)
+
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    leader.associatedAnnotation = farMtext.objectId
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = true
+    leader.textWidth = 0
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points[2].x).toBeGreaterThan(100)
+    expect(points[2].x).not.toBeCloseTo(20)
+  })
+
+  it('includes hook line endpoint in geometricExtents', () => {
+    const leader = new AcDbLeader()
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(10, 5, 0))
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = true
+    leader.textWidth = 4
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    expect(leader.geometricExtents.max.x).toBeCloseTo(15)
+    expect(leader.geometricExtents.max.y).toBeCloseTo(5)
+  })
+
+  it('associates rotated MTEXT using oriented local coordinates', () => {
+    const db = createWorkingDb()
+    const decoy = new AcDbMText()
+    decoy.location = new AcGePoint3d(20, 5, 0)
+    decoy.height = 4
+    decoy.extentsWidth = 30
+    db.tables.blockTable.modelSpace.appendEntity(decoy)
+
+    const rotated = new AcDbMText()
+    rotated.location = new AcGePoint3d(10, 10, 0)
+    rotated.rotation = Math.PI / 2
+    rotated.direction = new AcGeVector3d(0, 1, 0)
+    rotated.height = 4
+    rotated.extentsWidth = 20
+    rotated.attachmentPoint = AcGiMTextAttachmentPoint.TopLeft
+    db.tables.blockTable.modelSpace.appendEntity(rotated)
+
+    const leader = new AcDbLeader()
+    db.tables.blockTable.modelSpace.appendEntity(leader)
+    leader.appendVertex(new AcGePoint3d(0, 0, 0))
+    leader.appendVertex(new AcGePoint3d(12, 20, 0))
+    leader.hasHookLine = true
+    leader.isHookLineSameDirection = true
+    leader.textWidth = 0
+    leader.horizontalDirection = new AcGeVector3d(1, 0, 0)
+
+    const renderer = createRenderer()
+    leader.subWorldDraw(renderer as never)
+    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    expect(points).toHaveLength(3)
+    expect(points[2].x).toBeCloseTo(14)
+    expect(points[2].y).toBeCloseTo(20)
   })
 
   it('transforms vertices and keeps working for splined geometry', () => {

--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -99,6 +99,29 @@ describe('AcDbMText', () => {
     expect(mtext.geometricExtents.max.y).toBeCloseTo(0)
   })
 
+  it('prefers extentsWidth over reference width in geometricExtents', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.contents = 'Short'
+    mtext.height = 2
+    mtext.width = 5
+    mtext.extentsWidth = 20
+    mtext.location = { x: 0, y: 0, z: 0 }
+
+    expect(mtext.geometricExtents.max.x).toBeCloseTo(20)
+  })
+
+  it('scales extentsWidth when transformed along the text direction', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.extentsWidth = 10
+    mtext.direction = { x: 1, y: 0, z: 0 }
+
+    mtext.transformBy(new AcGeMatrix3d().makeScale(2, 1, 1))
+
+    expect(mtext.extentsWidth).toBeCloseTo(20)
+  })
+
   it('returns insertion osnap point only for insertion mode', () => {
     createWorkingDb()
     const mtext = new AcDbMText()
@@ -310,6 +333,7 @@ describe('AcDbMText', () => {
     expect(dxfWithoutBackground).toContain('30\n3')
     expect(dxfWithoutBackground).toContain('40\n2')
     expect(dxfWithoutBackground).toContain('41\n10')
+    expect(dxfWithoutBackground).not.toContain('414\n')
     expect(dxfWithoutBackground).toContain('1\na\\Pb\\Pc\\Pd')
     expect(dxfWithoutBackground).toContain('7\nMyTextStyle')
     expect(dxfWithoutBackground).toContain('50\n90')
@@ -342,5 +366,20 @@ describe('AcDbMText', () => {
     expect(dxfWithBackground).toContain('63\n1122867')
     expect(dxfWithBackground).toContain('441\n128')
     expect(dxfWithBackground).toContain('45\n2.5')
+  })
+
+  it('writes actual text width as DXF group 414 when extentsWidth is set', () => {
+    createWorkingDb()
+    const mtext = new AcDbMText()
+    mtext.ownerId = 'ABC'
+    mtext.location = { x: 0, y: 0, z: 0 }
+    mtext.height = 2
+    mtext.width = 10
+    mtext.extentsWidth = 18.5
+
+    const filer = new AcDbDxfFiler()
+    mtext.dxfOutFields(filer)
+
+    expect(filer.toString()).toContain('414\n18.5')
   })
 })

--- a/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
@@ -6,12 +6,16 @@ import {
 import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
 import {
+  acdbCollectMTextOrientedCorners,
   acdbCountMTextLines,
   acdbEstimateMTextHeight,
   acdbEstimatePlainTextWidth,
   acdbExpandBoxByOrientedTextRect,
   acdbGetLocalBoundsFromAttachment,
-  acdbStripMTextControlCodes
+  acdbResolveMTextLayoutMetrics,
+  acdbScorePointAgainstMTextLayout,
+  acdbStripMTextControlCodes,
+  acdbWorldPointToMTextLocal
 } from '../src/entity/AcDbTextExtentsHelpers'
 
 describe('AcDbTextExtentsHelpers', () => {
@@ -122,6 +126,63 @@ describe('AcDbTextExtentsHelpers', () => {
       expect(box.min.x).toBeCloseTo(-2)
       expect(box.max.x).toBeCloseTo(0)
       expect(box.max.y).toBeCloseTo(4)
+    })
+  })
+
+  describe('oriented MTEXT association helpers', () => {
+    const createRotatedLayout = () =>
+      acdbResolveMTextLayoutMetrics({
+        contents: 'Rotated',
+        height: 4,
+        width: 0,
+        extentsWidth: 20,
+        lineSpacingFactor: 0.25,
+        attachmentPoint: AcGiMTextAttachmentPoint.TopLeft,
+        rotation: Math.PI / 2,
+        direction: new AcGeVector3d(0, 1, 0),
+        location: new AcGePoint3d(10, 10, 0)
+      })
+
+    it('maps world points into MTEXT-local coordinates using rotation/direction', () => {
+      const layout = createRotatedLayout()
+      const local = acdbWorldPointToMTextLocal(new AcGePoint3d(12, 20, 0), layout)
+
+      expect(local.x).toBeCloseTo(10)
+      expect(local.y).toBeCloseTo(-2)
+    })
+
+    it('scores landing points against oriented bounds instead of world-axis padding', () => {
+      const layout = createRotatedLayout()
+      const padding = { padX: 8, padYAbove: 4, padYBelow: 10 }
+
+      expect(
+        acdbScorePointAgainstMTextLayout(
+          new AcGePoint3d(12, 20, 0),
+          layout,
+          padding
+        )
+      ).toBe(0)
+
+      expect(
+        acdbScorePointAgainstMTextLayout(
+          new AcGePoint3d(16, 40, 0),
+          layout,
+          padding
+        )
+      ).toBeNull()
+    })
+
+    it('collects oriented corners for hook-line span calculations', () => {
+      const layout = createRotatedLayout()
+      const corners = acdbCollectMTextOrientedCorners(layout)
+
+      expect(corners).toHaveLength(4)
+      expect(
+        corners.some(corner => corner.x === 14 && corner.y === 10)
+      ).toBe(true)
+      expect(
+        corners.some(corner => corner.x === 14 && corner.y === 30)
+      ).toBe(true)
     })
   })
 })

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -11,14 +11,27 @@ import {
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import {
+  AcDbBlockTableRecord,
+  AcDbDimStyleTableRecord,
+  AcDbDimTextVertical
+} from '../database'
 import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbCurve } from './AcDbCurve'
 import { acdbMovePointArrayGripAt } from './AcDbGripHelpers'
+import { AcDbMText } from './AcDbMText'
 import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
 } from './AcDbOsnapHelpers'
 import { AcDbPolyline, offsetVertexPathAsPolyline } from './AcDbPolyline'
+import {
+  acdbCollectMTextOrientedCorners,
+  acdbEstimatePlainTextWidth,
+  acdbResolveMTextLayoutMetrics,
+  acdbScorePointAgainstMTextLayout,
+  acdbStripMTextControlCodes
+} from './AcDbTextExtentsHelpers'
 
 /**
  * Defines the annotation type for leader entities.
@@ -475,10 +488,9 @@ export class AcDbLeader extends AcDbCurve {
   get geometricExtents() {
     if (this._isSplined && this.splineGeo) {
       return this.splineGeo.calculateBoundingBox()
-    } else {
-      const box = new AcGeBox3d()
-      return box.setFromPoints(this._vertices)
     }
+    const box = new AcGeBox3d()
+    return box.setFromPoints(this.collectDrawPoints())
   }
 
   /**
@@ -521,11 +533,257 @@ export class AcDbLeader extends AcDbCurve {
    * @inheritdoc
    */
   subWorldDraw(renderer: AcGiRenderer) {
+    return renderer.lines(this.collectDrawPoints())
+  }
+
+  /**
+   * Builds the leader polyline including the optional horizontal hook line
+   * segment that spans the associated annotation width.
+   */
+  private collectDrawPoints(): AcGePoint3d[] {
     if (this.isSplined && this.splineGeo) {
-      const points = this.splineGeo.getPoints(100)
-      return renderer.lines(points)
+      return this.splineGeo.getPoints(100)
+    }
+
+    const points = this._vertices.map(vertex => vertex.clone())
+    // Splined leaders do not render a horizontal hook line segment.
+    if (points.length > 0 && !this._isSplined) {
+      const lastVertex = points[points.length - 1]
+      if (this.shouldDrawHookLine(lastVertex)) {
+        const hookEnd = this.computeHookLineEndPoint(lastVertex)
+        if (hookEnd) {
+          points.push(hookEnd)
+        }
+      }
+    }
+    return points
+  }
+
+  /**
+   * Whether a hook line should be rendered for the landing vertex.
+   */
+  private shouldDrawHookLine(lastVertex: AcGePoint3d): boolean {
+    if (this.resolveHookLineLength(lastVertex) <= 0) {
+      return false
+    }
+    if (this._hasHookLine) {
+      return true
+    }
+
+    const mtext = this.resolveAssociatedMText()
+    if (mtext && this.resolveHookSpanFromMText(mtext, lastVertex) > 0) {
+      return true
+    }
+
+    if (this._annoType !== AcDbLeaderAnnotationType.MText) {
+      return false
+    }
+
+    const dimStyle = this.resolveDimensionStyle()
+    const dimtad =
+      dimStyle?.dimtad ?? AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimtad
+    return dimtad !== AcDbDimTextVertical.Center
+  }
+
+  /**
+   * Computes the hook-line endpoint from the last leader vertex.
+   */
+  private computeHookLineEndPoint(lastVertex: AcGePoint3d): AcGePoint3d | null {
+    const hookLength = this.resolveHookLineLength(lastVertex)
+    if (hookLength <= 0) {
+      return null
+    }
+
+    const direction = this.resolveHookAxis()
+    return lastVertex.clone().addScaledVector(direction, hookLength)
+  }
+
+  /**
+   * Resolves hook-line length using dimension-style gap plus associated MTEXT
+   * geometry when available.
+   */
+  private resolveHookLineLength(lastVertex: AcGePoint3d): number {
+    const dimStyle = this.resolveDimensionStyle()
+    const gap =
+      (dimStyle?.dimgap ??
+        AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimgap) *
+      (dimStyle?.dimscale ??
+        AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimscale)
+    let length = this._textWidth + gap
+
+    const mtext = this.resolveAssociatedMText()
+    if (mtext) {
+      const span = this.resolveHookSpanFromMText(mtext, lastVertex)
+      if (span > 0) {
+        length = Math.max(length, span)
+      } else {
+        const width = this.resolveAnnotationWidth(mtext)
+        if (width > 0) {
+          length = Math.max(length, width)
+        }
+      }
+    }
+
+    return length
+  }
+
+  /**
+   * Returns the signed axis along which the hook line extends.
+   */
+  private resolveHookAxis(): AcGeVector3d {
+    const direction = this._horizontalDirection.clone()
+    if (direction.lengthSq() === 0) {
+      direction.set(1, 0, 0)
     } else {
-      return renderer.lines(this._vertices)
+      direction.normalize()
+    }
+    const sign = this._isHookLineSameDirection ? 1 : -1
+    direction.multiplyScalar(sign)
+    return direction
+  }
+
+  /**
+   * Computes hook span from the landing vertex to the far edge of MTEXT bounds.
+   */
+  private resolveHookSpanFromMText(
+    mtext: AcDbMText,
+    lastVertex: AcGePoint3d
+  ): number {
+    const axis = this.resolveHookAxis()
+    const layout = this.resolveMTextLayoutMetrics(mtext)
+    let maxSpan = 0
+
+    for (const corner of acdbCollectMTextOrientedCorners(layout)) {
+      const span =
+        (corner.x - lastVertex.x) * axis.x +
+        (corner.y - lastVertex.y) * axis.y +
+        (corner.z - lastVertex.z) * axis.z
+      if (span > maxSpan) {
+        maxSpan = span
+      }
+    }
+
+    return maxSpan
+  }
+
+  /**
+   * Estimates annotation width from MTEXT content when extents are unavailable.
+   */
+  private resolveAnnotationWidth(mtext: AcDbMText): number {
+    if (mtext.extentsWidth > 0) {
+      return mtext.extentsWidth
+    }
+
+    const lines = acdbStripMTextControlCodes(mtext.contents).split('\n')
+    return Math.max(
+      ...lines.map(line =>
+        acdbEstimatePlainTextWidth(line.trim(), mtext.height)
+      ),
+      0
+    )
+  }
+
+  private resolveMTextLayoutMetrics(mtext: AcDbMText) {
+    return acdbResolveMTextLayoutMetrics({
+      contents: mtext.contents,
+      height: mtext.height,
+      width: mtext.width,
+      extentsWidth: mtext.extentsWidth,
+      lineSpacingFactor: mtext.lineSpacingFactor,
+      attachmentPoint: mtext.attachmentPoint,
+      rotation: mtext.rotation,
+      direction: mtext.direction,
+      location: mtext.location
+    })
+  }
+
+  /**
+   * Scores how closely one MTEXT annotation matches a leader landing vertex.
+   */
+  private scoreMTextAssociation(
+    mtext: AcDbMText,
+    lastVertex: AcGePoint3d
+  ): number | null {
+    const layout = this.resolveMTextLayoutMetrics(mtext)
+    const padX = Math.max(mtext.height * 2, 1)
+    const padYAbove = Math.max(mtext.height, 1)
+    const padYBelow = Math.max(layout.height, mtext.height * 4, 10)
+
+    return acdbScorePointAgainstMTextLayout(lastVertex, layout, {
+      padX,
+      padYAbove,
+      padYBelow
+    })
+  }
+
+  /**
+   * Resolves the dimension style referenced by this leader.
+   */
+  private resolveDimensionStyle(): AcDbDimStyleTableRecord | undefined {
+    const styleName = this._dimensionStyle?.trim()
+    const database = this.tryGetDatabase()
+    if (!styleName || !database) {
+      return undefined
+    }
+    return database.tables.dimStyleTable.getAt(styleName)
+  }
+
+  /**
+   * Resolves the MTEXT annotation associated with this leader.
+   */
+  private resolveAssociatedMText(): AcDbMText | undefined {
+    const database = this.tryGetDatabase()
+    if (!database) {
+      return undefined
+    }
+
+    if (this._associatedAnnotation) {
+      const object = database.getObjectById(this._associatedAnnotation)
+      if (object instanceof AcDbMText) {
+        return object
+      }
+    }
+
+    if (this._vertices.length === 0) {
+      return undefined
+    }
+
+    const ownerId = this.getAttrWithoutException('ownerId')
+    if (!ownerId) {
+      return undefined
+    }
+
+    const owner = database.getObjectById(ownerId)
+    if (!(owner instanceof AcDbBlockTableRecord)) {
+      return undefined
+    }
+
+    const lastVertex = this._vertices[this._vertices.length - 1]
+    let bestMatch: AcDbMText | undefined
+    let bestScore = Number.POSITIVE_INFINITY
+
+    for (const entity of owner.newIterator()) {
+      if (!(entity instanceof AcDbMText)) {
+        continue
+      }
+
+      const score = this.scoreMTextAssociation(entity, lastVertex)
+      if (score == null || score >= bestScore) {
+        continue
+      }
+
+      bestScore = score
+      bestMatch = entity
+    }
+
+    return bestMatch
+  }
+
+  private tryGetDatabase() {
+    try {
+      return this.database
+    } catch {
+      return undefined
     }
   }
 

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -61,6 +61,8 @@ export class AcDbMText extends AcDbEntity {
   private _height: number
   /** The maximum width for word wrap formatting */
   private _width: number
+  /** Cached actual text extents width from the source drawing, when available */
+  private _extentsWidth: number
   /** The text contents */
   private _contents: string
   /** The line spacing style */
@@ -107,6 +109,7 @@ export class AcDbMText extends AcDbEntity {
     this._contents = ''
     this._height = 0
     this._width = 0
+    this._extentsWidth = 0
     this._lineSpacingFactor = 0.25
     this._lineSpacingStyle = 0
     this._backgroundFill = false
@@ -213,6 +216,20 @@ export class AcDbMText extends AcDbEntity {
    */
   set width(value: number) {
     this._width = value
+  }
+
+  /**
+   * Gets the cached actual text extents width from the source file.
+   *
+   * When present, this reflects the rendered width of the MTEXT content and is
+   * preferred over {@link width} (reference/wrap width) for layout calculations.
+   */
+  get extentsWidth() {
+    return this._extentsWidth
+  }
+
+  set extentsWidth(value: number) {
+    this._extentsWidth = value
   }
 
   /**
@@ -356,9 +373,11 @@ export class AcDbMText extends AcDbEntity {
   get geometricExtents(): AcGeBox3d {
     const box = new AcGeBox3d()
     const width =
-      this.width > 0
-        ? this.width
-        : acdbEstimatePlainTextWidth(this.contents, this.height)
+      this.extentsWidth > 0
+        ? this.extentsWidth
+        : this.width > 0
+          ? this.width
+          : acdbEstimatePlainTextWidth(this.contents, this.height)
     const lineCount = acdbCountMTextLines(this.contents)
     const height = acdbEstimateMTextHeight(
       lineCount,
@@ -451,6 +470,9 @@ export class AcDbMText extends AcDbEntity {
       this._direction.copy(xAxis).normalize()
       this._rotation = Math.atan2(this._direction.y, this._direction.x)
       this._width *= xScale
+      if (this._extentsWidth > 0) {
+        this._extentsWidth *= xScale
+      }
     }
     if (yScale > 0) {
       this._height *= yScale
@@ -708,6 +730,9 @@ export class AcDbMText extends AcDbEntity {
     filer.writePoint3d(10, this.location)
     filer.writeDouble(40, this.height)
     filer.writeDouble(41, this.width)
+    if (this.extentsWidth > 0) {
+      filer.writeDouble(414, this.extentsWidth)
+    }
     // MTEXT contents use \P for paragraph breaks; raw newlines must not appear in DXF.
     filer.writeString(1, this.encodeMTextContentsForDxf(this.contents))
     filer.writeString(7, this.styleName)

--- a/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
+++ b/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
@@ -134,6 +134,18 @@ export function acdbGetLocalBoundsFromAttachment(
   }
 }
 
+/**
+ * Builds orthonormal text axes from rotation and/or direction.
+ *
+ * When `direction` is provided and non-zero it defines the local X axis;
+ * otherwise X is derived from `rotation` in the XY plane. Y is the
+ * counter-clockwise perpendicular to X.
+ *
+ * @param rotation - Text rotation in radians, used when direction is absent.
+ * @param direction - Optional direction vector overriding rotation.
+ * @returns Normalized local X and Y axis vectors.
+ * @internal
+ */
 function getTextAxes(rotation: number, direction?: AcGeVector3d) {
   let xAxis: AcGeVector3d
   if (direction && direction.lengthSq() > 0) {
@@ -195,4 +207,208 @@ export function acdbExpandBoxByOrientedTextRect(
   }
 
   return box
+}
+
+/**
+ * Resolved layout metrics for an oriented MTEXT rectangle.
+ *
+ * All width/height values are expressed in drawing units. Local axes follow
+ * AutoCAD MTEXT semantics: the X axis aligns with {@link AcDbMTextLayoutMetrics.direction}
+ * (or {@link AcDbMTextLayoutMetrics.rotation} when direction is unset), and the Y axis
+ * is the 90-degree counter-clockwise perpendicular in the text plane.
+ */
+export interface AcDbMTextLayoutMetrics {
+  /** Effective text width used for layout, preferring actual extents when available. */
+  width: number
+  /** Estimated total text height from line count and line spacing. */
+  height: number
+  /** Attachment point that anchors the local bounds to {@link AcDbMTextLayoutMetrics.location}. */
+  attachment: AcGiMTextAttachmentPoint
+  /** Rotation angle in radians relative to the text OCS X axis. */
+  rotation: number
+  /** Optional direction vector overriding {@link AcDbMTextLayoutMetrics.rotation}. */
+  direction?: AcGeVector3d
+  /** Insertion/anchor point of the MTEXT entity in world coordinates. */
+  location: AcGePoint3d
+}
+
+/**
+ * Padding applied in MTEXT-local coordinates when scoring annotation association.
+ *
+ * Padding extends the oriented text bounds along local axes:
+ * `padX` on local X, `padYAbove` toward local +Y, and `padYBelow` toward local -Y.
+ */
+export interface AcDbMTextAssociationPadding {
+  /** Extra tolerance along the local X axis on both sides of the text bounds. */
+  padX: number
+  /** Extra tolerance toward local +Y (above the oriented top edge). */
+  padYAbove: number
+  /** Extra tolerance toward local -Y (below the oriented bottom edge). */
+  padYBelow: number
+}
+
+/**
+ * Resolves oriented MTEXT layout metrics used for association and hook-line math.
+ *
+ * Width resolution order matches {@link AcDbMText.geometricExtents}:
+ * `extentsWidth` → `width` → estimated plain-text width.
+ *
+ * @param input - Raw MTEXT properties used to derive oriented layout metrics.
+ * @param input.contents - MTEXT contents, used for line-count and width estimation.
+ * @param input.height - Text height in drawing units.
+ * @param input.width - Reference/wrap width from the entity.
+ * @param input.extentsWidth - Cached actual rendered width from the source file.
+ * @param input.lineSpacingFactor - Line spacing factor (DXF group 44 semantics).
+ * @param input.attachmentPoint - Attachment point for local bound anchoring.
+ * @param input.rotation - Text rotation in radians.
+ * @param input.direction - Text direction vector; takes precedence over rotation when non-zero.
+ * @param input.location - MTEXT insertion point in world coordinates.
+ * @returns Normalized layout metrics with cloned direction/location values.
+ */
+export function acdbResolveMTextLayoutMetrics(input: {
+  contents: string
+  height: number
+  width: number
+  extentsWidth: number
+  lineSpacingFactor: number
+  attachmentPoint: AcGiMTextAttachmentPoint
+  rotation: number
+  direction: AcGeVector3d
+  location: AcGePoint3dLike
+}): AcDbMTextLayoutMetrics {
+  const width =
+    input.extentsWidth > 0
+      ? input.extentsWidth
+      : input.width > 0
+        ? input.width
+        : acdbEstimatePlainTextWidth(input.contents, input.height)
+  const height = acdbEstimateMTextHeight(
+    acdbCountMTextLines(input.contents),
+    input.height,
+    input.lineSpacingFactor
+  )
+
+  return {
+    width,
+    height,
+    attachment: input.attachmentPoint,
+    rotation: input.rotation,
+    direction:
+      input.direction.lengthSq() > 0 ? input.direction.clone() : undefined,
+    location: new AcGePoint3d(
+      input.location.x,
+      input.location.y,
+      input.location.z ?? 0
+    )
+  }
+}
+
+/**
+ * Converts a world-space point into MTEXT-local coordinates.
+ *
+ * Local X/Y are dot-product projections onto the oriented text axes derived
+ * from {@link AcDbMTextLayoutMetrics.rotation} and
+ * {@link AcDbMTextLayoutMetrics.direction}.
+ *
+ * @param point - Point to convert, typically a leader landing vertex.
+ * @param layout - Resolved MTEXT layout metrics.
+ * @returns Local coordinates `{ x, y }` relative to {@link AcDbMTextLayoutMetrics.location}.
+ */
+export function acdbWorldPointToMTextLocal(
+  point: AcGePoint3dLike,
+  layout: AcDbMTextLayoutMetrics
+): { x: number; y: number } {
+  const { xAxis, yAxis } = getTextAxes(layout.rotation, layout.direction)
+  const dx = point.x - layout.location.x
+  const dy = point.y - layout.location.y
+  const dz = (point.z ?? 0) - layout.location.z
+
+  return {
+    x: dx * xAxis.x + dy * xAxis.y + dz * xAxis.z,
+    y: dx * yAxis.x + dy * yAxis.y + dz * yAxis.z
+  }
+}
+
+/**
+ * Returns the four corners of an oriented MTEXT rectangle in world space.
+ *
+ * Corners are ordered counter-clockwise starting from
+ * `(minX, minY)` in local coordinates.
+ *
+ * @param layout - Resolved MTEXT layout metrics.
+ * @returns World-space corner points of the oriented text bounds.
+ */
+export function acdbCollectMTextOrientedCorners(
+  layout: AcDbMTextLayoutMetrics
+): AcGePoint3d[] {
+  const bounds = acdbGetLocalBoundsFromAttachment(
+    layout.width,
+    layout.height,
+    layout.attachment
+  )
+  const { xAxis, yAxis } = getTextAxes(layout.rotation, layout.direction)
+  const localCorners: Array<[number, number]> = [
+    [bounds.minX, bounds.minY],
+    [bounds.maxX, bounds.minY],
+    [bounds.maxX, bounds.maxY],
+    [bounds.minX, bounds.maxY]
+  ]
+
+  return localCorners.map(
+    ([localX, localY]) =>
+      new AcGePoint3d(
+        layout.location.x + xAxis.x * localX + yAxis.x * localY,
+        layout.location.y + xAxis.y * localX + yAxis.y * localY,
+        layout.location.z + xAxis.z * localX + yAxis.z * localY
+      )
+  )
+}
+
+/**
+ * Scores how closely one world point matches an oriented MTEXT annotation.
+ *
+ * The score is the Manhattan distance from the point to the inner text bounds
+ * in local coordinates. A score of `0` means the point lies inside the
+ * oriented bounds; larger values indicate proximity within the padded region.
+ *
+ * @param point - Candidate association point, usually a leader landing vertex.
+ * @param layout - Resolved MTEXT layout metrics.
+ * @param padding - Local-axis padding applied before rejecting a candidate.
+ * @returns Association score, or `null` when the point is outside padded bounds.
+ */
+export function acdbScorePointAgainstMTextLayout(
+  point: AcGePoint3dLike,
+  layout: AcDbMTextLayoutMetrics,
+  padding: AcDbMTextAssociationPadding
+): number | null {
+  const bounds = acdbGetLocalBoundsFromAttachment(
+    layout.width,
+    layout.height,
+    layout.attachment
+  )
+  const { x: localX, y: localY } = acdbWorldPointToMTextLocal(point, layout)
+
+  const minX = bounds.minX - padding.padX
+  const maxX = bounds.maxX + padding.padX
+  const minY = bounds.minY - padding.padYBelow
+  const maxY = bounds.maxY + padding.padYAbove
+
+  if (localX < minX || localX > maxX || localY < minY || localY > maxY) {
+    return null
+  }
+
+  const dx =
+    localX < bounds.minX
+      ? bounds.minX - localX
+      : localX > bounds.maxX
+        ? bounds.maxX - localX
+        : 0
+  const dy =
+    localY < bounds.minY
+      ? bounds.minY - localY
+      : localY > bounds.maxY
+        ? localY - bounds.maxY
+        : 0
+
+  return dx + dy
 }

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -8,6 +8,7 @@ import {
   AcDbMLeader,
   AcDbMLeaderContentType,
   AcDbMLeaderLineType,
+  AcDbMText,
   AcDbPolyline,
   AcDbProxyEntity,
   AcDbRotatedDimension,
@@ -227,6 +228,38 @@ describe('AcDbEntityConverter', () => {
     expect(leader.byBlockColor).toBe(256)
     expect(leader.associatedAnnotation).toBe('AA')
     expect(leader.offsetFromAnnotation).toMatchObject({ x: 1, y: 0, z: 0 })
+  })
+
+  it('converts MTEXT extentsWidth from dxf-json entities', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'MTEXT',
+      text: 'Hello',
+      height: 2,
+      width: 10,
+      extentsWidth: 7.5,
+      insertionPoint: { x: 0, y: 0, z: 0 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMText)
+    expect((result as AcDbMText).extentsWidth).toBeCloseTo(7.5)
+  })
+
+  it('converts MTEXT actualWidth alias from dxf-json entities', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'MTEXT',
+      text: 'Hello',
+      height: 2,
+      width: 10,
+      actualWidth: 6,
+      insertionPoint: { x: 0, y: 0, z: 0 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMText)
+    expect((result as AcDbMText).extentsWidth).toBeCloseTo(6)
   })
 
   it('converts dxf-json MULTILEADER text and leaderSections shape', () => {

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -796,7 +796,19 @@ export class AcDbEntityConverter {
     }
     dbEntity.drawingDirection =
       mtext.drawingDirection as unknown as AcGiMTextFlowDirection
+    const extentsWidth = this.readMTextExtentsWidth(mtext)
+    if (extentsWidth != null && extentsWidth > 0) {
+      dbEntity.extentsWidth = extentsWidth
+    }
     return dbEntity
+  }
+
+  private readMTextExtentsWidth(mtext: MTextEntity): number | undefined {
+    const candidate = mtext as MTextEntity & {
+      extentsWidth?: number
+      actualWidth?: number
+    }
+    return candidate.extentsWidth ?? candidate.actualWidth
   }
 
   private convertLeader(leader: LeaderEntity) {

--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -6,6 +6,9 @@ import {
   AcDbCircle,
   AcDbDatabase,
   AcDbHatch,
+  AcDbLeader,
+  AcDbLeaderAnnotationType,
+  AcDbMText,
   AcDbProxyEntity,
   AcDbShape,
   acdbHostApplicationServices
@@ -318,5 +321,50 @@ describe('libredwg AcDbEntityConverter', () => {
 
     expect(result).toBeInstanceOf(AcDb3PointAngularDimension)
     expect((result as AcDb3PointAngularDimension).dimBlockId).toBe('*D64')
+  })
+
+  it('converts LEADER hook-line metadata from libredwg entities', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'LEADER',
+      styleName: 'Standard',
+      isArrowheadEnabled: true,
+      isSpline: false,
+      leaderCreationFlag: 0,
+      isHooklineSameDirection: true,
+      isHooklineExists: true,
+      textHeight: 5,
+      textWidth: 9.51,
+      vertices: [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 5, z: 0 }
+      ],
+      horizontalDirection: { x: 1, y: 0, z: 0 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbLeader)
+    const leader = result as AcDbLeader
+    expect(leader.hasHookLine).toBe(true)
+    expect(leader.isHookLineSameDirection).toBe(true)
+    expect(leader.textWidth).toBeCloseTo(9.51)
+    expect(leader.annoType).toBe(AcDbLeaderAnnotationType.MText)
+    expect(leader.horizontalDirection).toMatchObject({ x: 1, y: 0, z: 0 })
+  })
+
+  it('converts MTEXT extentsWidth from libredwg entities', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'MTEXT',
+      text: 'Note',
+      textHeight: 2.5,
+      rectWidth: 10,
+      extentsWidth: 16.25,
+      insertionPoint: { x: 0, y: 0, z: 0 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbMText)
+    expect((result as AcDbMText).extentsWidth).toBeCloseTo(16.25)
   })
 })

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -707,6 +707,9 @@ export class AcDbEntityConverter {
     }
     dbEntity.drawingDirection =
       mtext.drawingDirection as unknown as AcGiMTextFlowDirection
+    if (mtext.extentsWidth != null && mtext.extentsWidth > 0) {
+      dbEntity.extentsWidth = mtext.extentsWidth
+    }
     return dbEntity
   }
 
@@ -717,10 +720,25 @@ export class AcDbEntityConverter {
     })
     dbEntity.hasArrowHead = leader.isArrowheadEnabled
     dbEntity.hasHookLine = leader.isHooklineExists
+    dbEntity.isHookLineSameDirection = leader.isHooklineSameDirection
     dbEntity.isSplined = leader.isSpline
-    dbEntity.dimensionStyle = leader.styleName
+    dbEntity.dimensionStyle = leader.styleName ?? ''
     dbEntity.annoType =
       leader.leaderCreationFlag as unknown as AcDbLeaderAnnotationType
+    if (leader.textHeight != null) dbEntity.textHeight = leader.textHeight
+    if (leader.textWidth != null) dbEntity.textWidth = leader.textWidth
+    if (leader.byBlockColor != null) dbEntity.byBlockColor = leader.byBlockColor
+    if (leader.associatedAnnotation) {
+      dbEntity.associatedAnnotation = leader.associatedAnnotation
+    }
+    if (leader.normal) dbEntity.normal = leader.normal
+    if (leader.horizontalDirection) {
+      dbEntity.horizontalDirection = leader.horizontalDirection
+    }
+    if (leader.offsetFromBlock) dbEntity.offsetFromBlock = leader.offsetFromBlock
+    if (leader.offsetFromAnnotation) {
+      dbEntity.offsetFromAnnotation = leader.offsetFromAnnotation
+    }
     return dbEntity
   }
 


### PR DESCRIPTION
## Summary

- Render horizontal leader hook-line segments from associated MTEXT geometry, including rotated/oriented bounds via new layout helpers in `AcDbTextExtentsHelpers`.
- Add `AcDbMText.extentsWidth` (DXF group 414) for actual rendered text width, preferred over reference wrap width in bounds and hook-line calculations.
- Resolve associated MTEXT by `associatedAnnotation` handle first, then spatial search with oriented local-coordinate scoring.
- Wire `extentsWidth` and leader hook-line metadata through dxf-json and libredwg entity converters.

## Test plan

- [x] `pnpm test -- --testPathPattern="AcDbLeader|AcDbMText|AcDbTextExtentsHelpers|AcDbEntityConverter"`
- [x] `pnpm test -- packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts`
- [ ] Load a DWG/DXF with leaders and MTEXT annotations and verify hook lines span the annotation width
- [ ] Verify rotated MTEXT leaders resolve hook-line length from oriented bounds, not world-axis padding
