### PR TITLE
fix(data-model): apply VPORT view target and twist when restoring saved views

### DIFF
--- a/packages/data-model/__tests__/AcDbActiveModelView.spec.ts
+++ b/packages/data-model/__tests__/AcDbActiveModelView.spec.ts
@@ -1,4 +1,4 @@
-import { AcGeBox2d, AcGePoint2d } from '@mlightcad/geometry-engine'
+import { AcGeBox2d, AcGePoint2d, AcGePoint3d } from '@mlightcad/geometry-engine'
 
 import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
@@ -78,6 +78,37 @@ describe('AcDbActiveModelView', () => {
     const box = record.modelViewBox(2)
     expect(box!.min).toEqual({ x: -10, y: -5 })
     expect(box!.max).toEqual({ x: 10, y: 5 })
+  })
+
+  it('offsets the DCS view center by the WCS view target', () => {
+    // Real-world regression: cad-viewer PR #423 test DWGs store
+    // target (750984, -1587549) with center (165042, 1206723); the WCS
+    // view center is their sum (916026, -380826). Ignoring the target
+    // framed empty space ~1.9M units away from the drawing.
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(165042, 1206723)
+    record.viewTarget = new AcGePoint3d(750984, -1587549, 0)
+    record.viewHeight = 40000
+    setVportAspectRatio(record, 2)
+
+    const box = record.modelViewBox(2)
+    expect(box!.min).toEqual({ x: 916026 - 40000, y: -380826 - 20000 })
+    expect(box!.max).toEqual({ x: 916026 + 40000, y: -380826 + 20000 })
+  })
+
+  it('rotates the DCS view center by the view twist angle', () => {
+    const record = new AcDbViewportTableRecord()
+    record.centerPoint = new AcGePoint2d(100, 0)
+    record.viewTwistAngle = Math.PI / 2
+    record.viewHeight = 10
+    setVportAspectRatio(record, 1)
+
+    // center (100, 0) rotated +90° -> (0, 100)
+    const box = record.modelViewBox(1)
+    expect(box!.min.x).toBeCloseTo(-5)
+    expect(box!.max.x).toBeCloseTo(5)
+    expect(box!.min.y).toBeCloseTo(95)
+    expect(box!.max.y).toBeCloseTo(105)
   })
 
   it('returns undefined when view height is invalid', () => {

--- a/packages/data-model/src/database/AcDbViewportTableRecord.ts
+++ b/packages/data-model/src/database/AcDbViewportTableRecord.ts
@@ -340,10 +340,20 @@ export class AcDbViewportTableRecord extends AcDbAbstractViewTableRecord<AcDbVie
    * Builds the model-space WCS view rectangle from this VPORT record.
    *
    * AutoCAD stores:
-   * - view center in groups 10/20 (mapped to `centerPoint`)
+   * - view center in groups 12/22 (mapped to `centerPoint`) — in DCS
+   *   (display coordinate system), i.e. relative to the view target and
+   *   rotated by the view twist angle, NOT in WCS
+   * - view target in group 17 (`viewTarget`) — in WCS
+   * - view twist angle in group 51 (`viewTwistAngle`)
    * - view height in group 40/45 (`viewHeight`)
    * - aspect ratio in group 41 (`gsView.aspectRatio`) ??the AutoCAD graphics
    *   window width/height at save time, not the model-space view on its own
+   *
+   * The WCS view center is therefore `target + rotate(center, twist)`.
+   * Most drawings save a (0,0,0) target so the distinction is invisible,
+   * but AutoCAD does persist non-zero targets (e.g. after DVIEW/3D orbit
+   * round-trips); ignoring the target restores the view over empty space
+   * arbitrarily far from the drawing.
    *
    * View width = view height ? aspect ratio. The viewer uses the current canvas
    * aspect ratio so DWG/DXF exports of the same drawing frame identically even
@@ -362,6 +372,25 @@ export class AcDbViewportTableRecord extends AcDbAbstractViewTableRecord<AcDbVie
       return undefined
     }
 
+    // DCS -> WCS: rotate the stored center by the twist angle, then
+    // translate by the view target. The DCS axes are the WCS axes rotated
+    // counterclockwise by the twist angle about the view direction, so DCS
+    // coordinates map back to WCS by rotating +twist.
+    const twist = this.viewTwistAngle
+    let wcsCenterX = center.x
+    let wcsCenterY = center.y
+    if (Number.isFinite(twist) && twist !== 0) {
+      const cos = Math.cos(twist)
+      const sin = Math.sin(twist)
+      wcsCenterX = center.x * cos - center.y * sin
+      wcsCenterY = center.x * sin + center.y * cos
+    }
+    const target = this.viewTarget
+    if (target && Number.isFinite(target.x) && Number.isFinite(target.y)) {
+      wcsCenterX += target.x
+      wcsCenterY += target.y
+    }
+
     const aspectRatio = resolveViewAspectRatio(this, canvasAspectRatio)
 
     const viewWidth = viewHeight * aspectRatio
@@ -370,12 +399,12 @@ export class AcDbViewportTableRecord extends AcDbAbstractViewTableRecord<AcDbVie
 
     return new AcGeBox2d()
       .expandByPoint({
-        x: center.x - halfWidth,
-        y: center.y - halfHeight
+        x: wcsCenterX - halfWidth,
+        y: wcsCenterY - halfHeight
       })
       .expandByPoint({
-        x: center.x + halfWidth,
-        y: center.y + halfHeight
+        x: wcsCenterX + halfWidth,
+        y: wcsCenterY + halfHeight
       })
   }
 


### PR DESCRIPTION
## Summary

`AcDbViewportTableRecord.modelViewBox()` treated the VPORT view center (DXF groups 12/22) as a plain WCS point. AutoCAD actually stores it in **DCS** — display coordinates relative to the view target point (group 17, WCS) and rotated by the view twist angle (group 51). The WCS view center is `target + rotate(center, twist)`.

Most drawings save a `(0,0,0)` target, so the bug is invisible for them. Real-world files do persist non-zero targets: the two DWGs reported in mlightcad/cad-viewer#423 store a target of `(750984, -1587549)` with a center of `(165042, 1206723)`. The correct WCS view center is their sum, `(916026, -380826)` — the middle of the floor plan — while the old code framed empty space ~1.9M units away, so the drawing opened as a blank canvas.

## Changes

- `modelViewBox()` now rotates the stored DCS center by the twist angle and translates it by the view target before building the WCS view rectangle.
- Doc comment updated to spell out the DCS/WCS distinction per group code.

## Tests

- New unit test with the exact target/center values from the cad-viewer#423 regression files.
- New unit test for the twist-angle rotation path.
- Full data-model suite: 689/689 passing.
- Verified end-to-end in cad-viewer with the reported DWGs: both now open at the exact view saved in AutoCAD.