### PR TITLE
fix(data-model): continue database read when font loading fails by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ await database.read(
 
 For a complete example, see the [example project](./packages/example/src/main.ts).
 
+### Font Loading and Self-Hosting
+
+When using a viewer such as `@mlightcad/cad-simple-viewer`, fonts are loaded from a
+`baseUrl` (default: jsDelivr CDN). If the CDN is unreachable, `@mlightcad/data-model`
+continues parsing DWG/DXF entities by default; text may fall back until fonts load.
+
+For self-hosted fonts, templates, `fonts.json`, and server setup, see
+[Self Hosted Fonts and Templates](https://github.com/mlightcad/cad-viewer/wiki/Self-Hosted-Fonts-and-Templates)
+in the cad-viewer wiki.
+
 ### Extensibility
 
 This mechanism allows you to:

--- a/packages/data-model/README.md
+++ b/packages/data-model/README.md
@@ -194,6 +194,23 @@ const buffer = await file.arrayBuffer()
 await database.read(buffer, { readOnly: true }, AcDbFileType.DXF)
 ```
 
+### Font Loading
+
+Text-heavy drawings may reference SHX or mesh fonts. Pass an `AcDbFontLoader` via
+`AcDbOpenDatabaseOptions.fontLoader` to fetch font files while the database is opened.
+Viewers such as `@mlightcad/cad-simple-viewer` typically load font metadata from
+[mlightcad/cad-data](https://github.com/mlightcad/cad-data) (default CDN:
+`https://cdn.jsdelivr.net/gh/mlightcad/cad-data@main/`).
+
+If the font CDN is unreachable, `AcDbDatabase.read()` **continues parsing entities by
+default** and logs a warning. Text may render with fallback fonts until fonts are loaded
+later. Set `failOnFontLoadError: true` to restore the previous strict behavior.
+
+To self-host fonts and templates (directory layout, `fonts.json`, CORS, and `baseUrl`
+configuration), see the
+[Self Hosted Fonts and Templates](https://github.com/mlightcad/cad-viewer/wiki/Self-Hosted-Fonts-and-Templates)
+guide in the cad-viewer wiki.
+
 ### Dimension Creation
 ```typescript
 import { AcDbAlignedDimension, AcGePoint3d } from '@mlightcad/data-model';

--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -2,6 +2,7 @@ import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 
 import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDatabaseConverterManager } from '../src/database/AcDbDatabaseConverterManager'
 import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
 import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
 import { DEFAULT_TEXT_STYLE } from '../src/misc/AcDbConstants'
@@ -64,5 +65,91 @@ describe('AcDbDatabase', () => {
     const db = new AcDbDatabase()
     db.initializeHandleSeed('FFFF')
     expect(db.generateHandle()).toBe('FFFF')
+  })
+
+  it('continues reading when font loading fails by default', async () => {
+    const db = new AcDbDatabase()
+    const fileType = 'test-font-load'
+    const fontLoader = {
+      load: jest.fn().mockRejectedValue(new Error('Failed to fetch')),
+      getAvaiableFonts: jest.fn().mockResolvedValue([])
+    }
+    const converter = {
+      read: jest.fn(
+        async (
+          _data: ArrayBuffer,
+          _db: AcDbDatabase,
+          _minimumChunkSize: number,
+          progress?: (
+            percentage: number,
+            stage: string,
+            stageStatus: string,
+            data?: unknown
+          ) => Promise<void>
+        ) => {
+          if (progress) {
+            await progress(5, 'FONT', 'END', ['arial'])
+          }
+        }
+      )
+    }
+    const manager = AcDbDatabaseConverterManager.instance
+    manager.register(fileType, converter as never)
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await expect(
+        db.read(new ArrayBuffer(0), { fontLoader, readOnly: true }, fileType)
+      ).resolves.toBeUndefined()
+      expect(fontLoader.load).toHaveBeenCalledWith(['arial'])
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+      manager.unregister(fileType)
+    }
+  })
+
+  it('aborts reading when font loading fails and failOnFontLoadError is true', async () => {
+    const db = new AcDbDatabase()
+    const fileType = 'test-font-load-strict'
+    const loadError = new Error('Failed to fetch')
+    const fontLoader = {
+      load: jest.fn().mockRejectedValue(loadError),
+      getAvaiableFonts: jest.fn().mockResolvedValue([])
+    }
+    const converter = {
+      read: jest.fn(
+        async (
+          _data: ArrayBuffer,
+          _db: AcDbDatabase,
+          _minimumChunkSize: number,
+          progress?: (
+            percentage: number,
+            stage: string,
+            stageStatus: string,
+            data?: unknown
+          ) => Promise<void>
+        ) => {
+          if (progress) {
+            await progress(5, 'FONT', 'END', ['arial'])
+          }
+        }
+      )
+    }
+    const manager = AcDbDatabaseConverterManager.instance
+    manager.register(fileType, converter as never)
+
+    try {
+      await expect(
+        db.read(
+          new ArrayBuffer(0),
+          { fontLoader, readOnly: true, failOnFontLoadError: true },
+          fileType
+        )
+      ).rejects.toThrow('Failed to fetch')
+    } finally {
+      manager.unregister(fileType)
+    }
   })
 })

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -216,9 +216,18 @@ export interface AcDbOpenDatabaseOptions {
    * Loader used to load fonts used in the drawing database.
    *
    * This loader will be used to load any fonts referenced by text entities
-   * in the drawing database.
+   * in the drawing database. By default, font load failures are logged and
+   * parsing continues without the missing fonts. Set {@link failOnFontLoadError}
+   * to `true` to abort the read when font loading fails.
    */
   fontLoader?: AcDbFontLoader
+
+  /**
+   * When `true`, aborts {@link AcDbDatabase.read} if {@link fontLoader} fails.
+   *
+   * Defaults to `false` so unreachable font CDNs do not block entity parsing.
+   */
+  failOnFontLoadError?: boolean
 
   /**
    * The minimum number of items in one chunk.
@@ -1949,7 +1958,29 @@ export class AcDbDatabase extends AcDbObject {
           const fonts = data
             ? (data as string[])
             : this.tables.textStyleTable.fonts
-          await options.fontLoader.load(fonts)
+          try {
+            await options.fontLoader.load(fonts)
+          } catch (error) {
+            if (options.failOnFontLoadError) {
+              throw error
+            }
+            const message =
+              error instanceof Error ? error.message : String(error)
+            console.warn(
+              'Failed to load fonts; continuing without them. ' +
+                'Check your network or configure a local baseUrl. See ' +
+                'https://github.com/mlightcad/cad-viewer/wiki/Self-Hosted-Fonts-and-Templates',
+              error
+            )
+            this.events.openProgress.dispatch({
+              database: this,
+              percentage: percentage,
+              stage: 'CONVERSION',
+              subStage: stage,
+              subStageStatus: 'ERROR',
+              data: { fonts, error: message }
+            })
+          }
         }
       },
       options?.timeout,


### PR DESCRIPTION
## Summary
- Font load failures during `AcDbDatabase.read()` are logged and skipped by default so unreachable CDNs do not block DWG/DXF entity parsing.
- Added `failOnFontLoadError` option to restore the previous strict abort-on-failure behavior.
- Documented font loading, CDN fallback behavior, and self-hosting in README files.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbDatabase.spec.ts` passes (7/7)
- [ ] Open a text-heavy DWG with CDN blocked — entities should still parse; text may use fallback fonts
- [ ] Open with `failOnFontLoadError: true` — read should abort when font loading fails