### PR TITLE
feat(data-model): add structured open-database errors for worker failures

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -1,6 +1,7 @@
 import { AcCmColor, AcCmColorMethod } from '@mlightcad/common'
 
 import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbOpenDatabaseError } from '../src/database/AcDbOpenDatabaseError'
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbDatabaseConverterManager } from '../src/database/AcDbDatabaseConverterManager'
 import { AcDbLayerTableRecord } from '../src/database/AcDbLayerTableRecord'
@@ -148,6 +149,70 @@ describe('AcDbDatabase', () => {
           fileType
         )
       ).rejects.toThrow('Failed to fetch')
+    } finally {
+      manager.unregister(fileType)
+    }
+  })
+
+  it('exposes worker OOM failures via lastOpenError, openFailed, and openProgress', async () => {
+    const db = new AcDbDatabase()
+    const fileType = 'test-open-failure'
+    const oomError = new AcDbOpenDatabaseError(
+      "Failed to parse drawing due to error: 'Data cannot be cloned, out of memory.'",
+      'worker_oom',
+      { stage: 'PARSE' }
+    )
+    const converter = {
+      read: jest.fn(
+        async (
+          _data: ArrayBuffer,
+          _db: AcDbDatabase,
+          _minimumChunkSize: number,
+          progress?: (
+            percentage: number,
+            stage: string,
+            stageStatus: string,
+            data?: unknown,
+            taskError?: { error: unknown; task: { name: string }; taskIndex: number }
+          ) => Promise<void>
+        ) => {
+          if (progress) {
+            await progress(5, 'PARSE', 'ERROR', undefined, {
+              error: oomError,
+              task: { name: 'PARSE' },
+              taskIndex: 1
+            })
+          }
+          throw oomError
+        }
+      )
+    }
+    const manager = AcDbDatabaseConverterManager.instance
+    manager.register(fileType, converter as never)
+
+    const openFailed = jest.fn()
+    const openProgress = jest.fn()
+    db.events.openFailed.addEventListener(openFailed)
+    db.events.openProgress.addEventListener(openProgress)
+
+    try {
+      await expect(
+        db.read(new ArrayBuffer(0), { readOnly: true }, fileType)
+      ).rejects.toMatchObject({ code: 'worker_oom' })
+
+      expect(db.lastOpenError?.code).toBe('worker_oom')
+      expect(openFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          database: db,
+          error: expect.objectContaining({ code: 'worker_oom' })
+        })
+      )
+      expect(openProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subStageStatus: 'ERROR',
+          data: expect.objectContaining({ code: 'worker_oom' })
+        })
+      )
     } finally {
       manager.unregister(fileType)
     }

--- a/packages/data-model/__tests__/AcDbOpenDatabaseError.spec.ts
+++ b/packages/data-model/__tests__/AcDbOpenDatabaseError.spec.ts
@@ -1,0 +1,48 @@
+import { AcDbOpenDatabaseError } from '../src/database/AcDbOpenDatabaseError'
+
+describe('AcDbOpenDatabaseError', () => {
+  it('detects worker OOM messages', () => {
+    expect(
+      AcDbOpenDatabaseError.isWorkerOutOfMemoryMessage(
+        "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Data cannot be cloned, out of memory."
+      )
+    ).toBe(true)
+    expect(
+      AcDbOpenDatabaseError.classifyWorkerErrorMessage(
+        'Worker operation timed out after 30ms'
+      )
+    ).toBe('worker_timeout')
+  })
+
+  it('normalizes generic errors', () => {
+    const error = AcDbOpenDatabaseError.from(new Error('bad dwg'), 'PARSE')
+    expect(error.name).toBe('AcDbOpenDatabaseError')
+    expect(error.code).toBe('worker_error')
+    expect(error.stage).toBe('PARSE')
+  })
+
+  it('throws typed parse failures from worker results', () => {
+    expect(() =>
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure({
+        success: false,
+        error:
+          "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Data cannot be cloned, out of memory.",
+        errorCode: 'worker_oom',
+        duration: 1
+      })
+    ).toThrow(/out of memory/)
+
+    try {
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure({
+        success: false,
+        error:
+          "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Data cannot be cloned, out of memory.",
+        errorCode: 'worker_oom',
+        duration: 1
+      })
+    } catch (error) {
+      expect((error as AcDbOpenDatabaseError).code).toBe('worker_oom')
+      expect((error as AcDbOpenDatabaseError).name).toBe('AcDbOpenDatabaseError')
+    }
+  })
+})

