### PR TITLE
feat(data-model): add AcDbFcf entity and TOLERANCE converter support

### DIFF
--- a/packages/data-model/__tests__/AcDbFcf.spec.ts
+++ b/packages/data-model/__tests__/AcDbFcf.spec.ts
@@ -1,0 +1,204 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbFcf } from '../src/entity'
+import { AcDbOsnapMode } from '../src/misc'
+import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+const createWorkingDb = () => {
+  const db = new AcDbDatabase()
+  db.createDefaultData()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('AcDbFcf', () => {
+  it('exposes static and DXF type names', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+
+    expect(AcDbFcf.typeName).toBe('Fcf')
+    expect(fcf.dxfTypeName).toBe('TOLERANCE')
+  })
+
+  it('initializes defaults and supports property accessors', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+
+    expect(fcf.location).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(fcf.text).toBe('')
+    expect(fcf.dimensionStyle).toBe('')
+    expect(fcf.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(fcf.direction).toMatchObject({ x: 1, y: 0, z: 0 })
+
+    fcf.location = new AcGePoint3d(10, 20, 0)
+    fcf.text = '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|'
+    fcf.dimensionStyle = 'Standard'
+    fcf.normal = { x: 0, y: 0, z: 1 }
+    fcf.direction = { x: 0, y: 1, z: 0 }
+
+    expect(fcf.location).toMatchObject({ x: 10, y: 20, z: 0 })
+    expect(fcf.text).toContain('gdt')
+    expect(fcf.dimensionStyle).toBe('Standard')
+    expect(fcf.direction).toMatchObject({ x: 0, y: 1, z: 0 })
+  })
+
+  it('computes bounding points from tolerance cells', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(0, 0, 0)
+    fcf.text = 'A|B|C'
+    fcf.dimensionStyle = 'Standard'
+
+    const points = fcf.getBoundingPoints()
+    const textHeight = fcf.textHeight
+    expect(points).toHaveLength(4)
+    expect(points[0]).toMatchObject({ x: 0, y: textHeight, z: 0 })
+    expect(points[1].x).toBeGreaterThan(points[0].x)
+    expect(points[2].y).toBeLessThan(points[0].y)
+  })
+
+  it('parses DXF %%v tolerance text into three compartments', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.dimensionStyle = 'Standard'
+
+    fcf.text = '{\\Fgdt;b}%%v0.1%%v%%vA%%v%%v%%v^J'
+    const perpendicularity = fcf.getBoundingPoints()
+    expect(perpendicularity[1].x - perpendicularity[0].x).toBeGreaterThan(
+      perpendicularity[1].y - perpendicularity[3].y
+    )
+
+    fcf.text = '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+    const runout = fcf.getBoundingPoints()
+    expect(runout[1].x - runout[0].x).toBeGreaterThan(
+      runout[1].y - runout[3].y
+    )
+  })
+
+  it('keeps pipe-delimited tolerance text compatible', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(0, 0, 0)
+    fcf.text = '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|'
+    fcf.dimensionStyle = 'Standard'
+
+    const points = fcf.getBoundingPoints()
+    expect(points[2].x).toBeGreaterThan(points[0].x * 2)
+  })
+
+  it('returns geometricExtents and grip/osnap points', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(5, 5, 0)
+    fcf.text = 'Position|0.1'
+    fcf.dimensionStyle = 'Standard'
+
+    expect(fcf.geometricExtents.isEmpty()).toBe(false)
+    expect(fcf.subGetGripPoints()).toEqual([fcf.location])
+
+    const snapPoints: AcGePoint3d[] = []
+    fcf.subGetOsnapPoints(
+      AcDbOsnapMode.Insertion,
+      new AcGePoint3d(),
+      new AcGePoint3d(),
+      snapPoints
+    )
+    expect(snapPoints[0]).toMatchObject({ x: 5, y: 5, z: 0 })
+  })
+
+  it('supports setOrientation and transformBy', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(1, 2, 0)
+    fcf.setOrientation({ x: 0, y: 0, z: 1 }, { x: 0, y: 1, z: 0 })
+
+    expect(fcf.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(fcf.direction).toMatchObject({ x: 0, y: 1, z: 0 })
+
+    fcf.transformBy(new AcGeMatrix3d().makeTranslation(3, 4, 0))
+    expect(fcf.location).toMatchObject({ x: 4, y: 6, z: 0 })
+  })
+
+  it('writes DXF fields for TOLERANCE entity', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(10, 20, 0)
+    fcf.text = '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|'
+    fcf.dimensionStyle = 'Standard'
+    fcf.direction = { x: 0, y: 1, z: 0 }
+    fcf.ownerId = '0'
+
+    const filer = new AcDbDxfFiler()
+    fcf.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('100\nAcDbFcf\n')
+    expect(dxf).toContain('3\nStandard\n')
+    expect(dxf).toContain('1\n')
+    expect(dxf).toContain('11\n0\n21\n1\n31\n0\n')
+  })
+
+  it('deep-clones as a detached object', () => {
+    expectDetachedClone(() => new AcDbFcf())
+  })
+
+  it('anchors the frame at the left-edge center insertion point', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(100, 200, 0)
+    fcf.text = '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+    fcf.dimensionStyle = 'Standard'
+
+    const points = fcf.getBoundingPoints()
+    const leftCenterY = (points[0].y + points[3].y) / 2
+    const rightCenterY = (points[1].y + points[2].y) / 2
+
+    expect(points[0]).toMatchObject({ x: 100, z: 0 })
+    expect(points[1].x).toBeGreaterThan(100)
+    expect(leftCenterY).toBeCloseTo(200, 6)
+    expect(rightCenterY).toBeCloseTo(200, 6)
+  })
+
+  it('places the insertion point on the right edge when direction points left', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(344, 270, 0)
+    fcf.direction = { x: -1, y: 0, z: 0 }
+    fcf.text = '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+    fcf.dimensionStyle = 'Standard'
+
+    const points = fcf.getBoundingPoints()
+    const rightCenterY = (points[0].y + points[3].y) / 2
+
+    expect(points[0]).toMatchObject({ x: 344, z: 0 })
+    expect(points[3]).toMatchObject({ x: 344, z: 0 })
+    expect(points[1].x).toBeLessThan(344)
+    expect(rightCenterY).toBeCloseTo(270, 6)
+  })
+
+  it('draws frame borders and dividers as separate axis-aligned segments', () => {
+    createWorkingDb()
+    const fcf = new AcDbFcf()
+    fcf.text = '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+    fcf.dimensionStyle = 'Standard'
+
+    const renderer = {
+      lines: jest.fn((points: unknown[]) => ({ kind: 'lines', points })),
+      mtext: jest.fn(() => ({ kind: 'mtext' })),
+      group: jest.fn((entities: unknown[]) => ({ kind: 'group', entities }))
+    }
+
+    fcf.subWorldDraw(renderer as never)
+
+    expect(renderer.lines).toHaveBeenCalled()
+    for (const [points] of renderer.lines.mock.calls as [AcGePoint3d[]][]) {
+      expect(points).toHaveLength(2)
+      const [start, end] = points
+      const dx = Math.abs(end.x - start.x)
+      const dy = Math.abs(end.y - start.y)
+      expect(dx === 0 || dy === 0).toBe(true)
+    }
+  })
+})

