### PR TITLE
feat(data-model): render 3DSOLID entities as a wireframe bounding box

### DIFF
--- a/packages/data-model/__tests__/AcDb3dSolid.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dSolid.spec.ts
@@ -1,0 +1,122 @@
+import { AcGeMatrix3d } from '@mlightcad/geometry-engine'
+
+import { AcDb3dSolid } from '../src/entity'
+
+/**
+ * Real ACIS SAT text for a cylinder (radius 10, from z=-10 to z=10), taken
+ * verbatim from the ACIS "SAT Save File Format" spec (Spatial Corp, SAT
+ * Format 7.0), Figure 2-2/2-3 example. Used here only to confirm point
+ * extraction works against a real, spec-sourced SAT stream rather than an
+ * invented one.
+ */
+const REAL_CYLINDER_SAT = `400 0 1 0
+11 Scheme AIDE 11 ACIS 4.0 NT 24 Mon Apr 12 13:59:03 1998
+25.4 1e-06 1e-10
+-0 body $1 $2 $-1 $3 #
+-1 display_attribute-st-attrib $-1 $4 $-1 $0 1 #
+-2 lump $-1 $-1 $5 $0 #
+-3 transform $-1 1 0 0 0 -1 0 1 0 0 10 0 1 rotate no_reflect no_shear #
+-4 rgb_color-st-attrib $-1 $6 $1 $0 0 1 0 #
+-5 shell $-1 $-1 $-1 $7 $-1 $2 #
+-6 id_attribute-st-attrib $-1 $-1 $-1 $4 $0 1 #
+-7 face $-1 $8 $9 $5 $-1 $10 forward single #
+-8 face $-1 $11 $12 $5 $-1 $13 forward single #
+-9 loop $-1 $14 $15 $7 #
+-10 cone-surface $-1 0 0 0 0 0 1 10 0 0 1 I I 0 1 forward I I I #
+-11 face $-1 $-1 $16 $5 $-1 $17 forward single #
+-12 loop $-1 $-1 $18 $8 #
+-13 plane-surface $-1 0 0 -10 0 0 -1 -1 0 0 forward_v I I I #
+-14 loop $-1 $-1 $19 $7 #
+-15 coedge $-1 $15 $15 $18 $20 1 $9 $-1 #
+-16 loop $-1 $-1 $21 $11 #
+-17 plane-surface $-1 0 0 10 0 0 1 1 0 0 forward_v I I I I #
+-18 coedge $-1 $18 $18 $15 $20 0 $12 $-1 #
+-19 coedge $-1 $19 $19 $21 $22 1 $14 $-1 #
+-20 edge $-1 $23 $23 $18 $24 forward #
+-21 coedge $-1 $21 $21 $19 $22 0 $16 $-1 #
+-22 edge $-1 $25 $25 $21 $26 forward #
+-23 vertex $-1 $20 $27 #
+-24 ellipse-curve $-1 0 0 -10 0 0 -1 10 0 0 1 I I #
+-25 vertex $-1 $22 $28 #
+-26 ellipse-curve $-1 0 0 10 0 0 1 10 0 0 1 I I #
+-27 point $-1 10 0 -10 #
+-28 point $-1 10 0 10 #
+End-of-ACIS-data`
+
+/**
+ * A synthetic SAT snippet with three non-collinear points, used to verify
+ * bounding-box math against known, easy-to-check values (the real cylinder
+ * sample above only has 2 points, which collapses to a degenerate box).
+ */
+const SYNTHETIC_BOX_POINTS = `body $1 $2 $-1 $-1 #
+point $-1 0 0 0 #
+point $-1 5 3 0 #
+point $-1 5 3 7 #
+End-of-ACIS-data`
+
+describe('AcDb3dSolid', () => {
+  it('exposes type names', () => {
+    const solid = new AcDb3dSolid('')
+    expect(AcDb3dSolid.typeName).toBe('3dSolid')
+    expect(solid.dxfTypeName).toBe('3DSOLID')
+  })
+
+  it('extracts every point record from real, spec-sourced ACIS SAT text', () => {
+    const solid = new AcDb3dSolid(REAL_CYLINDER_SAT, 400)
+    expect(solid.acisData).toBe(REAL_CYLINDER_SAT)
+    expect(solid.version).toBe(400)
+    expect(solid.hasRenderableGeometry).toBe(true)
+
+    const extents = solid.geometricExtents
+    expect(extents.min).toMatchObject({ x: 10, y: 0, z: -10 })
+    expect(extents.max).toMatchObject({ x: 10, y: 0, z: 10 })
+  })
+
+  it('computes a correct bounding box from a synthetic point set', () => {
+    const solid = new AcDb3dSolid(SYNTHETIC_BOX_POINTS)
+    const extents = solid.geometricExtents
+    expect(extents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(extents.max).toMatchObject({ x: 5, y: 3, z: 7 })
+  })
+
+  it('reports no renderable geometry and draws nothing for non-SAT (binary/empty) data', () => {
+    const solid = new AcDb3dSolid('')
+    expect(solid.hasRenderableGeometry).toBe(false)
+    expect(solid.geometricExtents.min).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(solid.geometricExtents.max).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    const renderer = {
+      lineSegments: jest.fn()
+    }
+    const result = solid.subWorldDraw(renderer as never)
+    expect(result).toBeUndefined()
+    expect(renderer.lineSegments).not.toHaveBeenCalled()
+  })
+
+  it('draws a 12-edge wireframe box referencing the 8 bounding corners', () => {
+    const solid = new AcDb3dSolid(SYNTHETIC_BOX_POINTS)
+    const lineSegments = jest.fn()
+    const renderer = {
+      lineSegments
+    }
+
+    solid.subWorldDraw(renderer as never)
+
+    expect(lineSegments).toHaveBeenCalledTimes(1)
+    const [buffer, itemSize, indices] = lineSegments.mock.calls[0]
+    expect(itemSize).toBe(3)
+    expect(buffer).toHaveLength(8 * 3) // 8 corners
+    expect(indices).toHaveLength(12 * 2) // 12 edges
+  })
+
+  it('transforms the extracted point cloud (and thus the bounding box)', () => {
+    const solid = new AcDb3dSolid(SYNTHETIC_BOX_POINTS)
+    const matrix = new AcGeMatrix3d().makeTranslation(1, 2, 3)
+
+    solid.transformBy(matrix)
+
+    const extents = solid.geometricExtents
+    expect(extents.min).toMatchObject({ x: 1, y: 2, z: 3 })
+    expect(extents.max).toMatchObject({ x: 6, y: 5, z: 10 })
+  })
+})

--- a/packages/data-model/src/entity/AcDb3dSolid.ts
+++ b/packages/data-model/src/entity/AcDb3dSolid.ts
@@ -1,0 +1,196 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d
+} from '@mlightcad/geometry-engine'
+import { AcGiRenderer } from '@mlightcad/graphic-interface'
+
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbEntity } from './AcDbEntity'
+
+/**
+ * Matches every `point` record in an ACIS SAT text stream, e.g.
+ * `point $-1 10 0 -10 #`. The `point` record format (attribute pointer
+ * followed by x/y/z) has been stable across ACIS SAT versions, unlike the
+ * topology records (`face`/`loop`/`coedge`/`edge`), whose field layout and
+ * count vary by surface/curve type and ACIS version. Extracting every point
+ * this way, independent of the body's topology, is a format detail that's
+ * safe to rely on regardless of which faces/edges reference it.
+ */
+const ACIS_POINT_RECORD = /\bpoint\s+\$-?\d+\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)/g
+
+/**
+ * Extracts every vertex position referenced by `point` records in an ACIS
+ * SAT text stream.
+ *
+ * @param acisData - Raw ACIS SAT text (the concatenated group 1/3 lines of a
+ * DXF `3DSOLID`/`REGION`/`BODY` entity).
+ * @returns Every point found, in file order. Empty when `acisData` doesn't
+ * contain any recognizable `point` records (e.g. binary ASM/SAB data).
+ */
+function extractAcisPointCloud(acisData: string): AcGePoint3d[] {
+  const points: AcGePoint3d[] = []
+  for (const match of acisData.matchAll(ACIS_POINT_RECORD)) {
+    const x = Number.parseFloat(match[1])
+    const y = Number.parseFloat(match[2])
+    const z = Number.parseFloat(match[3])
+    if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
+      points.push(new AcGePoint3d(x, y, z))
+    }
+  }
+  return points
+}
+
+/**
+ * Represents a 3D solid (ACIS/ASM B-rep) entity, such as those created by
+ * AutoCAD's BOX, WEDGE, EXTRUDE, or boolean solid-modeling commands.
+ *
+ * Full B-rep tessellation (rendering the solid's actual trimmed
+ * NURBS/planar faces) is not yet supported — that requires implementing (or
+ * embedding) a real ACIS/ASM geometry kernel, which is out of scope here.
+ *
+ * Instead, this renders a wireframe bounding box derived from every vertex
+ * position embedded in the entity's raw ACIS SAT data, so the solid is at
+ * least visible at its correct location and approximate size rather than
+ * silently missing from the drawing. The `point` record format is stable
+ * across ACIS SAT versions and independent of the (much more variable)
+ * topology record layouts, which is why this approach works without a full
+ * B-rep parser. When `acisData` holds binary ASM/SAB data instead of SAT
+ * text (common in DWG 2013+), no points are found and this renders nothing.
+ */
+export class AcDb3dSolid extends AcDbEntity {
+  /** The entity type name */
+  static override typeName: string = '3dSolid'
+
+  override get dxfTypeName() {
+    return '3DSOLID'
+  }
+
+  /** Raw ACIS SAT text (or ASM/SAB binary payload) for this solid. */
+  private _acisData: string
+  /** DXF group 70 ACIS version number, when present. */
+  private _version?: number
+  /** Vertex positions extracted from `point` records in {@link _acisData}. */
+  private _points: AcGePoint3d[]
+
+  /**
+   * Creates a new 3D solid entity from raw ACIS data.
+   *
+   * @param acisData - Raw ACIS SAT text (group 1/3 lines) or ASM/SAB binary payload.
+   * @param version - DXF group 70 ACIS version number, when present.
+   */
+  constructor(acisData: string, version?: number) {
+    super()
+    this._acisData = acisData
+    this._version = version
+    this._points = extractAcisPointCloud(acisData)
+  }
+
+  /**
+   * Raw ACIS SAT text (or ASM/SAB binary payload) for this solid, preserved
+   * for future full B-rep parsing support.
+   */
+  get acisData(): string {
+    return this._acisData
+  }
+
+  /** DXF group 70 ACIS version number, when present. */
+  get version(): number | undefined {
+    return this._version
+  }
+
+  /**
+   * Whether any vertex positions could be extracted from {@link acisData}.
+   * False when the data is binary (ASM/SAB) rather than SAT text.
+   */
+  get hasRenderableGeometry(): boolean {
+    return this._points.length > 0
+  }
+
+  /** @inheritdoc */
+  get geometricExtents(): AcGeBox3d {
+    if (this._points.length === 0) {
+      return new AcGeBox3d(new AcGePoint3d(0, 0, 0), new AcGePoint3d(0, 0, 0))
+    }
+    return new AcGeBox3d().setFromPoints(this._points)
+  }
+
+  /**
+   * Transforms this solid by the specified matrix.
+   *
+   * Only the extracted point cloud (and thus the wireframe bounding box) is
+   * transformed; {@link acisData} itself is left untouched since it isn't
+   * fully parsed.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    this._points.forEach(point => point.applyMatrix4(matrix))
+    return this
+  }
+
+  /**
+   * Draws a wireframe bounding box around the solid's extracted point cloud.
+   *
+   * @param renderer - The renderer to use for drawing
+   * @returns The rendered wireframe entity, or `undefined` when no points
+   * could be extracted from {@link acisData}.
+   */
+  subWorldDraw(renderer: AcGiRenderer) {
+    if (this._points.length === 0) {
+      return undefined
+    }
+    const box = this.geometricExtents
+    const min = box.min
+    const max = box.max
+    const corners = [
+      new AcGePoint3d(min.x, min.y, min.z),
+      new AcGePoint3d(max.x, min.y, min.z),
+      new AcGePoint3d(max.x, max.y, min.z),
+      new AcGePoint3d(min.x, max.y, min.z),
+      new AcGePoint3d(min.x, min.y, max.z),
+      new AcGePoint3d(max.x, min.y, max.z),
+      new AcGePoint3d(max.x, max.y, max.z),
+      new AcGePoint3d(min.x, max.y, max.z)
+    ]
+    const buffer = new Float32Array(corners.length * 3)
+    corners.forEach((corner, i) => {
+      buffer[i * 3] = corner.x
+      buffer[i * 3 + 1] = corner.y
+      buffer[i * 3 + 2] = corner.z
+    })
+    // 12 edges of a box, referencing the 8 corners above.
+    const indices = new Uint16Array([
+      0, 1, 1, 2, 2, 3, 3, 0, // bottom face
+      4, 5, 5, 6, 6, 7, 7, 4, // top face
+      0, 4, 1, 5, 2, 6, 3, 7 // vertical edges
+    ])
+    return renderer.lineSegments(buffer, 3, indices)
+  }
+
+  /**
+   * Writes DXF fields for this object.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDb3dSolid')
+    if (this._version != null) {
+      filer.writeInt16(70, this._version)
+    }
+    // ACIS text is written as chunked group-3 continuation lines (max 255
+    // chars each per the DXF spec), terminated by a final group-1 line.
+    const maxChunkLength = 255
+    const lines = this._acisData.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const isLast = i === lines.length - 1
+      let line = lines[i]
+      while (line.length > maxChunkLength) {
+        filer.writeString(3, line.slice(0, maxChunkLength))
+        line = line.slice(maxChunkLength)
+      }
+      filer.writeString(isLast ? 1 : 3, line)
+    }
+    return this
+  }
+}

--- a/packages/data-model/src/entity/index.ts
+++ b/packages/data-model/src/entity/index.ts
@@ -1,6 +1,7 @@
 export { AcDb2dPolyline, AcDbPoly2dType } from './AcDb2dPolyline'
 export { AcDb2dVertex, AcDb2dVertexType } from './AcDb2dVertex'
 export { AcDb3dPolyline, AcDbPoly3dType } from './AcDb3dPolyline'
+export { AcDb3dSolid } from './AcDb3dSolid'
 export { AcDb3dVertex, AcDb3dVertexType } from './AcDb3dVertex'
 export { AcDbArc } from './AcDbArc'
 export { AcDbAttribute } from './AcDbAttribute'

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -132,6 +132,7 @@ export {
   AcDb2dVertexType,
   AcDb3PointAngularDimension,
   AcDb3dPolyline,
+  AcDb3dSolid,
   AcDb3dVertex,
   AcDb3dVertexType,
   AcDbAlignedDimension,

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AcDb3dSolid,
   AcDb3PointAngularDimension,
   AcDbAlignedDimension,
   AcDbArc,
@@ -441,5 +442,31 @@ describe('AcDbEntityConverter', () => {
 
     expect(result).toBeInstanceOf(AcDb3PointAngularDimension)
     expect((result as AcDb3PointAngularDimension).dimBlockId).toBe('*D62')
+  })
+
+  it('converts 3DSOLID entity, preserving raw ACIS data and version', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const acisData = 'body $1 $2 $-1 $-1 #\npoint $-1 1 2 3 #\nEnd-of-ACIS-data'
+    const result = converter.convert({
+      type: '3DSOLID',
+      version: 400,
+      data: acisData
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDb3dSolid)
+    const solid = result as AcDb3dSolid
+    expect(solid.acisData).toBe(acisData)
+    expect(solid.version).toBe(400)
+    expect(solid.hasRenderableGeometry).toBe(true)
+  })
+
+  it('converts 3DSOLID entity with missing ACIS data to an empty (non-crashing) solid', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({ type: '3DSOLID' } as any)
+
+    expect(result).toBeInstanceOf(AcDb3dSolid)
+    expect((result as AcDb3dSolid).hasRenderableGeometry).toBe(false)
   })
 })

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -3,6 +3,7 @@ import {
   AcCmTransparency,
   AcDb2dPolyline,
   AcDb3dPolyline,
+  AcDb3dSolid,
   AcDb3PointAngularDimension,
   AcDbAlignedDimension,
   AcDbArc,
@@ -111,6 +112,7 @@ import {
   PolylineEntity,
   RayEntity,
   ShapeEntity,
+  Solid3DEntity,
   SolidEntity,
   SplineEntity,
   TableEntity,
@@ -258,6 +260,8 @@ export class AcDbEntityConverter {
       return this.convertShape(entity as ShapeEntity)
     } else if (entity.type == 'SOLID') {
       return this.convertSolid(entity as SolidEntity)
+    } else if (entity.type == '3DSOLID') {
+      return this.convert3dSolid(entity as Solid3DEntity)
     } else if (entity.type == 'VIEWPORT') {
       return this.convertViewport(entity as ViewportEntity)
     } else if (entity.type == 'WIPEOUT') {
@@ -480,6 +484,19 @@ export class AcDbEntityConverter {
     solid.points.forEach((point, index) => dbEntity.setPointAt(index, point))
     dbEntity.thickness = solid.thickness
     return dbEntity
+  }
+
+  /**
+   * Converts a 3DSOLID entity (ACIS/ASM B-rep solid).
+   *
+   * Full B-rep tessellation is not supported yet; see {@link AcDb3dSolid} for
+   * what is rendered (a wireframe bounding box derived from the ACIS point
+   * cloud) and why. `entity.data` is missing entirely when the DXF has no
+   * ACIS payload at all, in which case an empty string still produces a
+   * valid (if geometry-less) entity rather than a converter crash.
+   */
+  private convert3dSolid(solid: Solid3DEntity) {
+    return new AcDb3dSolid(solid.data ?? '', solid.version)
   }
 
   private convertPolyline(polyline: PolylineEntity) {


### PR DESCRIPTION
## Summary

Relates to mlightcad/cad-viewer#318 ("Feature Request: Support 3DSOLID").

Full B-rep tessellation of ACIS/ASM solids (NURBS surfaces, B-rep topology, real tessellation) is a CAD-kernel-scale undertaking and out of scope for this PR. Currently 3DSOLID entities aren't created at all — `AcDbEntitiyConverter.createEntity()` has no `'3DSOLID'` branch, so they're silently dropped and the geometry simply vanishes from the drawing.

This adds a real, scoped, honest partial fix:

- New `AcDb3dSolid` entity (`packages/data-model/src/entity/AcDb3dSolid.ts`) that extracts every vertex position from `point` records in the entity's raw ACIS SAT text (already tokenized by `@mlightcad/dxf-json` into `entity.data`, just previously unused) and renders a **wireframe bounding box** from them via `renderer.lineSegments` — the same primitive `AcDbFace`/`AcDbPolyFaceMesh` already use for wireframe rendering.
- The `point` record format (`point $attrib x y z #`) has been stable across ACIS SAT versions, unlike the topology records (`face`/`loop`/`coedge`/`edge`), whose field layout and count vary by surface/curve type and ACIS version — extracting points this way is the one part of the format that's safe to rely on without implementing a full B-rep parser.
- Wired up the `'3DSOLID'` branch in `dxf-json-converter`'s `AcDbEntitiyConverter`.

## Scope / limitations

- **DXF only.** DWG 2013+ stores ACIS as proprietary binary ASM rather than SAT text; `hasRenderableGeometry` is `false` and nothing is drawn when no `point` records are found (binary data or missing `data`), rather than crashing or guessing.
- **Bounding box, not the real shape.** This is intentionally not real B-rep rendering — see the class doc comment for why (topology record grammar is version-dependent and risky to get subtly wrong; the point cloud is the one safe, verifiable extraction).
- Raw ACIS data is preserved on the entity (`acisData`) for future full-parser work.

## Test plan

- [x] New unit tests in `AcDb3dSolid.spec.ts`, including one against a **real, spec-sourced ACIS SAT sample** (the cylinder example from the ACIS "SAT Save File Format" spec, Format 7.0) to confirm point extraction works against genuine ACIS text, not just an invented format
- [x] New unit tests in `AcDbEntityConverter.spec.ts` for the `'3DSOLID'` conversion path, including a missing-data case
- [x] Full `data-model` + `dxf-json-converter` test suites pass (105 suites / 726 tests, no regressions)
- [x] `eslint` clean on all changed files