### PR TITLE
fix(data-model): improve FCF GDT cell width estimation and add libredwg TOLERANCE support

### DIFF
--- a/packages/data-model/__tests__/AcDbFcf.spec.ts
+++ b/packages/data-model/__tests__/AcDbFcf.spec.ts
@@ -178,6 +178,28 @@ describe('AcDbFcf', () => {
     expect(rightCenterY).toBeCloseTo(270, 6)
   })
 
+  it('aligns the right edge with leader attachment for GDT tolerance text', () => {
+    const db = createWorkingDb()
+    const dimStyle = db.tables.dimStyleTable.getAt('Standard')
+    if (dimStyle) {
+      dimStyle.dimtxt = 3.5
+      dimStyle.dimscale = 1
+    }
+
+    const fcf = new AcDbFcf()
+    fcf.location = new AcGePoint3d(312.1120452047875, 270.2900270575117, 0)
+    fcf.text = '{\\Fgdt;r}%%v{\\Fgdt;n}0.05%%v%%vA%%v%%v%%v^J'
+    fcf.dimensionStyle = 'Standard'
+
+    const points = fcf.getBoundingPoints()
+    const rightEdgeCenterX = (points[1].x + points[2].x) / 2
+    const leaderAttachX = 343.9410452047876
+
+    expect(rightEdgeCenterX).toBeCloseTo(leaderAttachX, 0)
+    expect(points[0].x).toBeCloseTo(fcf.location.x, 6)
+    expect((points[0].y + points[3].y) / 2).toBeCloseTo(fcf.location.y, 6)
+  })
+
   it('draws frame borders and dividers as separate axis-aligned segments', () => {
     createWorkingDb()
     const fcf = new AcDbFcf()

--- a/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
@@ -10,11 +10,13 @@ import {
   acdbCountMTextLines,
   acdbEstimateMTextHeight,
   acdbEstimatePlainTextWidth,
+  acdbEstimateToleranceCellWidth,
   acdbExpandBoxByOrientedTextRect,
   acdbGetLocalBoundsFromAttachment,
   acdbResolveMTextLayoutMetrics,
   acdbScorePointAgainstMTextLayout,
   acdbStripMTextControlCodes,
+  acdbStripToleranceCellTextForWidth,
   acdbWorldPointToMTextLocal
 } from '../src/entity/AcDbTextExtentsHelpers'
 
@@ -23,6 +25,28 @@ describe('AcDbTextExtentsHelpers', () => {
     it('converts paragraph breaks and removes formatting codes', () => {
       expect(acdbStripMTextControlCodes('A\\PB')).toBe('A\nB')
       expect(acdbStripMTextControlCodes('{\\C1;Red}')).toBe('Red')
+    })
+  })
+
+  describe('acdbStripToleranceCellTextForWidth', () => {
+    it('removes GDT font codes and symbol characters from tolerance cells', () => {
+      expect(acdbStripToleranceCellTextForWidth('{\\Fgdt;r}')).toBe('')
+      expect(acdbStripToleranceCellTextForWidth('{\\Fgdt;n}0.05')).toBe('0.05')
+      expect(
+        acdbStripToleranceCellTextForWidth('{\\Fgdt.shx|b0|i0|c134|p6;j}')
+      ).toBe('')
+    })
+  })
+
+  describe('acdbEstimateToleranceCellWidth', () => {
+    it('uses text height for symbol-only GDT cells', () => {
+      expect(acdbEstimateToleranceCellWidth('{\\Fgdt;r}', 3.5)).toBeCloseTo(3.5)
+    })
+
+    it('measures numeric text without the GDT symbol character width', () => {
+      expect(acdbEstimateToleranceCellWidth('{\\Fgdt;n}0.05', 3.5)).toBeCloseTo(
+        14
+      )
     })
   })
 

--- a/packages/data-model/src/entity/AcDbFcf.ts
+++ b/packages/data-model/src/entity/AcDbFcf.ts
@@ -21,10 +21,7 @@ import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
 import { AcDbEntity } from './AcDbEntity'
 import { AcDbEntityProperties } from './AcDbEntityProperties'
 import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
-import {
-  acdbEstimatePlainTextWidth,
-  acdbStripMTextControlCodes
-} from './AcDbTextExtentsHelpers'
+import { acdbEstimateToleranceCellWidth } from './AcDbTextExtentsHelpers'
 
 interface ToleranceFrameRow {
   cells: string[]
@@ -559,8 +556,7 @@ export class AcDbFcf extends AcDbEntity {
         if (!cell.trim()) {
           continue
         }
-        const plainText = acdbStripMTextControlCodes(cell).trim()
-        const estimatedWidth = acdbEstimatePlainTextWidth(plainText, textHeight)
+        const estimatedWidth = acdbEstimateToleranceCellWidth(cell, textHeight)
         maxWidth = Math.max(maxWidth, estimatedWidth)
       }
       columnWidths.push(maxWidth)

--- a/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
+++ b/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
@@ -9,6 +9,12 @@ import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
 const CHAR_WIDTH_FACTOR = 1
 
+/** `\Ffont|params;symbol` tolerance/GDT inline font override including symbol char. */
+const TOLERANCE_INLINE_FONT_PATTERN =
+  /\\[fF][^\\|{}]*(?:\|[^;\\|{}]*)*;./i
+const TOLERANCE_INLINE_FONT_PATTERN_GLOBAL =
+  /\\[fF][^\\|{}]*(?:\|[^;\\|{}]*)*;./gi
+
 /**
  * Strips MTEXT control codes and returns plain text for width/line estimation.
  */
@@ -17,6 +23,48 @@ export function acdbStripMTextControlCodes(text: string): string {
     .replace(/\\[PpNn]/g, '\n')
     .replace(/\\[A-Za-z][^;]*;/g, '')
     .replace(/[{}]/g, '')
+}
+
+/**
+ * Strips tolerance cell formatting and returns measurable plain text.
+ *
+ * GDT font codes such as `{\Fgdt;r}` or `{\Fgdt;n}0.05` embed a single symbol
+ * character after the font name. That glyph must not contribute to ASCII width
+ * estimation because it is rendered from the GDT SHX font, not the text style.
+ */
+export function acdbStripToleranceCellTextForWidth(text: string): string {
+  return text
+    .replace(/\\[PpNn]/g, '\n')
+    .replace(TOLERANCE_INLINE_FONT_PATTERN_GLOBAL, '')
+    .replace(/\\[A-Za-z][^;]*;/g, '')
+    .replace(/[{}]/g, '')
+    .trim()
+}
+
+/**
+ * Estimates the rendered width of one tolerance frame cell.
+ */
+export function acdbEstimateToleranceCellWidth(
+  cellText: string,
+  textHeight: number,
+  widthFactor = 1
+): number {
+  const trimmed = cellText.trim()
+  if (!trimmed || textHeight <= 0) {
+    return 0
+  }
+
+  const measurableText = acdbStripToleranceCellTextForWidth(trimmed)
+  const hasInlineFont = TOLERANCE_INLINE_FONT_PATTERN.test(trimmed)
+
+  if (!measurableText) {
+    return hasInlineFont ? textHeight : 0
+  }
+
+  return Math.max(
+    textHeight,
+    acdbEstimatePlainTextWidth(measurableText, textHeight, widthFactor)
+  )
 }
 
 /**

--- a/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts
@@ -5,6 +5,7 @@ import {
   AcDbBlockReference,
   AcDbCircle,
   AcDbDatabase,
+  AcDbFcf,
   AcDbHatch,
   AcDbLeader,
   AcDbLeaderAnnotationType,
@@ -366,5 +367,28 @@ describe('libredwg AcDbEntityConverter', () => {
 
     expect(result).toBeInstanceOf(AcDbMText)
     expect((result as AcDbMText).extentsWidth).toBeCloseTo(16.25)
+  })
+
+  it('converts libredwg TOLERANCE entity to AcDbFcf', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'TOLERANCE',
+      layer: '0',
+      handle: '1A2B',
+      styleName: 'Standard',
+      insertionPoint: { x: 100, y: 200, z: 0 },
+      text: '{\\Fgdt.shx|b0|i0|c134|p6;j}|0.05|A|',
+      extrusionDirection: { x: 0, y: 0, z: 1 },
+      xAxisDirection: { x: 1, y: 0, z: 0 }
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbFcf)
+    const fcf = result as AcDbFcf
+    expect(fcf.location).toMatchObject({ x: 100, y: 200, z: 0 })
+    expect(fcf.text).toContain('gdt')
+    expect(fcf.dimensionStyle).toBe('Standard')
+    expect(fcf.normal).toMatchObject({ x: 0, y: 0, z: 1 })
+    expect(fcf.direction).toMatchObject({ x: 1, y: 0, z: 0 })
   })
 })

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -17,6 +17,7 @@ import {
   AcDbEllipse,
   AcDbEntity,
   AcDbFace,
+  AcDbFcf,
   AcDbHatch,
   AcDbHatchObjectType,
   AcDbHatchPatternType,
@@ -114,6 +115,7 @@ import type {
   DwgSplineEntity,
   DwgTableEntity,
   DwgTextEntity,
+  DwgToleranceEntity,
   DwgViewportEntity,
   DwgWipeoutEntity,
   DwgXlineEntity
@@ -202,6 +204,8 @@ export class AcDbEntityConverter {
       return this.convertTable(entity as DwgTableEntity)
     } else if (entity.type == 'TEXT') {
       return this.convertText(entity as DwgTextEntity)
+    } else if (entity.type == 'TOLERANCE') {
+      return this.convertTolerance(entity as DwgToleranceEntity)
     } else if (entity.type == 'SHAPE') {
       return this.convertShape(entity as DwgShapeEntity)
     } else if (entity.type == 'SOLID') {
@@ -687,6 +691,20 @@ export class AcDbEntityConverter {
     dbEntity.horizontalMode = text.halign as unknown as AcDbTextHorizontalMode
     dbEntity.verticalMode = text.valign as unknown as AcDbTextVerticalMode
     dbEntity.widthFactor = text.xScale ?? 1
+    return dbEntity
+  }
+
+  private convertTolerance(tolerance: DwgToleranceEntity) {
+    const dbEntity = new AcDbFcf()
+    dbEntity.location.copy(tolerance.insertionPoint)
+    dbEntity.text = tolerance.text
+    dbEntity.dimensionStyle = tolerance.styleName ?? ''
+    if (tolerance.extrusionDirection) {
+      dbEntity.normal.copy(tolerance.extrusionDirection)
+    }
+    if (tolerance.xAxisDirection) {
+      dbEntity.direction.copy(tolerance.xAxisDirection)
+    }
     return dbEntity
   }
 


### PR DESCRIPTION
## Summary

- Add tolerance-specific width helpers (cdbStripToleranceCellTextForWidth, cdbEstimateToleranceCellWidth) so GDT symbol glyphs from SHX fonts do not inflate ASCII width estimates
- Update AcDbFcf column width calculation to use the new helpers, aligning frame right edge with leader attachment points
- Add libredwg TOLERANCE entity conversion to AcDbFcf with unit test coverage

## Test plan

- [x] pnpm test -- packages/data-model/__tests__/AcDbFcf.spec.ts packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts packages/libredwg-converter/__tests__/AcDbEntitiyConverter.spec.ts (42 passed)

Made with [Cursor](https://cursor.com)