--- a/packages/data-model/__tests__/AcDbFontNameCollector.spec.ts
+++ b/packages/data-model/__tests__/AcDbFontNameCollector.spec.ts
@@ -84,6 +84,44 @@ describe('AcDbFontNameCollector', () => {
     expect(fonts).toEqual(expect.arrayContaining(['txt', 'simplex']))
   })
 
+  it('collects inline mtext fonts from both pipe and semicolon overrides', () => {
+    const fonts = new AcDbFontNameCollector({ styles: [] }).collect(
+      [
+        {
+          type: 'TOLERANCE',
+          text: '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|'
+        },
+        {
+          type: 'TOLERANCE',
+          text: '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+        }
+      ],
+      {
+        getEntityFontInfo: entity => ({
+          formattedText: entity.text
+        })
+      }
+    )
+
+    expect(fonts).toEqual(expect.arrayContaining(['gdt.shx', 'gdt']))
+  })
+
+  it('collects fonts from every named style table entry', () => {
+    const fonts = new AcDbFontNameCollector({
+      styles: [
+        { name: 'Standard', font: 'txt.shx', bigFont: 'gbcbig.shx' },
+        { name: 'Romans', font: 'romans.shx', standardFlag: 0 },
+        { name: '', font: 'tecosymbol.shx', standardFlag: 1 }
+      ]
+    }).collect([], {
+      getEntityFontInfo: () => null
+    })
+
+    expect(fonts).toEqual(
+      expect.arrayContaining(['txt', 'gbcbig', 'romans', 'tecosymbol'])
+    )
+  })
+
   it('collects shape-definition fonts from the style table', () => {
     const fonts = new AcDbFontNameCollector({
       styles: [
@@ -94,6 +132,6 @@ describe('AcDbFontNameCollector', () => {
       getEntityFontInfo: () => null
     })
 
-    expect(fonts).toEqual(['tecosymbol'])
+    expect(fonts).toEqual(['tecosymbol', 'romans'])
   })
 })

--- a/packages/data-model/src/converter/AcDbFontNameCollector.ts
+++ b/packages/data-model/src/converter/AcDbFontNameCollector.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_TEXT_STYLE } from '../misc/AcDbConstants'
 
-const MTEXT_INLINE_FONT_PATTERN = /\\f(.*?)\|/g
+/** `\Ffont|b0|i0;...` extended inline font override. */
+const MTEXT_INLINE_FONT_PIPE_PATTERN = /\\[fF](.*?)\|/g
+/** `\Ffont;...` short inline font override (e.g. tolerance `{\Fgdt;r}`). */
+const MTEXT_INLINE_FONT_SEMICOLON_PATTERN = /\\[fF]([^|;]+);/g
 
 /** STYLE table entry protocol used when collecting fonts before conversion. */
 export type AcDbFontNameCollectorStyleEntry = {
@@ -62,6 +65,11 @@ export class AcDbFontNameCollector {
   ): string[] {
     const fonts = new Set<string>()
     for (const fontName of AcDbFontNameCollector.collectShapeDefinitionFonts(
+      this.styles
+    )) {
+      fonts.add(fontName)
+    }
+    for (const fontName of AcDbFontNameCollector.collectNamedStyleTableFonts(
       this.styles
     )) {
       fonts.add(fontName)
@@ -188,6 +196,24 @@ export class AcDbFontNameCollector {
     return fontNames
   }
 
+  /**
+   * Collects primary, big, and extended fonts from every named STYLE entry.
+   * Ensures fonts referenced only in the style table (or in blocks not reached
+   * from model space) are still preloaded when opening a drawing.
+   */
+  private static collectNamedStyleTableFonts(
+    styles: AcDbFontNameCollectorStyleEntry[]
+  ): string[] {
+    const fonts: string[] = []
+    for (const style of styles) {
+      if (style.standardFlag && style.standardFlag & 1) {
+        continue
+      }
+      fonts.push(...AcDbFontNameCollector.collectStyleEntryFontNames(style))
+    }
+    return fonts
+  }
+
   private static collectShapeDefinitionFonts(
     styles: Array<
       Pick<AcDbFontNameCollectorStyleEntry, 'font' | 'standardFlag'>
@@ -208,10 +234,13 @@ export class AcDbFontNameCollector {
   }
 
   private static extractInlineMTextFonts(text: string): string[] {
-    const fonts: string[] = []
-    for (const match of text.matchAll(MTEXT_INLINE_FONT_PATTERN)) {
-      fonts.push(match[1].toLowerCase())
+    const fonts = new Set<string>()
+    for (const match of text.matchAll(MTEXT_INLINE_FONT_PIPE_PATTERN)) {
+      fonts.add(match[1].toLowerCase())
     }
-    return fonts
+    for (const match of text.matchAll(MTEXT_INLINE_FONT_SEMICOLON_PATTERN)) {
+      fonts.add(match[1].toLowerCase())
+    }
+    return Array.from(fonts)
   }
 }

--- a/packages/data-model/src/entity/AcDbFcf.ts
+++ b/packages/data-model/src/entity/AcDbFcf.ts
@@ -1,0 +1,737 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGePoint3dLike,
+  AcGeVector3d,
+  AcGeVector3dLike
+} from '@mlightcad/geometry-engine'
+import {
+  AcGiEntity,
+  AcGiMTextAttachmentPoint,
+  AcGiMTextData,
+  AcGiMTextFlowDirection,
+  AcGiRenderer,
+  AcGiTextStyle
+} from '@mlightcad/graphic-interface'
+
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbDimStyleTableRecord } from '../database'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
+import { AcDbEntity } from './AcDbEntity'
+import { AcDbEntityProperties } from './AcDbEntityProperties'
+import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
+import {
+  acdbEstimatePlainTextWidth,
+  acdbStripMTextControlCodes
+} from './AcDbTextExtentsHelpers'
+
+interface ToleranceFrameRow {
+  cells: string[]
+}
+
+interface ToleranceFrameLayout {
+  width: number
+  totalHeight: number
+  rowHeight: number
+  columnWidths: number[]
+  columnDivisions: number[]
+  rowCount: number
+  cellPadding: number
+  columnGap: number
+}
+
+const TOLERANCE_SLOT_COUNT = 6
+
+/**
+ * Represents a feature control frame (FCF) entity in AutoCAD.
+ *
+ * Feature control frames are used for geometric dimensioning and tolerancing
+ * (GD&T). They are created by the TOLERANCE command and controlled by dimension
+ * styles, mirroring {@link https://help.autodesk.com/view/OARX/2023/ENU/?guid=OARX-RefGuide-AcDbFcf AcDbFcf}
+ * in ObjectARX.
+ *
+ * @example
+ * ```typescript
+ * const fcf = new AcDbFcf();
+ * fcf.location = new AcGePoint3d(10, 20, 0);
+ * fcf.text = '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|';
+ * fcf.dimensionStyle = 'Standard';
+ * ```
+ */
+export class AcDbFcf extends AcDbEntity {
+  /** The entity type name */
+  static override typeName: string = 'Fcf'
+
+  override get dxfTypeName() {
+    return 'TOLERANCE'
+  }
+
+  /**
+   * The insertion point of the feature control frame in WCS coordinates.
+   *
+   * This is the center of the left edge for the first row in the entity-local
+   * frame. Geometry uses +localX along {@link direction}; when direction points
+   * left (e.g. leader on the right), this insertion point coincides with the
+   * right-edge center in WCS.
+   */
+  private _location: AcGePoint3d
+  /** The encoded tolerance text string (symbol and format codes). */
+  private _text: string
+  /** The dimension style name applied to this feature control frame. */
+  private _dimensionStyle: string
+  /** The plane normal vector in WCS coordinates. */
+  private _normal: AcGeVector3d
+  /** The X-axis direction vector for the feature control frame in WCS coordinates. */
+  private _direction: AcGeVector3d
+
+  /**
+   * Creates a new feature control frame entity at the origin with default orientation.
+   */
+  constructor() {
+    super()
+    this._location = new AcGePoint3d()
+    this._text = ''
+    this._dimensionStyle = ''
+    this._normal = new AcGeVector3d(0, 0, 1)
+    this._direction = new AcGeVector3d(1, 0, 0)
+  }
+
+  /**
+   * Gets the insertion point of this feature control frame.
+   *
+   * Mirrors `AcDbFcf::location()` in ObjectARX.
+   */
+  get location(): AcGePoint3d {
+    return this._location
+  }
+
+  /**
+   * Sets the insertion point of this feature control frame.
+   *
+   * Mirrors `AcDbFcf::setLocation()` in ObjectARX.
+   */
+  set location(value: AcGePoint3dLike) {
+    this._location.set(value.x, value.y, value.z ?? 0)
+  }
+
+  /**
+   * Gets the encoded tolerance text string.
+   *
+   * Mirrors `AcDbFcf::text()` in ObjectARX.
+   */
+  get text(): string {
+    return this._text
+  }
+
+  /**
+   * Sets the encoded tolerance text string.
+   *
+   * Mirrors `AcDbFcf::setText()` in ObjectARX.
+   */
+  set text(value: string) {
+    this._text = value
+  }
+
+  /**
+   * Gets the dimension style name applied to this feature control frame.
+   */
+  get dimensionStyle(): string {
+    return this._dimensionStyle
+  }
+
+  /**
+   * Sets the dimension style name applied to this feature control frame.
+   */
+  set dimensionStyle(value: string) {
+    this._dimensionStyle = value
+  }
+
+  /**
+   * Gets the plane normal vector in WCS coordinates.
+   *
+   * Mirrors `AcDbFcf::normal()` in ObjectARX.
+   */
+  get normal(): AcGeVector3d {
+    return this._normal
+  }
+
+  /**
+   * Sets the plane normal vector in WCS coordinates.
+   */
+  set normal(value: AcGeVector3dLike) {
+    this._normal.set(value.x, value.y, value.z ?? 0)
+    if (this._normal.lengthSq() > 0) {
+      this._normal.normalize()
+    }
+  }
+
+  /**
+   * Gets the X-axis direction vector in WCS coordinates.
+   *
+   * Mirrors `AcDbFcf::direction()` in ObjectARX.
+   */
+  get direction(): AcGeVector3d {
+    return this._direction
+  }
+
+  /**
+   * Sets the X-axis direction vector in WCS coordinates.
+   */
+  set direction(value: AcGeVector3dLike) {
+    this._direction.set(value.x, value.y, value.z ?? 0)
+    if (this._direction.lengthSq() > 0) {
+      this._direction.normalize()
+    }
+  }
+
+  /**
+   * Sets the plane normal and X-axis direction for this feature control frame.
+   *
+   * Mirrors `AcDbFcf::setOrientation()` in ObjectARX.
+   */
+  setOrientation(normal: AcGeVector3dLike, direction: AcGeVector3dLike) {
+    this.normal = normal
+    this.direction = direction
+    return this
+  }
+
+  /**
+   * Returns the consecutive distinct corner points of the feature control frame.
+   *
+   * Mirrors `AcDbFcf::getBoundingPoints()` in ObjectARX.
+   */
+  getBoundingPoints(): AcGePoint3d[] {
+    return this.getBoundingPolyline().slice(0, 4)
+  }
+
+  /**
+   * Returns the closed bounding polyline of the feature control frame.
+   *
+   * Mirrors `AcDbFcf::getBoundingPolyline()` in ObjectARX.
+   */
+  getBoundingPolyline(): AcGePoint3d[] {
+    const { width, rowHeight, rowCount } = this.resolveFrameLayout()
+    const frameTop = rowHeight / 2
+    const frameBottom = frameTop - rowHeight * rowCount
+    const corners = [
+      new AcGePoint3d(0, frameTop, 0),
+      new AcGePoint3d(width, frameTop, 0),
+      new AcGePoint3d(width, frameBottom, 0),
+      new AcGePoint3d(0, frameBottom, 0),
+      new AcGePoint3d(0, frameTop, 0)
+    ]
+
+    return corners.map(corner => this.toFrameWcs(corner.x, corner.y))
+  }
+
+  get geometricExtents(): AcGeBox3d {
+    const box = new AcGeBox3d()
+    for (const point of this.getBoundingPoints()) {
+      box.expandByPoint(point)
+    }
+    if (box.isEmpty()) {
+      box.expandByPoint(this._location)
+    }
+    return box
+  }
+
+  subGetGripPoints() {
+    return [this._location]
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    acdbMovePrimaryGripPointAt(indices, offset, this._location)
+    return this
+  }
+
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    _pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    if (osnapMode === AcDbOsnapMode.Insertion) {
+      snapPoints.push(this._location)
+    }
+  }
+
+  transformBy(matrix: AcGeMatrix3d) {
+    const basis = this.resolveLocalBasis()
+    const origin = this._location.clone()
+    const xAxisPoint = origin.clone().add(basis.xAxis)
+    const yAxisPoint = origin.clone().add(basis.yAxis)
+
+    origin.applyMatrix4(matrix)
+    xAxisPoint.applyMatrix4(matrix)
+    yAxisPoint.applyMatrix4(matrix)
+
+    const xAxis = new AcGeVector3d(xAxisPoint).sub(origin)
+    const yAxis = new AcGeVector3d(yAxisPoint).sub(origin)
+
+    let normal = new AcGeVector3d().crossVectors(xAxis, yAxis)
+    if (normal.lengthSq() === 0) {
+      normal = this._normal.clone().transformDirection(matrix)
+    } else {
+      normal.normalize()
+    }
+
+    let direction = xAxis.clone()
+    if (direction.lengthSq() === 0) {
+      direction = this._direction.clone().transformDirection(matrix)
+    } else {
+      direction.normalize()
+    }
+
+    this._location.copy(origin)
+    this._normal.copy(normal)
+    this._direction.copy(direction)
+    return this
+  }
+
+  get properties(): AcDbEntityProperties {
+    return {
+      type: this.type,
+      groups: [
+        this.getGeneralProperties(),
+        {
+          groupName: 'tolerance',
+          properties: [
+            {
+              name: 'text',
+              type: 'string',
+              editable: true,
+              accessor: {
+                get: () => this.text,
+                set: (v: string) => {
+                  this.text = v
+                }
+              }
+            },
+            {
+              name: 'dimensionStyle',
+              type: 'string',
+              editable: true,
+              accessor: {
+                get: () => this.dimensionStyle,
+                set: (v: string) => {
+                  this.dimensionStyle = v
+                }
+              }
+            },
+            {
+              name: 'textHeight',
+              type: 'float',
+              editable: false,
+              accessor: {
+                get: () => this.textHeight
+              }
+            }
+          ]
+        },
+        {
+          groupName: 'geometry',
+          properties: [
+            {
+              name: 'locationX',
+              type: 'float',
+              editable: true,
+              accessor: {
+                get: () => this.location.x,
+                set: (v: number) => {
+                  this.location.x = v
+                }
+              }
+            },
+            {
+              name: 'locationY',
+              type: 'float',
+              editable: true,
+              accessor: {
+                get: () => this.location.y,
+                set: (v: number) => {
+                  this.location.y = v
+                }
+              }
+            },
+            {
+              name: 'locationZ',
+              type: 'float',
+              editable: true,
+              accessor: {
+                get: () => this.location.z,
+                set: (v: number) => {
+                  this.location.z = v
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  subWorldDraw(
+    renderer: AcGiRenderer,
+    delay?: boolean
+  ): AcGiEntity | undefined {
+    const frameSegments = this.collectFrameLineSegments()
+    const frameEntities = frameSegments.map(([start, end]) =>
+      renderer.lines([start, end])
+    )
+    const textEntity = this.drawToleranceText(renderer, delay)
+    if (frameEntities.length > 0 && textEntity) {
+      return renderer.group([...frameEntities, textEntity])
+    }
+    if (frameEntities.length === 1) {
+      return frameEntities[0]
+    }
+    if (frameEntities.length > 1) {
+      return renderer.group(frameEntities)
+    }
+    return textEntity
+  }
+
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbFcf')
+    if (this._dimensionStyle) {
+      filer.writeString(3, this._dimensionStyle)
+    }
+    filer.writePoint3d(10, this._location)
+    filer.writeString(1, this._text)
+    if (!this._normal.equals(AcGeVector3d.Z_AXIS)) {
+      filer.writeVector3d(210, this._normal)
+    }
+    if (!this._direction.equals(AcGeVector3d.X_AXIS)) {
+      filer.writeVector3d(11, this._direction)
+    }
+    return this
+  }
+
+  /**
+   * Gets the rendered text height derived from the associated dimension style.
+   */
+  get textHeight(): number {
+    const dimStyle = this.resolveDimensionStyle()
+    const dimtxt =
+      dimStyle?.dimtxt ?? AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimtxt
+    const dimscale =
+      dimStyle?.dimscale ??
+      AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimscale
+    return dimtxt * dimscale
+  }
+
+  private drawToleranceText(
+    renderer: AcGiRenderer,
+    delay?: boolean
+  ): AcGiEntity | undefined {
+    const rows = this.parseToleranceFrame(this._text)
+    if (rows.length === 0) {
+      return undefined
+    }
+
+    const layout = this.resolveFrameLayout(rows)
+    const textStyle = this.getTextStyle()
+    const entities: AcGiEntity[] = []
+
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+      const row = rows[rowIndex]
+      let cellOffset = layout.cellPadding
+      const rowCenterY = -layout.rowHeight * rowIndex
+
+      for (let columnIndex = 0; columnIndex < row.cells.length; columnIndex++) {
+        const cellText = row.cells[columnIndex]
+        const cellWidth = layout.columnWidths[columnIndex] ?? this.textHeight
+        if (cellText.trim()) {
+          const position = this.toFrameWcs(
+            cellOffset + cellWidth / 2,
+            rowCenterY
+          )
+
+          const mtextData: AcGiMTextData = {
+            text: cellText,
+            height: this.textHeight,
+            width: Infinity,
+            position,
+            directionVector: this._direction,
+            attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+            drawingDirection: AcGiMTextFlowDirection.LEFT_TO_RIGHT
+          }
+          entities.push(renderer.mtext(mtextData, textStyle, delay))
+        }
+        cellOffset += cellWidth + layout.columnGap
+      }
+    }
+
+    if (entities.length === 0) {
+      return undefined
+    }
+    if (entities.length === 1) {
+      return entities[0]
+    }
+    return renderer.group(entities)
+  }
+
+  private collectFrameLineSegments(): [AcGePoint3d, AcGePoint3d][] {
+    const rows = this.parseToleranceFrame(this._text)
+    const layout = this.resolveFrameLayout(rows)
+    const { width, rowHeight, rowCount, columnDivisions } = layout
+    if (width <= 0 || rowHeight <= 0 || rowCount <= 0) {
+      return []
+    }
+
+    const frameTop = rowHeight / 2
+    const frameBottom = frameTop - rowHeight * rowCount
+    const segments: [AcGePoint3d, AcGePoint3d][] = []
+    const pushSegment = (start: AcGePoint3d, end: AcGePoint3d) => {
+      segments.push([start, end])
+    }
+
+    pushSegment(
+      this.toFrameWcs(0, frameTop),
+      this.toFrameWcs(width, frameTop)
+    )
+    pushSegment(
+      this.toFrameWcs(width, frameTop),
+      this.toFrameWcs(width, frameBottom)
+    )
+    pushSegment(
+      this.toFrameWcs(width, frameBottom),
+      this.toFrameWcs(0, frameBottom)
+    )
+    pushSegment(
+      this.toFrameWcs(0, frameBottom),
+      this.toFrameWcs(0, frameTop)
+    )
+
+    for (const division of columnDivisions) {
+      pushSegment(
+        this.toFrameWcs(division, frameTop),
+        this.toFrameWcs(division, frameBottom)
+      )
+    }
+
+    for (let rowIndex = 1; rowIndex < rows.length; rowIndex++) {
+      const y = frameTop - rowHeight * rowIndex
+      pushSegment(this.toFrameWcs(0, y), this.toFrameWcs(width, y))
+    }
+
+    return segments
+  }
+
+  private toFrameWcs(localX: number, localY: number): AcGePoint3d {
+    const basis = this.resolveLocalBasis()
+    return this._location
+      .clone()
+      .addScaledVector(basis.xAxis, localX)
+      .addScaledVector(basis.yAxis, localY)
+  }
+
+  private resolveFrameLayout(rows?: ToleranceFrameRow[]): ToleranceFrameLayout {
+    const frameRows = rows ?? this.parseToleranceFrame(this._text)
+    const textHeight = this.textHeight
+    const rowHeight = textHeight * 2
+    const cellPadding = textHeight / 2
+    const columnGap = textHeight
+
+    if (textHeight <= 0 || frameRows.length === 0) {
+      return {
+        width: 0,
+        totalHeight: 0,
+        rowHeight: 0,
+        columnWidths: [],
+        columnDivisions: [],
+        rowCount: 0,
+        cellPadding: 0,
+        columnGap: 0
+      }
+    }
+
+    const columnCount = Math.max(...frameRows.map(row => row.cells.length), 0)
+    const columnWidths: number[] = []
+
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      let maxWidth = textHeight
+      for (const row of frameRows) {
+        const cell = row.cells[columnIndex] ?? ''
+        if (!cell.trim()) {
+          continue
+        }
+        const plainText = acdbStripMTextControlCodes(cell).trim()
+        const estimatedWidth = acdbEstimatePlainTextWidth(plainText, textHeight)
+        maxWidth = Math.max(maxWidth, estimatedWidth)
+      }
+      columnWidths.push(maxWidth)
+    }
+
+    const columnDivisions: number[] = [0]
+    let cursorX = cellPadding
+    for (let columnIndex = 0; columnIndex < columnWidths.length; columnIndex++) {
+      cursorX += columnWidths[columnIndex]
+      cursorX += columnGap
+      columnDivisions.push(cursorX - cellPadding)
+    }
+
+    const width = columnDivisions[columnDivisions.length - 1] ?? 0
+    return {
+      width,
+      totalHeight: rowHeight * frameRows.length,
+      rowHeight,
+      columnWidths,
+      columnDivisions,
+      rowCount: frameRows.length,
+      cellPadding,
+      columnGap
+    }
+  }
+
+  private parseToleranceFrame(text: string): ToleranceFrameRow[] {
+    if (!text) {
+      return []
+    }
+
+    const rowTexts = this.splitToleranceRows(text)
+    if (rowTexts.length === 0) {
+      return []
+    }
+
+    if (!text.includes('%%v')) {
+      return rowTexts.map(row => ({
+        cells: this.parsePipeSeparatedCells(row)
+      }))
+    }
+
+    const slotRows = rowTexts.map(row => {
+      const slots = this.splitToleranceTokens(row, '%%v')
+      const padded = slots.slice(0, TOLERANCE_SLOT_COUNT)
+      while (padded.length < TOLERANCE_SLOT_COUNT) {
+        padded.push('')
+      }
+      return padded
+    })
+
+    const columnIndices = [0, 1]
+    if (slotRows.some(slots => slots[2]?.trim())) {
+      columnIndices.push(2)
+    }
+    for (let slotIndex = 3; slotIndex < TOLERANCE_SLOT_COUNT; slotIndex++) {
+      if (slotRows.some(slots => slots[slotIndex]?.trim())) {
+        columnIndices.push(slotIndex)
+      }
+    }
+
+    return slotRows.map(slots => ({
+      cells: columnIndices.map(index => slots[index] ?? '')
+    }))
+  }
+
+  private splitToleranceRows(text: string): string[] {
+    const normalized = text.replace(/\^J/g, '\n')
+    return normalized
+      .split(/\r\n|\r|\n|\\P/i)
+      .map(row => row.trim())
+      .filter(row => row.length > 0)
+  }
+
+  private splitToleranceTokens(text: string, delimiter: string): string[] {
+    if (!text) {
+      return []
+    }
+
+    const tokens: string[] = []
+    let current = ''
+    let braceDepth = 0
+
+    for (let index = 0; index < text.length; ) {
+      if (text.startsWith(delimiter, index) && braceDepth === 0) {
+        tokens.push(current)
+        current = ''
+        index += delimiter.length
+        continue
+      }
+
+      const char = text[index]
+      if (char === '{') {
+        braceDepth++
+      } else if (char === '}') {
+        braceDepth = Math.max(0, braceDepth - 1)
+      }
+      current += char
+      index++
+    }
+
+    tokens.push(current)
+    return tokens
+  }
+
+  private parsePipeSeparatedCells(text: string): string[] {
+    if (!text) {
+      return []
+    }
+
+    const cells = this.splitToleranceTokens(text, '|')
+    return cells.filter(cell => cell.length > 0)
+  }
+
+  private resolveLocalBasis(): {
+    xAxis: AcGeVector3d
+    yAxis: AcGeVector3d
+    zAxis: AcGeVector3d
+  } {
+    const zAxis = this._normal.clone()
+    if (zAxis.lengthSq() === 0) {
+      zAxis.set(0, 0, 1)
+    } else {
+      zAxis.normalize()
+    }
+
+    let xAxis = this._direction.clone()
+    if (xAxis.lengthSq() === 0) {
+      xAxis.set(1, 0, 0)
+    } else {
+      xAxis.normalize()
+    }
+
+    let yAxis = new AcGeVector3d().crossVectors(zAxis, xAxis)
+    if (yAxis.lengthSq() === 0) {
+      xAxis = AcGeVector3d.X_AXIS.clone()
+      yAxis = new AcGeVector3d().crossVectors(zAxis, xAxis)
+    }
+    yAxis.normalize()
+    xAxis = new AcGeVector3d().crossVectors(yAxis, zAxis).normalize()
+
+    return { xAxis, yAxis, zAxis }
+  }
+
+  private resolveDimensionStyle(): AcDbDimStyleTableRecord | undefined {
+    const styleName = this._dimensionStyle.trim()
+    const database = this.tryGetDatabase()
+    if (!styleName || !database) {
+      return undefined
+    }
+    return database.tables.dimStyleTable.getAt(styleName)
+  }
+
+  private tryGetDatabase() {
+    try {
+      return this.database
+    } catch {
+      return undefined
+    }
+  }
+
+  private getTextStyle(): AcGiTextStyle {
+    const dimStyle = this.resolveDimensionStyle()
+    const styleName =
+      dimStyle?.dimtxsty ??
+      AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimtxsty ??
+      'Standard'
+    const style = this.database.tables.textStyleTable.resolveAt(styleName)
+    if (!style) {
+      throw new Error('No valid text style found in text style table.')
+    }
+    return style.textStyle
+  }
+}

--- a/packages/data-model/src/entity/index.ts
+++ b/packages/data-model/src/entity/index.ts
@@ -25,6 +25,7 @@ export type {
   AcDbPropertyAccessor
 } from './AcDbEntityProperties'
 export { AcDbFace } from './AcDbFace'
+export { AcDbFcf } from './AcDbFcf'
 export {
   AcDbGradientPatternType,
   AcDbHatch,

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -149,6 +149,7 @@ export {
   AcDbEllipse,
   AcDbEntity,
   AcDbFace,
+  AcDbFcf,
   AcDbGradientPatternType,
   AcDbHatch,
   AcDbHatchObjectType,

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -158,6 +158,33 @@ describe('AcDbDxfConverter', () => {
     expect(fonts).toEqual(expect.arrayContaining(['tecosymbol']))
   })
 
+  it('collects fonts from tolerance entities via dim style text style and inline fonts', () => {
+    const converter = new TestDxfConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      tables: {
+        STYLE: {
+          entries: [
+            { name: 'Standard', font: 'txt.shx' },
+            { name: 'DimText', font: 'romans.shx' }
+          ]
+        },
+        DIMSTYLE: {
+          entries: [{ name: 'Standard', DIMTXSTY: 'DimText' }]
+        }
+      },
+      entities: [
+        {
+          type: 'TOLERANCE',
+          styleName: 'Standard',
+          text: '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|'
+        }
+      ],
+      blocks: {}
+    })
+
+    expect(fonts).toEqual(expect.arrayContaining(['romans', 'gdt.shx']))
+  })
+
   it('preserves default table ownership when DXF table metadata omits owner ids', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -352,6 +352,31 @@ describe('AcDbEntityConverter', () => {
     expect(mleader.leaders[0].leaderLines[0].breaks[0].index).toBe(0)
   })
 
+  it('converts dxf-json TOLERANCE entity to AcDbFcf', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'TOLERANCE',
+      subclassMarker: 'AcDbFcf',
+      layer: '0',
+      handle: '1A2B',
+      styleName: 'Standard',
+      position: { x: 100, y: 200, z: 0 },
+      text: '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|',
+      extrusionDirection: { x: 0, y: 0, z: 1 },
+      xAxisDirection: { x: 1, y: 0, z: 0 }
+    } as any)
+
+    expect(result?.type).toBe('Fcf')
+    const fcf = result as any
+    expect(fcf.type).toBe('Fcf')
+    expect(fcf.location).toMatchObject({ x: 100, y: 200, z: 0 })
+    expect(fcf.text).toContain('gdt')
+    expect(fcf.dimensionStyle).toBe('Standard')
+    expect(fcf.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(fcf.direction).toMatchObject({ x: 1, y: 0, z: 0 })
+  })
+
   it('converts dxf-json SHAPE entity', () => {
     acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
     const converter = new AcDbEntityConverter()

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -60,6 +60,7 @@ import {
   ParsedDxf,
   StyleTableEntry,
   TextEntity,
+  ToleranceEntity,
   VPortTableEntry
 } from '@mlightcad/dxf-json/types'
 
@@ -138,11 +139,21 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
    */
   protected getFonts(dxf: ParsedDxf) {
     const blocks = dxf.blocks ?? {}
+    const dimStyleTextStyles = new Map<string, string>()
+    for (const entry of dxf.tables?.DIMSTYLE?.entries ?? []) {
+      dimStyleTextStyles.set(entry.name, entry.DIMTXSTY || DEFAULT_TEXT_STYLE)
+    }
+    const rootEntities: CommonDxfEntity[] = [...(dxf.entities ?? [])]
+    for (const block of Object.values(blocks)) {
+      if (block.entities?.length) {
+        rootEntities.push(...block.entities)
+      }
+    }
     return new AcDbFontNameCollector({
       styles: dxf.tables.STYLE?.entries ?? [],
       textStyleVar:
         (dxf.header?.['$TEXTSTYLE'] as string | undefined) || DEFAULT_TEXT_STYLE
-    }).collect(dxf.entities, {
+    }).collect(rootEntities, {
       getEntityFontInfo: (entity: CommonDxfEntity) => {
         if (entity.type == 'MTEXT') {
           const mtext = entity as MTextEntity
@@ -152,7 +163,11 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
             resolveStyle: true
           }
         }
-        if (entity.type == 'TEXT' || entity.type == 'ATTRIB') {
+        if (
+          entity.type == 'TEXT' ||
+          entity.type == 'ATTRIB' ||
+          entity.type == 'ATTDEF'
+        ) {
           const text = entity as TextEntity
           return { styleName: text.styleName, resolveStyle: true }
         }
@@ -168,13 +183,49 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
                 : undefined
           return { styleName, formattedText: text, resolveStyle: true }
         }
+        if (entity.type == 'TOLERANCE') {
+          const tolerance = entity as ToleranceEntity
+          return {
+            styleName: this.resolveDimStyleTextStyle(
+              dimStyleTextStyles,
+              tolerance.styleName
+            ),
+            formattedText: tolerance.text,
+            resolveStyle: true
+          }
+        }
         if (entity.type == 'INSERT') {
           return { blockName: (entity as InsertEntity).name }
+        }
+        if (entity.type == 'DIMENSION') {
+          const dimension = entity as InsertEntity
+          return dimension.name ? { blockName: dimension.name } : null
         }
         return null
       },
       getBlockEntities: (blockName: string) => blocks[blockName]?.entities
     })
+  }
+
+  private resolveDimStyleTextStyle(
+    dimStyleTextStyles: Map<string, string>,
+    dimStyleName?: string
+  ): string | undefined {
+    const trimmed = dimStyleName?.trim()
+    if (!trimmed) {
+      return undefined
+    }
+    const exact = dimStyleTextStyles.get(trimmed)
+    if (exact) {
+      return exact
+    }
+    const normalized = trimmed.toUpperCase()
+    for (const [name, textStyle] of dimStyleTextStyles) {
+      if (name.toUpperCase() === normalized) {
+        return textStyle
+      }
+    }
+    return undefined
   }
 
   /**

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -17,6 +17,7 @@ import {
   AcDbEllipse,
   AcDbEntity,
   AcDbFace,
+  AcDbFcf,
   AcDbHatch,
   AcDbHatchObjectType,
   AcDbHatchPatternType,
@@ -115,6 +116,7 @@ import {
   SplineEntity,
   TableEntity,
   TextEntity,
+  ToleranceEntity,
   ViewportEntity,
   WipeoutEntity,
   XLineEntity
@@ -254,6 +256,8 @@ export class AcDbEntityConverter {
       return this.convertTable(entity as TableEntity)
     } else if (entity.type == 'TEXT') {
       return this.convertText(entity as TextEntity)
+    } else if (entity.type == 'TOLERANCE') {
+      return this.convertTolerance(entity as ToleranceEntity)
     } else if (entity.type == 'SHAPE') {
       return this.convertShape(entity as ShapeEntity)
     } else if (entity.type == 'SOLID') {
@@ -776,6 +780,20 @@ export class AcDbEntityConverter {
     dbEntity.horizontalMode = text.halign as unknown as AcDbTextHorizontalMode
     dbEntity.verticalMode = text.valign as unknown as AcDbTextVerticalMode
     dbEntity.widthFactor = text.xScale ?? 1
+    return dbEntity
+  }
+
+  private convertTolerance(tolerance: ToleranceEntity) {
+    const dbEntity = new AcDbFcf()
+    dbEntity.location.copy(tolerance.position)
+    dbEntity.text = tolerance.text
+    dbEntity.dimensionStyle = tolerance.styleName ?? ''
+    if (tolerance.extrusionDirection) {
+      dbEntity.normal.copy(tolerance.extrusionDirection)
+    }
+    if (tolerance.xAxisDirection) {
+      dbEntity.direction.copy(tolerance.xAxisDirection)
+    }
     return dbEntity
   }
 

--- a/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
@@ -108,4 +108,77 @@ describe('AcDbLibreDwgConverter', () => {
       expect.arrayContaining(['tecosymbol', 'romans', 'inline'])
     )
   })
+
+  it('collects fonts from block definitions not referenced by model space inserts', () => {
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      header: { TEXTSTYLE: 'Standard' },
+      tables: {
+        STYLE: {
+          entries: [
+            {
+              name: 'Standard',
+              font: 'txt.shx',
+              bigFont: 'gbcbig.shx',
+              standardFlag: 0
+            },
+            {
+              name: 'Romans',
+              font: 'romans.shx',
+              standardFlag: 0
+            }
+          ]
+        },
+        BLOCK_RECORD: {
+          entries: [
+            {
+              name: 'TITLE',
+              entities: [{ type: 'TEXT', styleName: 'Romans' }]
+            }
+          ]
+        }
+      },
+      entities: []
+    })
+
+    expect(fonts).toEqual(
+      expect.arrayContaining(['txt', 'gbcbig', 'romans'])
+    )
+  })
+
+  it('collects fonts from tolerance entities via dim style text style and inline fonts', () => {
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      header: { TEXTSTYLE: 'Standard' },
+      tables: {
+        STYLE: {
+          entries: [
+            {
+              name: 'Standard',
+              font: 'txt.shx',
+              standardFlag: 0
+            },
+            {
+              name: 'DimText',
+              font: 'romans.shx',
+              standardFlag: 0
+            }
+          ]
+        },
+        DIMSTYLE: {
+          entries: [{ name: 'Standard', DIMTXSTY: 'DimText' }]
+        },
+        BLOCK_RECORD: { entries: [] }
+      },
+      entities: [
+        {
+          type: 'TOLERANCE',
+          styleName: 'Standard',
+          text: '{\\Fgdt.shx|b0|i0;c134|p6;j}|0.05|A|'
+        }
+      ]
+    })
+
+    expect(fonts).toEqual(expect.arrayContaining(['romans', 'gdt.shx']))
+  })
 })

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -104,6 +104,23 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     dwg.tables.BLOCK_RECORD.entries.forEach(btr => {
       blockMap.set(btr.name, btr)
     })
+    const dimStyleTextStyles = new Map<string, string>()
+    for (const entry of dwg.tables.DIMSTYLE?.entries ?? []) {
+      const dimtxsty = entry.DIMTXSTY
+      dimStyleTextStyles.set(
+        entry.name,
+        typeof dimtxsty === 'string' && dimtxsty
+          ? dimtxsty
+          : DEFAULT_TEXT_STYLE
+      )
+    }
+
+    const rootEntities: DwgEntity[] = [...(dwg.entities ?? [])]
+    for (const btr of dwg.tables.BLOCK_RECORD.entries) {
+      if (btr.entities?.length) {
+        rootEntities.push(...btr.entities)
+      }
+    }
 
     return new AcDbFontNameCollector({
       styles: dwg.tables.STYLE.entries.map(style => ({
@@ -114,7 +131,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         standardFlag: style.standardFlag
       })),
       textStyleVar: dwg.header?.TEXTSTYLE ?? DEFAULT_TEXT_STYLE
-    }).collect(dwg.entities, {
+    }).collect(rootEntities, {
       getEntityFontInfo: (entity: DwgEntity) => {
         if (entity.type == 'MTEXT') {
           const mtext = entity as DwgMTextEntity
@@ -124,7 +141,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
             resolveStyle: true
           }
         }
-        if (entity.type == 'TEXT' || entity.type == 'ATTRIB') {
+        if (
+          entity.type == 'TEXT' ||
+          entity.type == 'ATTRIB' ||
+          entity.type == 'ATTDEF'
+        ) {
           const text = entity as DwgTextEntity
           return { styleName: text.styleName, resolveStyle: true }
         }
@@ -145,13 +166,53 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
                 : undefined
           return { styleName, formattedText: text, resolveStyle: true }
         }
+        if (entity.type == 'TOLERANCE') {
+          const tolerance = entity as DwgEntity & {
+            styleName?: string
+            text?: string
+          }
+          return {
+            styleName: this.resolveDimStyleTextStyle(
+              dimStyleTextStyles,
+              tolerance.styleName
+            ),
+            formattedText:
+              typeof tolerance.text === 'string' ? tolerance.text : '',
+            resolveStyle: true
+          }
+        }
         if (entity.type == 'INSERT') {
           return { blockName: (entity as DwgInsertEntity).name }
+        }
+        if (entity.type == 'DIMENSION') {
+          const dimension = entity as DwgEntity & { name?: string }
+          return dimension.name ? { blockName: dimension.name } : null
         }
         return null
       },
       getBlockEntities: (blockName: string) => blockMap.get(blockName)?.entities
     })
+  }
+
+  private resolveDimStyleTextStyle(
+    dimStyleTextStyles: Map<string, string>,
+    dimStyleName?: string
+  ): string | undefined {
+    const trimmed = dimStyleName?.trim()
+    if (!trimmed) {
+      return undefined
+    }
+    const exact = dimStyleTextStyles.get(trimmed)
+    if (exact) {
+      return exact
+    }
+    const normalized = trimmed.toUpperCase()
+    for (const [name, textStyle] of dimStyleTextStyles) {
+      if (name.toUpperCase() === normalized) {
+        return textStyle
+      }
+    }
+    return undefined
   }
 
   protected processLineTypes(model: DwgDatabase, db: AcDbDatabase) {


### PR DESCRIPTION
## Summary

- Add `AcDbFcf` (feature control frame / GD&T) entity with bounding geometry, rendering, grips, transforms, and DXF export.
- Wire `TOLERANCE` entity conversion in the dxf-json converter and improve font preloading for tolerance text (inline `\F...` overrides, dim-style text styles, ATTDEF, dimension blocks, and block-definition entities).
- Extend `AcDbFontNameCollector` to collect fonts from all named style table entries and both pipe/semicolon inline mtext font overrides.

## Review notes

- All 47 related tests pass (`AcDbFcf`, font collector, dxf-json converter, libredwg converter).
- LibreDwg entity converter does not yet map `TOLERANCE` to `AcDbFcf` (font collection is covered); follow-up if DWG open support is needed.

## Test plan

- [x] Run targeted Jest suites for AcDbFcf, AcDbFontNameCollector, AcDbDxfConverter, AcDbEntityConverter, and AcDbLibreDwgConverter
- [ ] Open a DXF/DWG drawing containing GD&T feature control frames and verify frame borders, cell text, and font loading