--- a/packages/data-model/__tests__/AcDbWorkerManager.spec.ts
+++ b/packages/data-model/__tests__/AcDbWorkerManager.spec.ts
@@ -28,12 +28,36 @@ class FakeWorker {
     if (payload.input === 'no-response') {
       return
     }
+    if (payload.input === 'fail-result') {
+      const evt = {
+        data: {
+          id: payload.id,
+          success: false,
+          data: undefined,
+          error: payload.input === 'fail-result' ? 'failed' : undefined
+        }
+      }
+      this.listeners.message.forEach(cb => cb(evt))
+      return
+    }
+    if (payload.input === 'fail-oom') {
+      const evt = {
+        data: {
+          id: payload.id,
+          success: false,
+          error:
+            "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Data cannot be cloned, out of memory.",
+          errorCode: 'worker_oom'
+        }
+      }
+      this.listeners.message.forEach(cb => cb(evt))
+      return
+    }
     const evt = {
       data: {
         id: payload.id,
-        success: payload.input !== 'fail-result',
-        data: payload.input,
-        error: payload.input === 'fail-result' ? 'failed' : undefined
+        success: true,
+        data: payload.input
       }
     }
     this.listeners.message.forEach(cb => cb(evt))
@@ -73,6 +97,10 @@ describe('AcDbWorkerManager / AcDbWorkerApi', () => {
     const failed = await manager.execute<string, string>('fail-result')
     expect(failed.success).toBe(false)
     expect(failed.error).toBe('failed')
+
+    const oom = await manager.execute<string, string>('fail-oom')
+    expect(oom.success).toBe(false)
+    expect(oom.errorCode).toBe('worker_oom')
 
     const workerError = await manager.execute<string, string>('trigger-error')
     expect(workerError.success).toBe(false)

--- a/packages/data-model/src/converter/index.ts
+++ b/packages/data-model/src/converter/index.ts
@@ -18,5 +18,6 @@ export type {
   AcDbWorkerInstance,
   AcDbWorkerMessage,
   AcDbWorkerResponse,
-  AcDbWorkerResult
+  AcDbWorkerResult,
+  AcDbWorkerErrorCode
 } from './worker'

--- a/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
+++ b/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
@@ -5,16 +5,38 @@
 
 /// <reference lib="webworker" />
 
+/** Message sent from the main thread to a worker task. */
 export interface AcDbWorkerMessage<TInput = unknown> {
+  /** Unique task identifier used to correlate the response. */
   id: string
+  /** Task input payload. */
   input: TInput
 }
 
+/**
+ * Machine-readable error category for worker failures.
+ *
+ * - `worker_oom` — postMessage failed due to memory or clone limits
+ * - `worker_timeout` — task exceeded the configured timeout (main thread)
+ * - `worker_error` — generic worker or postMessage failure
+ */
+export type AcDbWorkerErrorCode =
+  | 'worker_oom'
+  | 'worker_timeout'
+  | 'worker_error'
+
+/** Response posted back to the main thread after a worker task completes. */
 export interface AcDbWorkerResponse<TOutput = unknown> {
+  /** Task identifier matching the originating {@link AcDbWorkerMessage.id}. */
   id: string
+  /** Whether the task completed without throwing. */
   success: boolean
+  /** Task result when {@link success} is true. */
   data?: TOutput
+  /** Human-readable error message when {@link success} is false. */
   error?: string
+  /** Structured error category when {@link success} is false. */
+  errorCode?: AcDbWorkerErrorCode
 }
 
 /**
@@ -54,16 +76,43 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
     id: string,
     success: boolean,
     data?: TOutput,
-    error?: string
+    error?: string,
+    errorCode?: AcDbWorkerErrorCode
   ): void {
     const response: AcDbWorkerResponse<TOutput> = {
       id,
       success,
       data,
-      error
+      error,
+      errorCode
     }
 
-    self.postMessage(response)
+    try {
+      self.postMessage(response)
+    } catch (postError) {
+      const message =
+        postError instanceof Error ? postError.message : String(postError)
+      self.postMessage({
+        id,
+        success: false,
+        error: message,
+        errorCode: this.classifyPostMessageError(message)
+      })
+    }
+  }
+
+  /**
+   * Map a postMessage failure message to a structured error code.
+   */
+  private classifyPostMessageError(message: string): AcDbWorkerErrorCode {
+    const lower = message.toLowerCase()
+    if (
+      lower.includes('out of memory') ||
+      lower.includes('data cannot be cloned')
+    ) {
+      return 'worker_oom'
+    }
+    return 'worker_error'
   }
 
   /**

--- a/packages/data-model/src/converter/worker/AcDbWorkerManager.ts
+++ b/packages/data-model/src/converter/worker/AcDbWorkerManager.ts
@@ -2,6 +2,8 @@
  * Simple worker framework
  */
 
+import type { AcDbWorkerErrorCode } from './AcDbBaseWorker'
+
 export interface AcDbWorkerConfig {
   /** Worker script URL (required if useWorker is true) */
   workerUrl: string | URL
@@ -11,10 +13,13 @@ export interface AcDbWorkerConfig {
   maxConcurrentWorkers?: number
 }
 
+export type { AcDbWorkerErrorCode } from './AcDbBaseWorker'
+
 export interface AcDbWorkerResult<TOutput = unknown> {
   success: boolean
   data?: TOutput
   error?: string
+  errorCode?: AcDbWorkerErrorCode
   duration: number
 }
 
@@ -67,9 +72,13 @@ export class AcDbWorkerManager {
       )
     } catch (error) {
       const duration = Date.now() - startTime
+      const message = error instanceof Error ? error.message : String(error)
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
+        errorCode: message.toLowerCase().includes('timed out')
+          ? 'worker_timeout'
+          : undefined,
         duration
       }
     }
@@ -115,7 +124,7 @@ export class AcDbWorkerManager {
 
       // Set up message handler
       const messageHandler = (event: MessageEvent) => {
-        const { id, success, data, error } = event.data
+        const { id, success, data, error, errorCode } = event.data
         if (id !== taskId) return
 
         this.cleanupTask(taskId)
@@ -131,6 +140,7 @@ export class AcDbWorkerManager {
           resolve({
             success: false,
             error,
+            errorCode,
             duration
           })
         }

--- a/packages/data-model/src/converter/worker/index.ts
+++ b/packages/data-model/src/converter/worker/index.ts
@@ -9,4 +9,4 @@ export type {
   AcDbWorkerResult
 } from './AcDbWorkerManager'
 export { AcDbBaseWorker } from './AcDbBaseWorker'
-export type { AcDbWorkerMessage, AcDbWorkerResponse } from './AcDbBaseWorker'
+export type { AcDbWorkerMessage, AcDbWorkerResponse, AcDbWorkerErrorCode } from './AcDbBaseWorker'

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -3,6 +3,7 @@ import {
   AcCmColor,
   AcCmColorMethod,
   AcCmEventManager,
+  AcCmTaskError,
   AcCmTransparency
 } from '@mlightcad/common'
 
@@ -40,6 +41,8 @@ import { AcDbXrecord } from '../object/AcDbXrecord'
 import { AcDbBlockTable } from './AcDbBlockTable'
 import { AcDbBlockTableRecord } from './AcDbBlockTableRecord'
 import { AcDbConversionStage, AcDbStageStatus } from './AcDbDatabaseConverter'
+import type { AcDbConversionProgressCallback } from './AcDbDatabaseConverter'
+import { AcDbOpenDatabaseError } from './AcDbOpenDatabaseError'
 import { AcDbDimStyleTable } from './AcDbDimStyleTable'
 import { AcDbDimStyleTableRecord } from './AcDbDimStyleTableRecord'
 import { AcDbLayerTable } from './AcDbLayerTable'
@@ -134,10 +137,21 @@ export interface AcDbProgressdEventArgs {
    * are as follows.
    * - 'PARSE' stage: statistics of parsing task
    * - 'FONT' stage: fonts needed by this drawing
+   * - Any stage with {@link subStageStatus} `'ERROR'`: `{ code, message, stage? }`
    *
-   * Note: For now, 'PARSE' and 'FONT' sub stages use this field only.
+   * Note: For now, 'PARSE' and 'FONT' sub stages use this field only, except on errors.
    */
   data?: unknown
+}
+
+/**
+ * Event arguments when opening a drawing database fails.
+ */
+export interface AcDbOpenFailedEventArgs {
+  /** The database that failed to open */
+  database: AcDbDatabase
+  /** Structured failure information */
+  error: AcDbOpenDatabaseError
 }
 
 /**
@@ -430,6 +444,7 @@ export class AcDbDatabase extends AcDbObject {
   private _pendingEntityErased: AcDbEntity[] = []
   private _pendingDictObjectSet: { object: AcDbObject; key: string }[] = []
   private _pendingDictObjectErased: { object: AcDbObject; key: string }[] = []
+  private _lastOpenError: AcDbOpenDatabaseError | null = null
 
   /**
    * Events that can be triggered by the database.
@@ -455,7 +470,9 @@ export class AcDbDatabase extends AcDbObject {
     /** Fired when a layer is erased from the database */
     layerErased: new AcCmEventManager<AcDbLayerEventArgs>(),
     /** Fired during database opening operations to report progress */
-    openProgress: new AcCmEventManager<AcDbProgressdEventArgs>()
+    openProgress: new AcCmEventManager<AcDbProgressdEventArgs>(),
+    /** Fired when {@link AcDbDatabase.read} or {@link AcDbDatabase.openUri} fails */
+    openFailed: new AcCmEventManager<AcDbOpenFailedEventArgs>()
   }
 
   /**
@@ -1891,6 +1908,16 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
+   * The most recent failure from {@link read} or {@link openUri}, or `null` after a successful open.
+   *
+   * Useful when a caller catches no exception (for example a viewer that returns `false`)
+   * but still needs to distinguish worker out-of-memory from other parse failures.
+   */
+  get lastOpenError(): AcDbOpenDatabaseError | null {
+    return this._lastOpenError
+  }
+
+  /**
    * Reads drawing data from a string or ArrayBuffer.
    *
    * This method parses the provided data and populates the database with
@@ -1926,68 +1953,95 @@ export class AcDbDatabase extends AcDbObject {
       )
 
     this.clear()
+    this._lastOpenError = null
     this._drawNoPlotLayers = options?.drawNoPlotLayers ?? true
     if (options?.fileName) {
       this.setDwgName(options.fileName)
     }
 
-    await converter.read(
-      data,
-      this,
-      (options && options.minimumChunkSize) || 10,
-      async (
-        percentage: number,
-        stage: AcDbConversionStage,
-        stageStatus: AcDbStageStatus,
-        data?: unknown
-      ) => {
-        this.events.openProgress.dispatch({
-          database: this,
-          percentage: percentage,
-          stage: 'CONVERSION',
-          subStage: stage,
-          subStageStatus: stageStatus,
-          data: data
-        })
-        if (
-          options &&
-          options.fontLoader &&
-          stage == 'FONT' &&
-          stageStatus == 'END'
-        ) {
-          const fonts = data
-            ? (data as string[])
-            : this.tables.textStyleTable.fonts
-          try {
-            await options.fontLoader.load(fonts)
-          } catch (error) {
-            if (options.failOnFontLoadError) {
-              throw error
-            }
-            const message =
-              error instanceof Error ? error.message : String(error)
-            console.warn(
-              'Failed to load fonts; continuing without them. ' +
-                'Check your network or configure a local baseUrl. See ' +
-                'https://github.com/mlightcad/cad-viewer/wiki/Self-Hosted-Fonts-and-Templates',
-              error
-            )
-            this.events.openProgress.dispatch({
-              database: this,
-              percentage: percentage,
-              stage: 'CONVERSION',
-              subStage: stage,
-              subStageStatus: 'ERROR',
-              data: { fonts, error: message }
-            })
-          }
-        }
-      },
-      options?.timeout,
-      options?.sysVars
-    )
+    try {
+      await converter.read(
+        data,
+        this,
+        (options && options.minimumChunkSize) || 10,
+        this.createConversionProgressHandler(options),
+        options?.timeout,
+        options?.sysVars
+      )
+    } catch (error) {
+      const openError = AcDbOpenDatabaseError.from(error)
+      this._lastOpenError = openError
+      this.events.openFailed.dispatch({ database: this, error: openError })
+      throw openError
+    }
 
+    this._lastOpenError = null
     this.ensureDatabaseDefaults()
+  }
+
+  private createConversionProgressHandler(
+    options?: AcDbOpenDatabaseOptions
+  ): AcDbConversionProgressCallback {
+    return async (
+      percentage: number,
+      stage: AcDbConversionStage,
+      stageStatus: AcDbStageStatus,
+      data?: unknown,
+      taskError?: AcCmTaskError
+    ) => {
+      let progressData: unknown = data
+      if (stageStatus === 'ERROR' && taskError) {
+        const openError = AcDbOpenDatabaseError.fromTask(taskError)
+        this._lastOpenError = openError
+        progressData = {
+          code: openError.code,
+          message: openError.message,
+          stage: openError.stage ?? stage
+        }
+      }
+
+      this.events.openProgress.dispatch({
+        database: this,
+        percentage: percentage,
+        stage: 'CONVERSION',
+        subStage: stage,
+        subStageStatus: stageStatus,
+        data: progressData
+      })
+      if (
+        options &&
+        options.fontLoader &&
+        stage == 'FONT' &&
+        stageStatus == 'END'
+      ) {
+        const fonts = data
+          ? (data as string[])
+          : this.tables.textStyleTable.fonts
+        try {
+          await options.fontLoader.load(fonts)
+        } catch (error) {
+          if (options.failOnFontLoadError) {
+            throw error
+          }
+          const message =
+            error instanceof Error ? error.message : String(error)
+          console.warn(
+            'Failed to load fonts; continuing without them. ' +
+              'Check your network or configure a local baseUrl. See ' +
+              'https://github.com/mlightcad/cad-viewer/wiki/Self-Hosted-Fonts-and-Templates',
+            error
+          )
+          this.events.openProgress.dispatch({
+            database: this,
+            percentage: percentage,
+            stage: 'CONVERSION',
+            subStage: stage,
+            subStageStatus: 'ERROR',
+            data: { fonts, error: message, code: 'font_load_failed' }
+          })
+        }
+      }
+    }
   }
 
   /**
@@ -2134,21 +2188,7 @@ export class AcDbDatabase extends AcDbObject {
       null as unknown as ArrayBuffer,
       this,
       500,
-      async (
-        percentage: number,
-        stage: AcDbConversionStage,
-        stageStatus: AcDbStageStatus,
-        data?: unknown
-      ) => {
-        this.events.openProgress.dispatch({
-          database: this,
-          percentage: percentage,
-          stage: 'CONVERSION',
-          subStage: stage,
-          subStageStatus: stageStatus,
-          data: data
-        })
-      }
+      this.createConversionProgressHandler()
     )
   }
 

--- a/packages/data-model/src/database/AcDbOpenDatabaseError.ts
+++ b/packages/data-model/src/database/AcDbOpenDatabaseError.ts
@@ -1,0 +1,201 @@
+import { AcCmTaskError } from '@mlightcad/common'
+
+import type { AcDbWorkerErrorCode } from '../converter/worker/AcDbBaseWorker'
+import { AcDbWorkerResult } from '../converter/worker/AcDbWorkerManager'
+import { AcDbConversionStage } from './AcDbDatabaseConverter'
+
+/**
+ * Machine-readable reason for a failed {@link AcDbDatabase.read} or {@link AcDbDatabase.openUri}.
+ *
+ * - `worker_oom` — worker serialization or postMessage failed due to memory limits
+ * - `worker_timeout` — a worker task exceeded its configured timeout
+ * - `worker_error` — generic worker or postMessage failure
+ * - `parse_failed` — the drawing could not be parsed into an {@link AcDbDatabase}
+ * - `font_load_failed` — required font files could not be downloaded or loaded
+ * - `fetch_failed` — the drawing source could not be fetched from a URI
+ * - `unknown` — failure reason could not be classified
+ */
+export type AcDbOpenDatabaseErrorCode =
+  | 'worker_oom'
+  | 'worker_timeout'
+  | 'worker_error'
+  | 'parse_failed'
+  | 'font_load_failed'
+  | 'fetch_failed'
+  | 'unknown'
+
+/**
+ * Structured error thrown when opening a drawing database fails.
+ *
+ * Callers can inspect {@link code} to distinguish worker out-of-memory failures
+ * from parse errors, timeouts, and other failure modes.
+ */
+export class AcDbOpenDatabaseError extends Error {
+  /** Machine-readable failure category for programmatic handling. */
+  readonly code: AcDbOpenDatabaseErrorCode
+
+  /**
+   * Conversion stage that was active when the failure occurred, when known.
+   *
+   * Populated for failures raised during {@link AcDbDatabase.read} or
+   * {@link AcDbDatabase.openUri} pipeline tasks.
+   */
+  readonly stage?: AcDbConversionStage
+
+  /**
+   * Substrings matched against worker error messages to detect out-of-memory failures.
+   *
+   * Used by {@link isWorkerOutOfMemoryMessage} when structured worker error codes
+   * are unavailable.
+   */
+  private static readonly WORKER_OOM_PATTERNS = [
+    'out of memory',
+    'data cannot be cloned',
+    'allocation failed',
+    'memory access out of bounds'
+  ]
+
+  /**
+   * Creates a new open-database error.
+   *
+   * @param message - Human-readable failure description
+   * @param code - Machine-readable failure category
+   * @param options - Optional conversion stage and original cause
+   */
+  constructor(
+    message: string,
+    code: AcDbOpenDatabaseErrorCode,
+    options?: { stage?: AcDbConversionStage; cause?: unknown }
+  ) {
+    super(message)
+    this.name = 'AcDbOpenDatabaseError'
+    this.code = code
+    this.stage = options?.stage
+  }
+
+  /**
+   * Returns `true` when the message indicates a worker serialization OOM failure.
+   *
+   * @param message - Worker or postMessage error text to inspect
+   * @returns Whether the message matches a known out-of-memory pattern
+   */
+  static isWorkerOutOfMemoryMessage(message: string): boolean {
+    const lower = message.toLowerCase()
+    return AcDbOpenDatabaseError.WORKER_OOM_PATTERNS.some(pattern =>
+      lower.includes(pattern)
+    )
+  }
+
+  /**
+   * Classifies a worker error message into an {@link AcDbOpenDatabaseErrorCode}.
+   *
+   * Checks out-of-memory patterns first, then timeout wording, and falls back to
+   * `worker_error` for all other messages.
+   *
+   * @param message - Worker or postMessage error text to classify
+   * @returns The inferred open-database error code
+   */
+  static classifyWorkerErrorMessage(
+    message: string
+  ): AcDbOpenDatabaseErrorCode {
+    if (AcDbOpenDatabaseError.isWorkerOutOfMemoryMessage(message)) {
+      return 'worker_oom'
+    }
+    if (message.toLowerCase().includes('timed out')) {
+      return 'worker_timeout'
+    }
+    return 'worker_error'
+  }
+
+  /**
+   * Normalizes any thrown value into an {@link AcDbOpenDatabaseError}.
+   *
+   * Returns the input unchanged when it is already an instance of this class.
+   * Otherwise extracts a message, classifies it, and wraps it in a new error.
+   *
+   * @param error - Thrown value from an open or conversion operation
+   * @param stage - Conversion stage active when the failure occurred
+   * @returns A typed open-database error
+   */
+  static from(
+    error: unknown,
+    stage?: AcDbConversionStage
+  ): AcDbOpenDatabaseError {
+    if (error instanceof AcDbOpenDatabaseError) {
+      return error
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+    const code = AcDbOpenDatabaseError.classifyWorkerErrorMessage(message)
+    return new AcDbOpenDatabaseError(message, code, { stage, cause: error })
+  }
+
+  /**
+   * Normalizes a task scheduler failure into an {@link AcDbOpenDatabaseError}.
+   *
+   * Uses the failed task name as the conversion {@link stage}.
+   *
+   * @param taskError - Error emitted by {@link AcCmTaskScheduler} for a failed task
+   * @returns A typed open-database error with stage populated from the task name
+   */
+  static fromTask(taskError: AcCmTaskError): AcDbOpenDatabaseError {
+    const stage = taskError.task.name as AcDbConversionStage
+    return AcDbOpenDatabaseError.from(taskError.error, stage)
+  }
+
+  /**
+   * Throws an {@link AcDbOpenDatabaseError} when a worker parse result failed.
+   *
+   * Acts as a type guard: when this method returns normally, `result.success`
+   * is known to be `true` and {@link AcDbWorkerResult.data} is defined.
+   *
+   * @param result - Worker task result to validate
+   * @param stage - Conversion stage to attach to the thrown error
+   * @throws {@link AcDbOpenDatabaseError} when `result.success` is `false`
+   */
+  static throwOnWorkerParseFailure<T>(
+    result: AcDbWorkerResult<T>,
+    stage: AcDbConversionStage = 'PARSE'
+  ): asserts result is AcDbWorkerResult<T> & { success: true; data: T } {
+    if (result.success) {
+      return
+    }
+
+    const message =
+      result.error != null
+        ? `Failed to parse drawing due to error: '${result.error}'`
+        : 'Failed to parse drawing due to an unknown worker error'
+
+    const code = AcDbOpenDatabaseError.mapWorkerResultCode(
+      result.errorCode,
+      result.error
+    )
+    throw new AcDbOpenDatabaseError(message, code, { stage })
+  }
+
+  /**
+   * Maps a structured worker error code to an {@link AcDbOpenDatabaseErrorCode}.
+   *
+   * When the worker code is missing or unrecognized, falls back to
+   * {@link classifyWorkerErrorMessage} on the optional message text.
+   *
+   * @param errorCode - Structured error category from the worker response
+   * @param message - Worker error text used for heuristic classification
+   * @returns The corresponding open-database error code
+   */
+  private static mapWorkerResultCode(
+    errorCode?: AcDbWorkerErrorCode,
+    message?: string
+  ): AcDbOpenDatabaseErrorCode {
+    switch (errorCode) {
+      case 'worker_oom':
+        return 'worker_oom'
+      case 'worker_timeout':
+        return 'worker_timeout'
+      case 'worker_error':
+        return 'worker_error'
+      default:
+        return AcDbOpenDatabaseError.classifyWorkerErrorMessage(message ?? '')
+    }
+  }
+}

--- a/packages/data-model/src/database/index.ts
+++ b/packages/data-model/src/database/index.ts
@@ -8,10 +8,13 @@ export type {
   AcDbLayerEventArgs,
   AcDbLayerModifiedEventArgs,
   AcDbOpenDatabaseOptions,
+  AcDbOpenFailedEventArgs,
   AcDbOpenFileStage,
   AcDbProgressdEventArgs,
   AcDbTables
 } from './AcDbDatabase'
+export { AcDbOpenDatabaseError } from './AcDbOpenDatabaseError'
+export type { AcDbOpenDatabaseErrorCode } from './AcDbOpenDatabaseError'
 export { AcDbBlockTable } from './AcDbBlockTable'
 export { AcDbBlockScaling, AcDbBlockTableRecord } from './AcDbBlockTableRecord'
 export type { AcDbBlockTableRecordAttrs } from './AcDbBlockTableRecord'

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -34,7 +34,8 @@ export type {
   AcDbWorkerInstance,
   AcDbWorkerMessage,
   AcDbWorkerResponse,
-  AcDbWorkerResult
+  AcDbWorkerResult,
+  AcDbWorkerErrorCode
 } from './converter'
 export {
   AC_DB_SYSTEM_VARIABLE_NAMES,
@@ -72,6 +73,7 @@ export {
   AcDbTransactionManager,
   AcDbUndoStack,
   collectChangeEntities,
+  AcDbOpenDatabaseError,
   AcDbTextStyleTable,
   AcDbTextStyleTableRecord,
   AcDbViewTable,
@@ -102,7 +104,9 @@ export type {
   AcDbLinetypePreviewSvgOptions,
   AcDbLinetypeTableRecordAttrs,
   AcDbOpenDatabaseOptions,
+  AcDbOpenFailedEventArgs,
   AcDbOpenFileStage,
+  AcDbOpenDatabaseErrorCode,
   AcDbParsingTaskResult,
   AcDbParsingTaskStats,
   AcDbProgressdEventArgs,

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -21,6 +21,7 @@ import {
   AcDbLayerTableRecord,
   AcDbLinetypeTableRecord,
   AcDbObjectId,
+  AcDbOpenDatabaseError,
   AcDbSymbolTable,
   AcDbSymbolTableRecord,
   AcDbSystemVariables,
@@ -108,17 +109,12 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       const result = await api.execute<ArrayBuffer, ParsedDxf>(data)
       // Release worker
       api.destroy()
-      if (result.success) {
-        return {
-          model: result.data,
-          data: {
-            unknownEntityCount: 0
-          }
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure(result)
+      return {
+        model: result.data,
+        data: {
+          unknownEntityCount: 0
         }
-      } else {
-        throw new Error(
-          `Failed to parse drawing due to error: '${result.error}'`
-        )
       }
     } else {
       throw new Error('dxf converter can run in web worker only!')

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -21,6 +21,7 @@ import {
   AcDbLinetypeTableRecord,
   AcDbLinetypeTableRecordAttrs,
   AcDbObject,
+  AcDbOpenDatabaseError,
   AcDbParsingTaskResult,
   AcDbRasterImageDef,
   AcDbSymbolTableRecord,
@@ -86,13 +87,8 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       >(data)
       // Release worker
       api.destroy()
-      if (result.success) {
-        return result.data!
-      } else {
-        throw new Error(
-          `Failed to parse drawing due to error: '${result.error}'`
-        )
-      }
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure(result)
+      return result.data!
     } else {
       throw new Error('dwg converter can run in web worker only!')
     }


### PR DESCRIPTION
## Summary

- Introduce `AcDbOpenDatabaseError` with machine-readable codes (`worker_oom`, `worker_timeout`, `worker_error`, etc.) so callers can distinguish worker out-of-memory from other parse failures.
- Propagate structured error codes through the worker layer (`AcDbBaseWorker`, `AcDbWorkerManager`) and converters (DXF/DWG), including a fallback when `postMessage` itself fails due to clone/memory limits.
- Expose `AcDbDatabase.lastOpenError`, `openFailed` event, and enriched `openProgress` ERROR payloads for programmatic handling in viewers and apps.

## Test plan

- [x] `AcDbOpenDatabaseError.spec.ts` — OOM detection, error normalization, worker parse failure throwing
- [x] `AcDbWorkerManager.spec.ts` — `errorCode: worker_oom` propagation
- [x] `AcDbDatabase.spec.ts` — `lastOpenError`, `openFailed`, and `openProgress` on worker OOM
- [ ] Manually open a large DWG/DXF that triggers worker OOM and verify UI can show a memory-specific message via `lastOpenError.code === 'worker_oom'`