### PR TITLE
feat(data-model): decode ACIS SAB and render 3DSOLID wireframes

### DIFF
--- a/packages/data-model/__tests__/AcDb3dSolid.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dSolid.spec.ts
@@ -68,8 +68,8 @@ describe('AcDb3dSolid', () => {
     expect(solid.hasRenderableGeometry).toBe(true)
 
     const extents = solid.geometricExtents
-    expect(extents.min).toMatchObject({ x: 10, y: 0, z: -10 })
-    expect(extents.max).toMatchObject({ x: 10, y: 0, z: 10 })
+    expect(extents.min).toMatchObject({ x: -10, y: -10, z: -10 })
+    expect(extents.max).toMatchObject({ x: 10, y: 10, z: 10 })
   })
 
   it('computes a correct bounding box from a synthetic point set', () => {
@@ -93,20 +93,31 @@ describe('AcDb3dSolid', () => {
     expect(renderer.lineSegments).not.toHaveBeenCalled()
   })
 
-  it('draws a 12-edge wireframe box referencing the 8 bounding corners', () => {
+  it('draws wireframe segments from SAT text when curve records are present', () => {
+    const solid = new AcDb3dSolid(REAL_CYLINDER_SAT, 400)
+    const lineSegments = jest.fn()
+    const renderer = { lineSegments }
+
+    solid.subWorldDraw(renderer as never)
+
+    expect(lineSegments).toHaveBeenCalledTimes(1)
+    const [, itemSize, indices] = lineSegments.mock.calls[0]
+    expect(itemSize).toBe(3)
+    expect(indices.length).toBeGreaterThan(12 * 2)
+  })
+
+  it('falls back to a bounding-box wireframe when only isolated point records exist', () => {
     const solid = new AcDb3dSolid(SYNTHETIC_BOX_POINTS)
     const lineSegments = jest.fn()
-    const renderer = {
-      lineSegments
-    }
+    const renderer = { lineSegments }
 
     solid.subWorldDraw(renderer as never)
 
     expect(lineSegments).toHaveBeenCalledTimes(1)
     const [buffer, itemSize, indices] = lineSegments.mock.calls[0]
     expect(itemSize).toBe(3)
-    expect(buffer).toHaveLength(8 * 3) // 8 corners
-    expect(indices).toHaveLength(12 * 2) // 12 edges
+    expect(buffer.length).toBeGreaterThanOrEqual(8 * 3)
+    expect(indices.length).toBeGreaterThanOrEqual(12 * 2)
   })
 
   it('transforms the extracted point cloud (and thus the bounding box)', () => {

--- a/packages/data-model/src/acis/AcDbAcisDecode.ts
+++ b/packages/data-model/src/acis/AcDbAcisDecode.ts
@@ -1,0 +1,71 @@
+import type { AcDbAcisModel } from './AcDbAcisEntities'
+import { buildAcDbAcisModel } from './AcDbAcisEntities'
+import { parseAcDbAcisSab } from './AcDbAcisSab'
+
+/** Known ACIS/ASM binary file signature strings searched in raw byte payloads. */
+const SAB_SIGNATURES = ['ACIS BinaryFile', 'ASM BinaryFile', 'ASM BinaryFile4'] as const
+
+/**
+ * Finds the first byte offset of an ASCII substring within `data`.
+ *
+ * @param data - Byte buffer to search.
+ * @param needle - ASCII string to locate.
+ * @returns Zero-based offset, or `-1` when not found.
+ */
+function findAscii(data: Uint8Array, needle: string): number {
+  if (needle.length === 0 || data.length < needle.length) return -1
+  const first = needle.charCodeAt(0)
+  for (let i = 0; i <= data.length - needle.length; i++) {
+    if (data[i] !== first) continue
+    let matched = true
+    for (let j = 1; j < needle.length; j++) {
+      if (data[i + j] !== needle.charCodeAt(j)) {
+        matched = false
+        break
+      }
+    }
+    if (matched) return i
+  }
+  return -1
+}
+
+/**
+ * Finds the byte offset of an ACIS/ASM binary signature within `data`.
+ *
+ * @param data - Raw SAB/ASM byte payload.
+ * @returns Zero-based offset, or `-1` when no known signature is found.
+ */
+export function findAcDbAcisSabSignatureOffset(data: Uint8Array): number {
+  for (const signature of SAB_SIGNATURES) {
+    const offset = findAscii(data, signature)
+    if (offset >= 0) return offset
+  }
+  return -1
+}
+
+/**
+ * Returns true when `data` begins with (or contains) an ACIS/ASM binary signature.
+ *
+ * @param data - Raw SAB/ASM byte payload.
+ */
+export function isAcDbAcisSabPayload(data: Uint8Array): boolean {
+  return findAcDbAcisSabSignatureOffset(data) >= 0
+}
+
+/**
+ * Decode an ACIS/ASM SAB byte stream into a resolved B-rep model graph.
+ *
+ * @param data - Raw SAB/ASM byte payload (may include leading non-ACIS bytes).
+ * @returns Resolved model graph, or `null` for empty payloads, missing signatures,
+ * or malformed streams.
+ */
+export function decodeAcDbAcisModel(data: Uint8Array): AcDbAcisModel | null {
+  if (data.length === 0) return null
+  const offset = findAcDbAcisSabSignatureOffset(data)
+  if (offset < 0) return null
+  try {
+    return buildAcDbAcisModel(parseAcDbAcisSab(data.subarray(offset)))
+  } catch {
+    return null
+  }
+}

--- a/packages/data-model/src/acis/AcDbAcisEntities.ts
+++ b/packages/data-model/src/acis/AcDbAcisEntities.ts
@@ -1,0 +1,110 @@
+import type {
+  AcDbAcisSabData,
+  AcDbAcisSabHeader,
+  AcDbAcisSabRecord,
+  AcDbAcisSabVector,
+} from './AcDbAcisSab'
+import { AcDbAcisSabTag } from './AcDbAcisSab'
+
+/**
+ * One node in the resolved ACIS B-rep entity DAG.
+ * Pointers in the source record are resolved to references to other nodes.
+ */
+export interface AcDbAcisNode {
+  /** Zero-based index of this node in the model's record list. */
+  readonly index: number
+  /** ACIS entity type name, e.g. `"body"`, `"edge"`, `"plane-surface"`. */
+  readonly type: string
+  /** Raw SAB record backing this node. */
+  readonly record: AcDbAcisSabRecord
+  /** Resolved pointer targets from this record's tokens. */
+  readonly refs: readonly (AcDbAcisNode | null)[]
+}
+
+/**
+ * Resolved ACIS/ASM B-rep model graph built from parsed SAB data.
+ */
+export interface AcDbAcisModel {
+  /** Parsed SAB file header metadata. */
+  readonly header: AcDbAcisSabHeader
+  /** All resolved entity nodes in record order. */
+  readonly nodes: readonly AcDbAcisNode[]
+  /** Top-level `body` entity nodes. */
+  readonly bodies: readonly AcDbAcisNode[]
+  /** Count of nodes per entity type name. */
+  readonly typeCounts: ReadonlyMap<string, number>
+  /** Returns all nodes whose entity type matches `type`. */
+  nodesOfType(type: string): readonly AcDbAcisNode[]
+  /** Collects 3D locations from all `point` entity records. */
+  pointLocations(): readonly AcDbAcisSabVector[]
+}
+
+const END_MARKERS = new Set([
+  'End-of-ACIS-data',
+  'End-of-ASM-data',
+  'End-of-ACIS-History-data',
+])
+
+interface AcDbAcisMutableNode {
+  index: number
+  type: string
+  record: AcDbAcisSabRecord
+  refs: (AcDbAcisNode | null)[]
+}
+
+/**
+ * Builds a resolved B-rep DAG from parsed SAB data by wiring pointer tokens
+ * between records.
+ *
+ * @param sab - Parsed SAB header and record list from {@link parseAcDbAcisSab}.
+ * @returns Resolved model graph with indexed nodes and type-based lookups.
+ */
+export function buildAcDbAcisModel(sab: AcDbAcisSabData): AcDbAcisModel {
+  const records = sab.records
+  const nodes: AcDbAcisMutableNode[] = records.map((record, index) => ({
+    index,
+    type: record.type,
+    record,
+    refs: [],
+  }))
+
+  for (const node of nodes) {
+    for (const token of node.record.tokens) {
+      if (token.tag !== AcDbAcisSabTag.Pointer) continue
+      const target = token.value as number
+      node.refs.push(
+        target >= 0 && target < nodes.length ? (nodes[target] as AcDbAcisNode) : null,
+      )
+    }
+  }
+
+  const frozen = nodes as unknown as AcDbAcisNode[]
+  const byType = new Map<string, AcDbAcisNode[]>()
+  const typeCounts = new Map<string, number>()
+  for (const node of frozen) {
+    if (END_MARKERS.has(node.type)) continue
+    let bucket = byType.get(node.type)
+    if (bucket === undefined) {
+      bucket = []
+      byType.set(node.type, bucket)
+    }
+    bucket.push(node)
+    typeCounts.set(node.type, (typeCounts.get(node.type) ?? 0) + 1)
+  }
+
+  return {
+    header: sab.header,
+    nodes: frozen,
+    bodies: byType.get('body') ?? [],
+    typeCounts,
+    nodesOfType: (type: string) => byType.get(type) ?? [],
+    pointLocations() {
+      const out: AcDbAcisSabVector[] = []
+      for (const node of byType.get('point') ?? []) {
+        const vec = node.record.tokens.find(t => t.tag === AcDbAcisSabTag.LocationVec)
+        if (vec !== undefined) out.push(vec.value as AcDbAcisSabVector)
+      }
+      return out
+    },
+  }
+}

--- a/packages/data-model/src/acis/AcDbAcisGeometry.ts
+++ b/packages/data-model/src/acis/AcDbAcisGeometry.ts
@@ -1,0 +1,618 @@
+// ACIS B-rep geometry extraction.
+//
+// Turns the resolved record graph (./AcDbAcisEntities.ts AcDbAcisModel) into usable geometry:
+// vertices (3D points), edges (segments between resolved vertex points + curve
+// type/params), and faces (surface type/params + loop structure). It reads each
+// record's analytic parameters by SAB token TAG-TYPE in wire order (a TokenCursor
+// that skips pointer/int noise) — NOT by positional field schema, which is the
+// exact assumption that breaks ezdxf's typed loader on newer ASM streams.
+//
+// Field-order sources (see DEFERRED note for intcurve):
+//   point / straight-curve / plane-surface — ezdxf ezdxf/acis/entities.py
+//     (Point.restore_data, StraightCurve.restore_data, Plane.restore_common) — oracle-backed.
+//   ellipse-curve / cone-surface / torus-surface — spec-confirmed against the
+//     ACIS 7.0 SAT save-file reference (ellipse/cone restore_data field order)
+//     and empirically cross-checked vs corpus records + an annotated .sat. There
+//     is no automated runtime oracle (ezdxf has no Ellipse/Cone/Torus types).
+
+import type { AcDbAcisModel, AcDbAcisNode } from './AcDbAcisEntities'
+import type { AcDbAcisSabToken, AcDbAcisSabVector } from './AcDbAcisSab'
+import { AcDbAcisSabTag } from './AcDbAcisSab'
+
+/** 3D position or direction vector `[x, y, z]`. */
+export type AcDbAcisVec3 = AcDbAcisSabVector
+
+/** Known analytic curve kinds extracted from ACIS edge geometry. */
+export type AcDbAcisCurveKind = 'straight' | 'ellipse' | 'intcurve' | 'unknown';
+
+/** Known analytic surface kinds extracted from ACIS face geometry. */
+export type AcDbAcisSurfaceKind = 'plane' | 'cone' | 'torus' | 'sphere' | 'spline' | 'unknown';
+
+/** Parameters for a straight (line) ACIS curve. */
+export interface AcDbAcisStraightCurveParams {
+  readonly kind: 'straight';
+  /** Line origin in model space. */
+  readonly origin: AcDbAcisVec3;
+  /** Unit direction vector along the line. */
+  readonly direction: AcDbAcisVec3;
+}
+
+/** Parameters for an ellipse (or circular arc) ACIS curve. */
+export interface AcDbAcisEllipseCurveParams {
+  readonly kind: 'ellipse';
+  /** Ellipse center in model space. */
+  readonly center: AcDbAcisVec3;
+  /** Plane normal of the ellipse. */
+  readonly normal: AcDbAcisVec3;
+  /** Major-axis vector (length defines semi-major axis). */
+  readonly majorAxis: AcDbAcisVec3;
+  /** Ratio of minor to major axis length. */
+  readonly ratio: number;
+}
+
+/**
+ * An interpolated/intersection spline curve. `controlPoints` is the `nubs`/`nurbs`
+ * B-spline control polygon extracted from the record's subtype block — a usable
+ * polyline approximation of the curve (the first/last control point coincide with
+ * the edge's start/end vertices). Empty when the subtype is a `nullbs` placeholder
+ * or the control polygon could not be read. Full NURBS evaluation is out of scope.
+ */
+export interface AcDbAcisIntCurveParams {
+  readonly kind: 'intcurve';
+  /** B-spline control polygon used as a polyline wireframe approximation. */
+  readonly controlPoints: readonly AcDbAcisVec3[];
+}
+
+/** Discriminated union of parsed ACIS curve parameters. */
+export type AcDbAcisCurveParams =
+  | AcDbAcisStraightCurveParams
+  | AcDbAcisEllipseCurveParams
+  | AcDbAcisIntCurveParams
+  | { readonly kind: 'unknown' };
+
+/** Parameters for a plane ACIS surface. */
+export interface AcDbAcisPlaneParams {
+  readonly kind: 'plane';
+  /** Point on the plane. */
+  readonly origin: AcDbAcisVec3;
+  /** Outward plane normal. */
+  readonly normal: AcDbAcisVec3;
+  /** Optional in-plane U direction. */
+  readonly uDir?: AcDbAcisVec3;
+}
+
+/** Parameters for a cone (or cylinder) ACIS surface. */
+export interface AcDbAcisConeParams {
+  readonly kind: 'cone';
+  /** Apex or base reference point. */
+  readonly origin: AcDbAcisVec3;
+  /** Axis direction. */
+  readonly axis: AcDbAcisVec3;
+  /** Major-axis vector in the base plane. */
+  readonly majorAxis: AcDbAcisVec3;
+  /** Ratio of minor to major axis in the base ellipse. */
+  readonly ratio: number;
+  /** Sine of the half-angle between axis and surface generator. */
+  readonly sineAngle: number;
+  /** Cosine of the half-angle between axis and surface generator. */
+  readonly cosineAngle: number;
+}
+
+/** Parameters for a torus ACIS surface. */
+export interface AcDbAcisTorusParams {
+  readonly kind: 'torus';
+  /** Torus center in model space. */
+  readonly center: AcDbAcisVec3;
+  /** Revolution axis direction. */
+  readonly axis: AcDbAcisVec3;
+  /** Distance from center to tube centerline. */
+  readonly majorRadius: number;
+  /** Tube radius. */
+  readonly minorRadius: number;
+}
+
+/** Parameters for a sphere ACIS surface. */
+export interface AcDbAcisSphereParams {
+  readonly kind: 'sphere';
+  /** Sphere center in model space. */
+  readonly center: AcDbAcisVec3;
+  /** Sphere radius. */
+  readonly radius: number;
+  /** Reference U direction on the sphere. */
+  readonly uDir: AcDbAcisVec3;
+  /** Pole axis direction. */
+  readonly poleAxis: AcDbAcisVec3;
+}
+
+/** Discriminated union of parsed ACIS surface parameters. */
+export type AcDbAcisSurfaceParams =
+  | AcDbAcisPlaneParams
+  | AcDbAcisConeParams
+  | AcDbAcisTorusParams
+  | AcDbAcisSphereParams
+  | { readonly kind: 'unknown' };
+
+/**
+ * A B-rep vertex with its resolved 3D point location.
+ */
+export interface AcDbAcisVertex {
+  /** Index of the source `vertex` node in the model graph. */
+  readonly nodeIndex: number;
+  /** Resolved 3D point location, or `null` when the pointer chain is broken. */
+  readonly point: AcDbAcisVec3 | null;
+}
+
+/**
+ * A B-rep edge with resolved endpoint locations and optional curve parameters.
+ */
+export interface AcDbAcisEdge {
+  /** Index of the source `edge` node in the model graph. */
+  readonly nodeIndex: number;
+  /** Resolved start vertex location. */
+  readonly start: AcDbAcisVec3 | null;
+  /** Resolved end vertex location. */
+  readonly end: AcDbAcisVec3 | null;
+  /** Parsed analytic curve kind. */
+  readonly curveType: AcDbAcisCurveKind;
+  /** Parsed curve parameters when the subtype is recognized. */
+  readonly curve?: AcDbAcisCurveParams;
+}
+
+/**
+ * One boundary loop on a B-rep face.
+ */
+export interface AcDbAcisFaceLoop {
+  /** Index of the source `loop` node in the model graph. */
+  readonly nodeIndex: number;
+  /** Number of coedges in the loop ring. */
+  readonly coedgeCount: number;
+}
+
+/**
+ * A B-rep face with surface type/parameters and boundary loop structure.
+ */
+export interface AcDbAcisFace {
+  /** Index of the source `face` node in the model graph. */
+  readonly nodeIndex: number;
+  /** Parsed analytic surface kind. */
+  readonly surfaceType: AcDbAcisSurfaceKind;
+  /** Parsed surface parameters when the subtype is recognized. */
+  readonly surface?: AcDbAcisSurfaceParams;
+  /** Ordered boundary loops on this face. */
+  readonly loops: readonly AcDbAcisFaceLoop[];
+}
+
+/** Axis-aligned bounding box over a set of 3D points. */
+export interface AcDbAcisBBox {
+  /** Minimum corner `[x, y, z]`. */
+  readonly min: AcDbAcisVec3;
+  /** Maximum corner `[x, y, z]`. */
+  readonly max: AcDbAcisVec3;
+}
+
+/** An indexed triangle mesh for one face: shared `positions` + `triangles` (index triples). */
+export interface AcDbAcisTriangleMesh {
+  /** Source surface kind for this mesh. */
+  readonly surfaceType: AcDbAcisSurfaceKind;
+  /** Shared vertex positions referenced by `triangles`. */
+  readonly positions: readonly AcDbAcisVec3[];
+  /** Triangle index triples into `positions`. */
+  readonly triangles: readonly (readonly [number, number, number])[];
+}
+
+/**
+ * Tessellation of a body's faces.
+ *
+ * - `faces`: legacy flat-polygon rings — one ordered ring per plane-surface face
+ *   bounded entirely by straight edges (kept for existing consumers).
+ * - `triangles`: indexed triangle meshes covering plane faces (fan-triangulated)
+ *   **and** the analytic curved faces — `cone` (incl. cylinders) and `torus`,
+ *   meshed as full surfaces of revolution with the v-range taken from each
+ *   face's loops. Correct for full-revolution faces (the common case);
+ *   u-partial curved faces are approximated (flagged in `diagnostics`).
+ *   sphere/spline surfaces are not meshed.
+ */
+export interface AcDbAcisMesh {
+  /** Legacy flat polygon rings for plane faces bounded by straight edges. */
+  readonly faces: readonly (readonly AcDbAcisVec3[])[];
+  /** Indexed triangle meshes for plane and selected curved faces. */
+  readonly triangles: readonly AcDbAcisTriangleMesh[];
+  /** Best-effort tessellation notes and approximations. */
+  readonly diagnostics: readonly string[];
+}
+
+/** Options for {@link tessellateAcDbAcisGeometry}. */
+export interface AcDbAcisTessellationOptions {
+  /** Samples per full revolution for curved faces (≥3). Default 32. */
+  readonly segments?: number;
+}
+
+/**
+ * Extracted B-rep geometry from a decoded ACIS model.
+ */
+export interface AcDbAcisGeometry {
+  /** Resolved B-rep vertices. */
+  readonly vertices: readonly AcDbAcisVertex[];
+  /** Resolved B-rep edges with optional curve parameters. */
+  readonly edges: readonly AcDbAcisEdge[];
+  /** Resolved B-rep faces with optional surface parameters. */
+  readonly faces: readonly AcDbAcisFace[];
+  /** Wireframe bounding box over resolved vertex points, or null when none resolve. */
+  readonly bbox: AcDbAcisBBox | null;
+  /** Best-effort notes: dangling pointers, degenerate edges, unhandled subtypes. */
+  readonly diagnostics: readonly string[];
+}
+
+/**
+ * Summary statistics over extracted ACIS geometry.
+ */
+export interface AcDbAcisGeometrySummary {
+  /** Number of resolved vertices. */
+  readonly vertexCount: number;
+  /** Number of resolved edges. */
+  readonly edgeCount: number;
+  /** Number of resolved faces. */
+  readonly faceCount: number;
+  /** Total boundary loops across all faces. */
+  readonly loopCount: number;
+  /** Histogram of parsed curve kinds. */
+  readonly curveTypes: Readonly<Record<AcDbAcisCurveKind, number>>;
+  /** Histogram of parsed surface kinds. */
+  readonly surfaceTypes: Readonly<Record<AcDbAcisSurfaceKind, number>>;
+  /** Bounding box over resolved vertices, if any. */
+  readonly bbox: AcDbAcisBBox | null;
+  /** Number of diagnostic messages. */
+  readonly diagnosticCount: number;
+  /** Diagnostic messages from geometry extraction. */
+  readonly diagnostics: readonly string[];
+}
+
+/** Walks a record's tokens in wire order, yielding the next token of a wanted tag. */
+class AcDbAcisTokenCursor {
+  private i = 0;
+  constructor(private readonly tokens: readonly AcDbAcisSabToken[]) {}
+  private next(...tags: number[]): AcDbAcisSabToken | undefined {
+    while (this.i < this.tokens.length) {
+      const token = this.tokens[this.i++];
+      if (token !== undefined && tags.includes(token.tag)) return token;
+    }
+    return undefined;
+  }
+  nextVec(): AcDbAcisVec3 | undefined {
+    return this.next(AcDbAcisSabTag.LocationVec, AcDbAcisSabTag.DirectionVec)?.value as AcDbAcisVec3 | undefined;
+  }
+  nextDouble(): number | undefined {
+    return this.next(AcDbAcisSabTag.Double)?.value as number | undefined;
+  }
+}
+
+const refOfType = (node: AcDbAcisNode, suffix: string): AcDbAcisNode | null =>
+  node.refs.find(r => r !== null && (r.type === suffix || r.type.endsWith(suffix))) ?? null;
+const refsOfType = (node: AcDbAcisNode, type: string): AcDbAcisNode[] =>
+  node.refs.filter((r): r is AcDbAcisNode => r !== null && r.type === type);
+
+function vertexPoint(vertex: AcDbAcisNode | null): AcDbAcisVec3 | null {
+  if (vertex === null) return null;
+  const point = refOfType(vertex, 'point');
+  if (point === null) return null;
+  const vec = point.record.tokens.find(t => t.tag === AcDbAcisSabTag.LocationVec);
+  return vec ? (vec.value as AcDbAcisVec3) : null;
+}
+
+function curveParams(curve: AcDbAcisNode): AcDbAcisCurveParams {
+  const c = new AcDbAcisTokenCursor(curve.record.tokens);
+  if (curve.type === 'straight-curve') {
+    const origin = c.nextVec(); const direction = c.nextVec();
+    if (origin && direction) return { kind: 'straight', origin, direction };
+  } else if (curve.type === 'ellipse-curve') {
+    const center = c.nextVec(); const normal = c.nextVec(); const majorAxis = c.nextVec();
+    const ratio = c.nextDouble();
+    if (center && normal && majorAxis && ratio !== undefined) {
+      return { kind: 'ellipse', center, normal, majorAxis, ratio };
+    }
+  } else if (curve.type === 'intcurve-curve') {
+    return { kind: 'intcurve', controlPoints: intcurveControlPoints(curve.record.tokens) };
+  }
+  return { kind: 'unknown' };
+}
+
+/**
+ * Extract the `nubs`/`nurbs` B-spline control polygon from an intcurve-curve's
+ * subtype tokens. Layout (ACIS .sat): after the `nubs` entity-type come
+ * `degree`, a flag enum, `numDistinctKnots`, then `numDistinctKnots × (knot
+ * Double, multiplicity Int)`, then a run of control-point coordinate Doubles
+ * (grouped into x/y/z triples; any trailing fit-tolerance scalar is dropped).
+ */
+function intcurveControlPoints(tokens: readonly AcDbAcisSabToken[]): AcDbAcisVec3[] {
+  const nubs = tokens.findIndex(t => t.tag === AcDbAcisSabTag.EntityType && (t.value === 'nubs' || t.value === 'nurbs'));
+  if (nubs < 0) return [];
+  // numKnots is the last Int before the first Double after `nubs` (skips degree/flag).
+  let i = nubs + 1;
+  let numKnots = -1;
+  for (; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === undefined) break;
+    if (t.tag === AcDbAcisSabTag.Double) break;
+    if (t.tag === AcDbAcisSabTag.Int) numKnots = t.value as number;
+    if (t.tag === AcDbAcisSabTag.EntityType || t.tag === AcDbAcisSabTag.SubtypeEnd) return [];
+  }
+  if (numKnots < 0) return [];
+  for (let k = 0; k < numKnots; k++) {
+    if (tokens[i]?.tag !== AcDbAcisSabTag.Double) return []; // knot value
+    i += 1;
+    if (tokens[i]?.tag === AcDbAcisSabTag.Int) i += 1;       // multiplicity (optional)
+  }
+  const coords: number[] = [];
+  while (tokens[i]?.tag === AcDbAcisSabTag.Double) {
+    const token = tokens[i];
+    if (token === undefined) break;
+    coords.push(token.value as number);
+    i += 1;
+  }
+  const points: AcDbAcisVec3[] = [];
+  for (let k = 0; k + 3 <= coords.length; k += 3) {
+    const x = coords[k];
+    const y = coords[k + 1];
+    const z = coords[k + 2];
+    if (x === undefined || y === undefined || z === undefined) break;
+    points.push([x, y, z]);
+  }
+  return points;
+}
+
+function surfaceParams(surface: AcDbAcisNode): AcDbAcisSurfaceParams {
+  const c = new AcDbAcisTokenCursor(surface.record.tokens);
+  if (surface.type === 'plane-surface') {
+    const origin = c.nextVec(); const normal = c.nextVec(); const uDir = c.nextVec();
+    if (origin && normal) return uDir ? { kind: 'plane', origin, normal, uDir } : { kind: 'plane', origin, normal };
+  } else if (surface.type === 'cone-surface') {
+    const origin = c.nextVec(); const axis = c.nextVec(); const majorAxis = c.nextVec();
+    const ratio = c.nextDouble(); const sineAngle = c.nextDouble(); const cosineAngle = c.nextDouble();
+    if (origin && axis && majorAxis && ratio !== undefined && sineAngle !== undefined && cosineAngle !== undefined) {
+      return { kind: 'cone', origin, axis, majorAxis, ratio, sineAngle, cosineAngle };
+    }
+  } else if (surface.type === 'torus-surface') {
+    const center = c.nextVec(); const axis = c.nextVec();
+    const majorRadius = c.nextDouble(); const minorRadius = c.nextDouble();
+    if (center && axis && majorRadius !== undefined && minorRadius !== undefined) {
+      return { kind: 'torus', center, axis, majorRadius, minorRadius };
+    }
+  } else if (surface.type === 'sphere-surface') {
+    const center = c.nextVec();
+    const radius = c.nextDouble();
+    const uDir = c.nextVec();
+    const poleAxis = c.nextVec();
+    if (center && radius !== undefined && uDir && poleAxis) {
+      return { kind: 'sphere', center, radius, uDir, poleAxis };
+    }
+  }
+  return { kind: 'unknown' };
+}
+
+/**
+ * Parses analytic surface parameters from a `-surface` ACIS node.
+ *
+ * @param surface - Resolved surface node from an ACIS model graph.
+ * @returns Discriminated surface parameters, or `{ kind: 'unknown' }`.
+ */
+export function acDbAcisParseSurfaceParams(surface: AcDbAcisNode): AcDbAcisSurfaceParams {
+  return surfaceParams(surface);
+}
+
+const SURFACE_KIND: Record<string, AcDbAcisSurfaceKind> = {
+  'plane-surface': 'plane', 'cone-surface': 'cone', 'torus-surface': 'torus',
+  'sphere-surface': 'sphere', 'spline-surface': 'spline',
+};
+const CURVE_KIND: Record<string, AcDbAcisCurveKind> = {
+  'straight-curve': 'straight', 'ellipse-curve': 'ellipse', 'intcurve-curve': 'intcurve',
+};
+
+/** Count coedges in a loop's ring (next-coedge in wire order), guarded against cycles. */
+function loopCoedgeCount(loop: AcDbAcisNode): number {
+  const start = refOfType(loop, 'coedge');
+  if (start === null) return 0;
+  const seen = new Set<number>();
+  let coedge: AcDbAcisNode | null = start;
+  while (coedge !== null && !seen.has(coedge.index)) {
+    seen.add(coedge.index);
+    // next_coedge is the first coedge-typed ref (next, prev, partner follow in wire order).
+    coedge = refsOfType(coedge, 'coedge')[0] ?? null;
+  }
+  return seen.size;
+}
+
+/**
+ * Extract the B-rep geometry from a decoded ACIS model. Never throws; unresolved
+ * topology/geometry is reported via `diagnostics` and `'unknown'` type labels.
+ *
+ * @param model - Resolved ACIS model graph.
+ * @returns Extracted vertices, edges, faces, bounding box, and diagnostics.
+ */
+export function extractAcDbAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry {
+  const diagnostics: string[] = [];
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  const grow = (p: AcDbAcisVec3): void => {
+    if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0];
+    if (p[1] < minY) minY = p[1]; if (p[1] > maxY) maxY = p[1];
+    if (p[2] < minZ) minZ = p[2]; if (p[2] > maxZ) maxZ = p[2];
+  };
+
+  const vertices: AcDbAcisVertex[] = model.nodesOfType('vertex').map(v => {
+    const point = vertexPoint(v);
+    if (point === null) diagnostics.push(`vertex#${String(v.index)}: no resolvable point`);
+    else grow(point);
+    return { nodeIndex: v.index, point };
+  });
+
+  const edges: AcDbAcisEdge[] = model.nodesOfType('edge').map(e => {
+    const verts = refsOfType(e, 'vertex');
+    const start = vertexPoint(verts[0] ?? null);
+    const end = vertexPoint(verts[1] ?? null);
+    const curveNode = refOfType(e, '-curve');
+    const curveType: AcDbAcisCurveKind = curveNode ? (CURVE_KIND[curveNode.type] ?? 'unknown') : 'unknown';
+    const curve = curveNode ? curveParams(curveNode) : undefined;
+    if (start !== null && end !== null && start[0] === end[0] && start[1] === end[1] && start[2] === end[2]) {
+      diagnostics.push(`edge#${String(e.index)}: degenerate (coincident endpoints)`);
+    }
+    return curve === undefined || curve.kind === 'unknown'
+      ? { nodeIndex: e.index, start, end, curveType }
+      : { nodeIndex: e.index, start, end, curveType, curve };
+  });
+
+  const faces: AcDbAcisFace[] = model.nodesOfType('face').map(f => {
+    const surfaceNode = refOfType(f, '-surface');
+    const surfaceType: AcDbAcisSurfaceKind = surfaceNode ? (SURFACE_KIND[surfaceNode.type] ?? 'unknown') : 'unknown';
+    const surface = surfaceNode ? surfaceParams(surfaceNode) : undefined;
+    // Walk the next-loop chain (loop-typed ref), guarded against cycles.
+    const loops: AcDbAcisFaceLoop[] = [];
+    const seen = new Set<number>();
+    let loop = refOfType(f, 'loop');
+    while (loop !== null && !seen.has(loop.index)) {
+      seen.add(loop.index);
+      loops.push({ nodeIndex: loop.index, coedgeCount: loopCoedgeCount(loop) });
+      loop = refOfType(loop, 'loop');
+    }
+    if (surfaceNode === null) diagnostics.push(`face#${String(f.index)}: no surface`);
+    return surface === undefined || surface.kind === 'unknown'
+      ? { nodeIndex: f.index, surfaceType, loops }
+      : { nodeIndex: f.index, surfaceType, surface, loops };
+  });
+
+  const bbox: AcDbAcisBBox | null = minX === Infinity
+    ? null
+    : { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+
+  return { vertices, edges, faces, bbox, diagnostics };
+}
+
+const v3add = (a: AcDbAcisVec3, b: AcDbAcisVec3): AcDbAcisVec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+const v3mul = (a: AcDbAcisVec3, s: number): AcDbAcisVec3 => [a[0] * s, a[1] * s, a[2] * s]
+const v3len = (a: AcDbAcisVec3): number => Math.hypot(a[0], a[1], a[2])
+const v3cross = (a: AcDbAcisVec3, b: AcDbAcisVec3): AcDbAcisVec3 =>
+  [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+const v3norm = (a: AcDbAcisVec3): AcDbAcisVec3 => {
+  const length = Math.hypot(a[0], a[1], a[2])
+  return length > 0 ? [a[0] / length, a[1] / length, a[2] / length] : [0, 0, 0]
+}
+
+/**
+ * Reads the curve parameter interval carried on an `edge` record (first two doubles).
+ *
+ * @param edge - Resolved `edge` node from an ACIS model graph.
+ * @returns Parameter interval `[t0, t1]`, or `null` when unavailable.
+ */
+export function acDbAcisEdgeParamBounds(edge: AcDbAcisNode): [number, number] | null {
+  const values: number[] = []
+  for (const token of edge.record.tokens) {
+    if (token.tag === AcDbAcisSabTag.Double) {
+      values.push(token.value as number)
+      if (values.length === 2) break
+    }
+  }
+  const start = values[0]
+  const end = values[1]
+  return start === undefined || end === undefined ? null : [start, end]
+}
+
+/**
+ * Sample an ellipse-curve arc over its parameter interval.
+ *
+ * @param params - Parsed ellipse curve parameters.
+ * @param t0 - Start parameter in radians.
+ * @param t1 - End parameter in radians.
+ * @param samples - Number of interior segments (≥1).
+ * @returns Sampled points along the arc, including both endpoints.
+ */
+export function sampleAcDbAcisEllipseArc(
+  params: AcDbAcisEllipseCurveParams,
+  t0: number,
+  t1: number,
+  samples: number,
+): AcDbAcisVec3[] {
+  const minor = v3mul(v3cross(v3norm(params.normal), params.majorAxis), params.ratio)
+  const steps = Math.max(1, samples)
+  const out: AcDbAcisVec3[] = []
+  for (let i = 0; i <= steps; i++) {
+    const t = t0 + ((t1 - t0) * i) / steps
+    out.push(
+      v3add(
+        params.center,
+        v3add(
+          v3mul(params.majorAxis, Math.cos(t)),
+          v3mul(minor, Math.sin(t)),
+        ),
+      ),
+    )
+  }
+  return out
+}
+
+/**
+ * Sample wireframe circles for a sphere surface (latitude/longitude-style rings).
+ *
+ * @param params - Parsed sphere surface parameters.
+ * @param segments - Approximate number of samples per full ring (default 16).
+ * @returns Closed polylines forming a sphere wireframe scaffold.
+ */
+export function sampleAcDbAcisSphereWireframe(
+  params: AcDbAcisSphereParams,
+  segments = 16,
+): AcDbAcisVec3[][] {
+  const pole = v3norm(params.poleAxis)
+  let u = v3norm(params.uDir)
+  let v = v3cross(pole, u)
+  if (v3len(v) < 1e-9) {
+    u = Math.abs(pole[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0]
+    v = v3norm(v3cross(pole, u))
+  } else {
+    v = v3norm(v)
+  }
+  u = v3norm(v3cross(v, pole))
+
+  const rings: AcDbAcisVec3[][] = []
+  const sampleRing = (axisA: AcDbAcisVec3, axisB: AcDbAcisVec3): void => {
+    const pts: AcDbAcisVec3[] = []
+    const steps = Math.max(8, segments)
+    for (let i = 0; i <= steps; i++) {
+      const t = (Math.PI * 2 * i) / steps
+      pts.push(
+        v3add(
+          params.center,
+          v3add(
+            v3mul(axisA, params.radius * Math.cos(t)),
+            v3mul(axisB, params.radius * Math.sin(t)),
+          ),
+        ),
+      )
+    }
+    rings.push(pts)
+  }
+
+  sampleRing(u, v)
+  sampleRing(u, pole)
+  sampleRing(v, pole)
+  for (const lat of [-0.5, 0.5]) {
+    const offset = v3mul(pole, params.radius * lat)
+    const ringCenter = v3add(params.center, offset)
+    const ringRadius = params.radius * Math.sqrt(Math.max(0, 1 - lat * lat))
+    if (ringRadius > 1e-6) {
+      const pts: AcDbAcisVec3[] = []
+      const steps = Math.max(8, segments)
+      for (let i = 0; i <= steps; i++) {
+        const t = (Math.PI * 2 * i) / steps
+        pts.push(
+          v3add(
+            ringCenter,
+            v3add(
+              v3mul(u, ringRadius * Math.cos(t)),
+              v3mul(v, ringRadius * Math.sin(t)),
+            ),
+          ),
+        )
+      }
+      rings.push(pts)
+    }
+  }
+  return rings
+}

--- a/packages/data-model/src/acis/AcDbAcisSab.ts
+++ b/packages/data-model/src/acis/AcDbAcisSab.ts
@@ -1,0 +1,251 @@
+// SAB (Standard ACIS Binary) low-level decoder.
+//
+// Decodes the byte-true SAB stream produced by `extractAcisSabStream` (see
+// ../acisDecode.ts) into a typed record list: the binary tag stream → a header
+// + a list of records, each with an entity-type name and its field tokens.
+// This is the foundation for the B-rep entity DAG (./AcDbAcisEntities.ts).
+//
+// The tag/byte layout is ported from ezdxf's `ezdxf/acis/sab.py`
+// (Copyright (c) Manfred Moitzi, MIT License) — the SAB byte format itself is
+// not copyrightable; the field-width conventions follow that reference.
+
+const SIGNATURES = ['ACIS BinaryFile', 'ASM BinaryFile4'] as const;
+const DATA_END_MARKERS = new Set([
+  'End-of-ACIS-data',
+  'End-of-ASM-data',
+  'End-of-ACIS-History-data',
+]);
+
+/**
+ * SAB tag bytes (ezdxf `Tags`).
+ * Each tag identifies the type of the next value in a SAB record stream.
+ */
+export const AcDbAcisSabTag = {
+  NoType: 0x00, Byte: 0x01, Char: 0x02, Short: 0x03, Int: 0x04, Float: 0x05,
+  Double: 0x06, Str: 0x07, Str2: 0x08, Str3: 0x09, BoolTrue: 0x0a,
+  BoolFalse: 0x0b, Pointer: 0x0c, EntityType: 0x0d, EntityTypeEx: 0x0e,
+  SubtypeStart: 0x0f, SubtypeEnd: 0x10, RecordEnd: 0x11, LiteralStr: 0x12,
+  LocationVec: 0x13, DirectionVec: 0x14, Enum: 0x15, Unknown0x17: 0x17,
+} as const;
+
+/** A 3D vector tuple `[x, y, z]` as stored in SAB location/direction tags. */
+export type AcDbAcisSabVector = readonly [number, number, number];
+
+/** Possible decoded values for a single SAB field token. */
+export type AcDbAcisSabTokenValue = number | boolean | string | AcDbAcisSabVector;
+
+/**
+ * One decoded field token from a SAB record stream.
+ */
+export interface AcDbAcisSabToken {
+  /** SAB tag byte identifying the value type. */
+  readonly tag: number;
+  /** Decoded field value. */
+  readonly value: AcDbAcisSabTokenValue;
+}
+
+/**
+ * One ACIS entity record from a SAB stream.
+ */
+export interface AcDbAcisSabRecord {
+  /** Record identity = the first entity-type, e.g. `"body"`, `"plane-surface"`. */
+  readonly type: string;
+  /**
+   * All field tokens in wire order, including entity-type tokens (the first is
+   * the record identity; later ones name nested subtypes, e.g. an
+   * `intcurve-curve`'s `nullbs` geometry).
+   */
+  readonly tokens: readonly AcDbAcisSabToken[];
+}
+
+/**
+ * Header metadata parsed from the start of a SAB stream.
+ */
+export interface AcDbAcisSabHeader {
+  /** File signature, e.g. `"ACIS BinaryFile"` or `"ASM BinaryFile4"`. */
+  readonly signature: string;
+  /** SAB format version number. */
+  readonly version: number;
+  /** Total record count declared in the header. */
+  readonly numRecords: number;
+  /** Entity count declared in the header. */
+  readonly numEntities: number;
+  /** Header flags bitmask. */
+  readonly flags: number;
+  /** Product identifier string. */
+  readonly productId: string;
+  /** ACIS kernel version string. */
+  readonly acisVersion: string;
+  /** Creation timestamp string from the SAB header. */
+  readonly creationDate: string;
+  /** Model units expressed in millimeters. */
+  readonly unitsInMm: number;
+  /** Resolution tolerance from the SAB header. */
+  readonly resTol: number;
+  /** Normal tolerance from the SAB header. */
+  readonly norTol: number;
+}
+
+/**
+ * Fully parsed SAB payload: file header plus the ordered record list.
+ */
+export interface AcDbAcisSabData {
+  /** Parsed SAB file header. */
+  readonly header: AcDbAcisSabHeader;
+  /** Ordered list of decoded entity records. */
+  readonly records: readonly AcDbAcisSabRecord[];
+}
+
+/** Sequential byte reader for low-level SAB decoding. */
+class AcDbAcisSabByteReader {
+  index = 0;
+  private readonly view: DataView;
+  constructor(private readonly data: Uint8Array) {
+    this.view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  }
+  get hasData(): boolean { return this.index < this.data.length; }
+  private require(n: number): void {
+    if (this.index + n > this.data.length) {
+      throw new RangeError(`SAB: read past end of data (need ${String(n)} at ${String(this.index)})`);
+    }
+  }
+  readByte(): number {
+    this.require(1);
+    return this.data[this.index++] ?? 0;
+  }
+  readInt(): number {
+    this.require(4);
+    const v = this.view.getInt32(this.index, true);
+    this.index += 4;
+    return v;
+  }
+  readFloat(): number {
+    this.require(8);
+    const v = this.view.getFloat64(this.index, true);
+    this.index += 8;
+    return v;
+  }
+  readStr(length: number): string {
+    this.require(length);
+    const text = LATIN1.decode(this.data.subarray(this.index, this.index + length));
+    this.index += length;
+    return text;
+  }
+}
+
+const LATIN1 = new TextDecoder('latin1');
+
+function readHeader(r: AcDbAcisSabByteReader, data: Uint8Array): AcDbAcisSabHeader {
+  let signature = '';
+  for (const sig of SIGNATURES) {
+    if (startsWithAscii(data, sig)) { signature = sig; r.index = sig.length; break; }
+  }
+  if (signature === '') throw new RangeError('SAB: not a SAB stream (missing signature)');
+
+  const version = r.readInt();
+  const numRecords = r.readInt();
+  const numEntities = r.readInt();
+  const flags = r.readInt();
+  const productId = readStrTag(r);
+  const acisVersion = readStrTag(r);
+  const creationDate = readStrTag(r);
+  const unitsInMm = readDoubleTag(r);
+  const resTol = readDoubleTag(r);
+  const norTol = readDoubleTag(r);
+  return {
+    signature, version, numRecords, numEntities, flags,
+    productId, acisVersion, creationDate, unitsInMm, resTol, norTol,
+  };
+}
+
+function readStrTag(r: AcDbAcisSabByteReader): string {
+  if (r.readByte() !== AcDbAcisSabTag.Str) throw new RangeError('SAB: expected string tag (0x07)');
+  return r.readStr(r.readByte());
+}
+
+function readDoubleTag(r: AcDbAcisSabByteReader): number {
+  if (r.readByte() !== AcDbAcisSabTag.Double) throw new RangeError('SAB: expected double tag (0x06)');
+  return r.readFloat();
+}
+
+/**
+ * Read one record (tokens up to RECORD_END, or the data-end marker at stream
+ * end). Mirrors ezdxf `Decoder.read_record`: the entity-type name is assembled
+ * from one or more ENTITY_TYPE_EX parts plus a final ENTITY_TYPE, joined by `-`.
+ */
+function readRecord(r: AcDbAcisSabByteReader): AcDbAcisSabRecord {
+  const tokens: AcDbAcisSabToken[] = [];
+  const typeParts: string[] = [];
+  let type = '';
+  let subtypeLevel = 0;
+
+  for (;;) {
+    if (!r.hasData) {
+      if (DATA_END_MARKERS.has(type)) return { type, tokens };
+      throw new RangeError('SAB: premature end of data');
+    }
+    const tag = r.readByte();
+    switch (tag) {
+      case AcDbAcisSabTag.Int: tokens.push({ tag, value: r.readInt() }); break;
+      case AcDbAcisSabTag.Double: tokens.push({ tag, value: r.readFloat() }); break;
+      case AcDbAcisSabTag.Str: tokens.push({ tag, value: r.readStr(r.readByte()) }); break;
+      case AcDbAcisSabTag.Pointer: tokens.push({ tag, value: r.readInt() }); break;
+      case AcDbAcisSabTag.BoolTrue: tokens.push({ tag, value: true }); break;
+      case AcDbAcisSabTag.BoolFalse: tokens.push({ tag, value: false }); break;
+      case AcDbAcisSabTag.LiteralStr: tokens.push({ tag, value: r.readStr(r.readInt()) }); break;
+      case AcDbAcisSabTag.EntityTypeEx: typeParts.push(r.readStr(r.readByte())); break;
+      case AcDbAcisSabTag.EntityType: {
+        typeParts.push(r.readStr(r.readByte()));
+        const name = typeParts.join('-');
+        typeParts.length = 0;
+        // The record's identity is the FIRST entity-type. Later ENTITY_TYPE
+        // tokens belong to nested subtypes (e.g. an intcurve-curve's `nullbs`
+        // geometry) — keep them as tokens, don't overwrite the record type.
+        if (type === '') type = name;
+        tokens.push({ tag, value: name });
+        break;
+      }
+      case AcDbAcisSabTag.LocationVec: tokens.push({ tag, value: readVec(r) }); break;
+      case AcDbAcisSabTag.DirectionVec: tokens.push({ tag, value: readVec(r) }); break;
+      case AcDbAcisSabTag.Enum: tokens.push({ tag, value: r.readInt() }); break;
+      case AcDbAcisSabTag.Unknown0x17: tokens.push({ tag, value: r.readFloat() }); break;
+      case AcDbAcisSabTag.SubtypeStart: subtypeLevel++; tokens.push({ tag, value: subtypeLevel }); break;
+      case AcDbAcisSabTag.SubtypeEnd: tokens.push({ tag, value: subtypeLevel }); subtypeLevel--; break;
+      case AcDbAcisSabTag.RecordEnd: return { type, tokens };
+      default:
+        throw new RangeError(`SAB: unknown tag 0x${tag.toString(16)} (${String(tag)}) in record '${type}'`);
+    }
+  }
+}
+
+function readVec(r: AcDbAcisSabByteReader): AcDbAcisSabVector {
+  return [r.readFloat(), r.readFloat(), r.readFloat()];
+}
+
+/**
+ * Decode a byte-true SAB stream into a header + record list. Reading stops at
+ * the `End-of-(ACIS|ASM)-data` record (inclusive) or when the data is exhausted.
+ *
+ * @param data - Raw SAB byte stream starting at (or containing) a known signature.
+ * @returns Parsed header and records.
+ * @throws `RangeError` on a malformed or truncated stream.
+ */
+export function parseAcDbAcisSab(data: Uint8Array): AcDbAcisSabData {
+  const r = new AcDbAcisSabByteReader(data);
+  const header = readHeader(r, data);
+  const records: AcDbAcisSabRecord[] = [];
+  while (r.hasData) {
+    const record = readRecord(r);
+    records.push(record);
+    if (DATA_END_MARKERS.has(record.type)) break;
+  }
+  return { header, records };
+}
+
+function startsWithAscii(data: Uint8Array, prefix: string): boolean {
+  if (data.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (data[i] !== prefix.charCodeAt(i)) return false;
+  }
+  return true;
+}

--- a/packages/data-model/src/acis/AcDbAcisSatWireframe.ts
+++ b/packages/data-model/src/acis/AcDbAcisSatWireframe.ts
@@ -1,0 +1,126 @@
+/**
+ * Best-effort wireframe extraction from SAT/ASM text (non-SAB) payloads.
+ * Used when ACSH history provides inline text rather than ACDSDATA binary.
+ */
+
+import {
+  type AcDbAcisEllipseCurveParams,
+  type AcDbAcisVec3,
+  sampleAcDbAcisEllipseArc,
+} from './AcDbAcisGeometry'
+
+const DEFAULT_ELLIPSE_SAMPLES = 16
+
+/**
+ * Reads numeric tokens from one SAT record, skipping pointers and sentinel tokens.
+ *
+ * @param record - One SAT entity record line.
+ * @param skipLeadingIndex - When true, skip the leading record index token.
+ */
+function readSatNumericTokens(record: string, skipLeadingIndex = true): number[] {
+  const parts = record.split(/\s+/)
+  const values: number[] = []
+  let skippedIndex = !skipLeadingIndex
+  for (const part of parts) {
+    if (!skippedIndex && /^-?\d+$/.test(part)) {
+      skippedIndex = true
+      continue
+    }
+    if (part.startsWith('$') || part === 'I' || part === 'F' || part === '#') {
+      continue
+    }
+    const value = Number.parseFloat(part)
+    if (Number.isFinite(value)) {
+      values.push(value)
+    }
+  }
+  return values
+}
+
+/** Appends one line segment (`a` → `b`) to a flat coordinate buffer. */
+function pushSegment(
+  segments: number[],
+  a: AcDbAcisVec3,
+  b: AcDbAcisVec3,
+): void {
+  segments.push(a[0], a[1], a[2], b[0], b[1], b[2])
+}
+
+/** Splits SAT text into individual `#`-delimited entity records. */
+function splitSatRecords(satText: string): string[] {
+  return satText
+    .split('#')
+    .map(record => record.trim())
+    .filter(record => record.length > 0)
+}
+
+/** Parses a `straight-curve` SAT record into start/end segment endpoints. */
+function parseStraightCurve(record: string): [AcDbAcisVec3, AcDbAcisVec3] | null {
+  if (!record.includes('straight-curve')) {
+    return null
+  }
+  const values = readSatNumericTokens(record)
+  if (values.length < 6) {
+    return null
+  }
+  const ox = values[0]!
+  const oy = values[1]!
+  const oz = values[2]!
+  const dx = values[3]!
+  const dy = values[4]!
+  const dz = values[5]!
+  return [
+    [ox, oy, oz],
+    [ox + dx, oy + dy, oz + dz],
+  ]
+}
+
+/** Parses an `ellipse-curve` SAT record into analytic curve parameters. */
+function parseEllipseCurve(record: string): AcDbAcisEllipseCurveParams | null {
+  if (!record.includes('ellipse-curve')) {
+    return null
+  }
+  const values = readSatNumericTokens(record)
+  if (values.length < 10) {
+    return null
+  }
+  return {
+    kind: 'ellipse',
+    center: [values[0]!, values[1]!, values[2]!],
+    normal: [values[3]!, values[4]!, values[5]!],
+    majorAxis: [values[6]!, values[7]!, values[8]!],
+    ratio: values[9]!,
+  }
+}
+
+/**
+ * Extract wireframe segments from a SAT text stream by matching common curve
+ * records. This is a fallback when SAB decoding is unavailable.
+ *
+ * @param satText - Plain SAT/ASM text payload.
+ * @returns Flat `Float32Array` of line-segment endpoint pairs (`[x,y,z,x,y,z,...]`).
+ */
+export function acDbAcisWireframeSegmentsFromSatText(satText: string): Float32Array {
+  const segments: number[] = []
+  if (!satText || satText.trim().length === 0) {
+    return new Float32Array(0)
+  }
+
+  for (const record of splitSatRecords(satText)) {
+    const straight = parseStraightCurve(record)
+    if (straight !== null) {
+      pushSegment(segments, straight[0], straight[1])
+      continue
+    }
+
+    const ellipse = parseEllipseCurve(record)
+    if (ellipse !== null) {
+      const arc = sampleAcDbAcisEllipseArc(ellipse, 0, Math.PI * 2, DEFAULT_ELLIPSE_SAMPLES)
+      for (let i = 1; i < arc.length; i++) {
+        pushSegment(segments, arc[i - 1]!, arc[i]!)
+      }
+    }
+  }
+
+  return new Float32Array(segments)
+}

--- a/packages/data-model/src/acis/AcDbAcisWireframe.ts
+++ b/packages/data-model/src/acis/AcDbAcisWireframe.ts
@@ -1,0 +1,117 @@
+import { decodeAcDbAcisModel } from './AcDbAcisDecode'
+import type { AcDbAcisModel, AcDbAcisNode } from './AcDbAcisEntities'
+import {
+  acDbAcisEdgeParamBounds,
+  type AcDbAcisGeometry,
+  acDbAcisParseSurfaceParams,
+  type AcDbAcisVec3,
+  extractAcDbAcisGeometry,
+  sampleAcDbAcisEllipseArc,
+  sampleAcDbAcisSphereWireframe,
+} from './AcDbAcisGeometry'
+
+/** Default number of samples when tessellating ellipse edges for wireframe output. */
+const DEFAULT_ELLIPSE_SAMPLES = 16
+
+const refOfType = (node: AcDbAcisNode, suffix: string): AcDbAcisNode | null =>
+  node.refs.find(r => r !== null && (r.type === suffix || r.type.endsWith(suffix))) ?? null
+
+/** Appends one line segment (`a` → `b`) to a flat coordinate buffer. */
+function pushSegment(segments: number[], a: AcDbAcisVec3, b: AcDbAcisVec3): void {
+  segments.push(a[0], a[1], a[2], b[0], b[1], b[2])
+}
+
+/** Appends consecutive point pairs from `points` as line segments. */
+function pushPolyline(segments: number[], points: readonly AcDbAcisVec3[]): void {
+  for (let i = 0; i + 1 < points.length; i++) {
+    const a = points[i]
+    const b = points[i + 1]
+    if (a && b) pushSegment(segments, a, b)
+  }
+}
+
+/**
+ * Builds wireframe rings for sphere faces when edge-based wireframe is empty.
+ *
+ * @param model - Resolved ACIS model graph.
+ * @returns Line-segment endpoint pairs for sphere surface scaffolds.
+ */
+function acdbAcisWireframeSegmentsFromSphereFaces(model: AcDbAcisModel): Float32Array {
+  const segments: number[] = []
+  for (const face of model.nodesOfType('face')) {
+    const surfaceNode = refOfType(face, '-surface')
+    if (surfaceNode?.type !== 'sphere-surface') continue
+    const params = acDbAcisParseSurfaceParams(surfaceNode)
+    if (params.kind !== 'sphere') continue
+    for (const ring of sampleAcDbAcisSphereWireframe(params)) {
+      pushPolyline(segments, ring)
+    }
+  }
+  return new Float32Array(segments)
+}
+
+/**
+ * Converts extracted ACIS B-rep geometry into line-segment endpoint pairs
+ * suitable for {@link AcGiRenderer.lineSegments}.
+ *
+ * @param geometry - Geometry extracted from a decoded ACIS model.
+ * @param model - Optional source model used to read edge parameter bounds.
+ * @returns Flat `Float32Array` of segment endpoint pairs.
+ */
+export function acdbAcisWireframeSegmentsFromGeometry(
+  geometry: AcDbAcisGeometry,
+  model?: AcDbAcisModel,
+): Float32Array {
+  const segments: number[] = []
+
+  for (const edge of geometry.edges) {
+    const edgeNode = model?.nodes[edge.nodeIndex]
+
+    if (edge.curve?.kind === 'ellipse') {
+      const bounds =
+        edgeNode !== undefined ? acDbAcisEdgeParamBounds(edgeNode) : null
+      const t0 = bounds?.[0] ?? 0
+      const t1 = bounds?.[1] ?? Math.PI * 2
+      pushPolyline(
+        segments,
+        sampleAcDbAcisEllipseArc(edge.curve, t0, t1, DEFAULT_ELLIPSE_SAMPLES),
+      )
+      continue
+    }
+
+    if (
+      edge.curve?.kind === 'intcurve' &&
+      edge.curve.controlPoints.length > 0
+    ) {
+      pushPolyline(segments, edge.curve.controlPoints)
+      continue
+    }
+
+    if (edge.start && edge.end) {
+      pushSegment(segments, edge.start, edge.end)
+    }
+  }
+
+  return new Float32Array(segments)
+}
+
+/**
+ * Decodes a SAB byte stream and returns wireframe line segments, or `null`
+ * when decoding fails or no drawable geometry is present.
+ *
+ * @param sabBytes - Raw SAB/ASM binary payload.
+ * @returns Wireframe segment buffer, or `null` when nothing drawable is found.
+ */
+export function acdbAcisWireframeSegmentsFromSab(
+  sabBytes: Uint8Array,
+): Float32Array | null {
+  const model = decodeAcDbAcisModel(sabBytes)
+  if (model === null) return null
+  const geometry = extractAcDbAcisGeometry(model)
+  const edgeWireframe = acdbAcisWireframeSegmentsFromGeometry(geometry, model)
+  if (edgeWireframe.length > 0) {
+    return edgeWireframe
+  }
+  const sphereWireframe = acdbAcisWireframeSegmentsFromSphereFaces(model)
+  return sphereWireframe.length > 0 ? sphereWireframe : null
+}

--- a/packages/data-model/src/acis/index.ts
+++ b/packages/data-model/src/acis/index.ts
@@ -1,0 +1,57 @@
+/**
+ * ACIS/ASM geometry decoding, B-rep extraction, and wireframe helpers.
+ *
+ * @packageDocumentation
+ */
+export { parseAcDbAcisSab, AcDbAcisSabTag } from './AcDbAcisSab'
+export type {
+  AcDbAcisSabData,
+  AcDbAcisSabHeader,
+  AcDbAcisSabRecord,
+  AcDbAcisSabToken,
+  AcDbAcisSabTokenValue,
+  AcDbAcisSabVector,
+} from './AcDbAcisSab'
+export { buildAcDbAcisModel } from './AcDbAcisEntities'
+export type { AcDbAcisModel, AcDbAcisNode } from './AcDbAcisEntities'
+export {
+  decodeAcDbAcisModel,
+  findAcDbAcisSabSignatureOffset,
+  isAcDbAcisSabPayload,
+} from './AcDbAcisDecode'
+export {
+  acDbAcisEdgeParamBounds,
+  acDbAcisParseSurfaceParams,
+  extractAcDbAcisGeometry,
+  sampleAcDbAcisEllipseArc,
+  sampleAcDbAcisSphereWireframe,
+} from './AcDbAcisGeometry'
+export type {
+  AcDbAcisBBox,
+  AcDbAcisConeParams,
+  AcDbAcisCurveKind,
+  AcDbAcisCurveParams,
+  AcDbAcisEdge,
+  AcDbAcisEllipseCurveParams,
+  AcDbAcisFace,
+  AcDbAcisFaceLoop,
+  AcDbAcisGeometry,
+  AcDbAcisGeometrySummary,
+  AcDbAcisIntCurveParams,
+  AcDbAcisMesh,
+  AcDbAcisPlaneParams,
+  AcDbAcisSphereParams,
+  AcDbAcisStraightCurveParams,
+  AcDbAcisSurfaceKind,
+  AcDbAcisSurfaceParams,
+  AcDbAcisTessellationOptions,
+  AcDbAcisTorusParams,
+  AcDbAcisTriangleMesh,
+  AcDbAcisVec3,
+  AcDbAcisVertex,
+} from './AcDbAcisGeometry'
+export {
+  acdbAcisWireframeSegmentsFromGeometry as acDbAcisWireframeSegmentsFromGeometry,
+  acdbAcisWireframeSegmentsFromSab as acDbAcisWireframeSegmentsFromSab,
+} from './AcDbAcisWireframe'
+export { acDbAcisWireframeSegmentsFromSatText } from './AcDbAcisSatWireframe'

--- a/packages/data-model/src/entity/AcDb3dSolid.ts
+++ b/packages/data-model/src/entity/AcDb3dSolid.ts
@@ -5,19 +5,64 @@ import {
 } from '@mlightcad/geometry-engine'
 import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
+import {
+  acDbAcisWireframeSegmentsFromSab,
+  acDbAcisWireframeSegmentsFromSatText
+} from '../acis'
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbEntity } from './AcDbEntity'
 
 /**
- * Matches every `point` record in an ACIS SAT text stream, e.g.
- * `point $-1 10 0 -10 #`. The `point` record format (attribute pointer
- * followed by x/y/z) has been stable across ACIS SAT versions, unlike the
- * topology records (`face`/`loop`/`coedge`/`edge`), whose field layout and
- * count vary by surface/curve type and ACIS version. Extracting every point
- * this way, independent of the body's topology, is a format detail that's
- * safe to rely on regardless of which faces/edges reference it.
+ * Construction options for {@link AcDb3dSolid} when geometry is supplied as
+ * binary SAB and/or plain SAT/ASM text rather than a single string argument.
  */
-const ACIS_POINT_RECORD = /\bpoint\s+\$-?\d+\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)/g
+export interface AcDb3dSolidOptions {
+  /** Binary SAB payload from ACDSDATA or inline modeler geometry. */
+  sabBytes?: Uint8Array
+  /** Plain SAT/ASM text from inline groups 1/3 or ACSH BREP. */
+  satText?: string
+  /** Legacy alias for {@link satText}. */
+  acisData?: string
+  /** DXF group 70 ACIS version number, when present. */
+  version?: number
+}
+
+/**
+ * Matches classic SAT `point` records (`point $-1 x y z`) and ASM-style records
+ * with additional pointer fields (`point $-1 -1 $-1 x y z`).
+ */
+const ACIS_POINT_RECORD =
+  /\bpoint\s+(?:\$-?\d+\s+){1,4}([-\d.eE+]+)\s+([-\d.eE+]+)\s+([-\d.eE+]+)/g
+
+/** Splits SAT text into individual `#`-delimited entity records. */
+function splitAcisRecords(acisData: string): string[] {
+  return acisData
+    .split('#')
+    .map(record => record.trim())
+    .filter(record => record.length > 0)
+}
+
+/**
+ * Reads numeric tokens from one SAT record, skipping pointer and sentinel tokens.
+ *
+ * @param record - One SAT entity record line.
+ * @param skip - Number of leading tokens to skip before scanning (default 1).
+ */
+function readNumericTokens(record: string, skip = 1): number[] {
+  const parts = record.split(/\s+/)
+  const values: number[] = []
+  for (let i = skip; i < parts.length; i++) {
+    const token = parts[i]!
+    if (token.startsWith('$') || token === 'I' || token === 'F') {
+      continue
+    }
+    const value = Number.parseFloat(token)
+    if (Number.isFinite(value)) {
+      values.push(value)
+    }
+  }
+  return values
+}
 
 /**
  * Extracts every vertex position referenced by `point` records in an ACIS
@@ -26,37 +71,82 @@ const ACIS_POINT_RECORD = /\bpoint\s+\$-?\d+\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)/g
  * @param acisData - Raw ACIS SAT text (the concatenated group 1/3 lines of a
  * DXF `3DSOLID`/`REGION`/`BODY` entity).
  * @returns Every point found, in file order. Empty when `acisData` doesn't
- * contain any recognizable `point` records (e.g. binary ASM/SAB data).
+ * contain any recognizable `point` records.
  */
 function extractAcisPointCloud(acisData: string): AcGePoint3d[] {
   const points: AcGePoint3d[] = []
   for (const match of acisData.matchAll(ACIS_POINT_RECORD)) {
-    const x = Number.parseFloat(match[1])
-    const y = Number.parseFloat(match[2])
-    const z = Number.parseFloat(match[3])
+    const x = Number.parseFloat(match[1]!)
+    const y = Number.parseFloat(match[2]!)
+    const z = Number.parseFloat(match[3]!)
     if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
+      points.push(new AcGePoint3d(x, y, z))
+    }
+  }
+
+  if (points.length > 0) {
+    return points
+  }
+
+  for (const record of splitAcisRecords(acisData)) {
+    if (!record.startsWith('point ')) {
+      continue
+    }
+    const values = readNumericTokens(record)
+    if (values.length >= 3) {
+      const x = values[values.length - 3]!
+      const y = values[values.length - 2]!
+      const z = values[values.length - 1]!
       points.push(new AcGePoint3d(x, y, z))
     }
   }
   return points
 }
 
+/** Collects unique segment endpoints from a wireframe buffer (`[x,y,z,...]`). */
+function pointsFromWireframe(wireframe: Float32Array): AcGePoint3d[] {
+  const points: AcGePoint3d[] = []
+  for (let i = 0; i < wireframe.length; i += 3) {
+    const x = wireframe[i]!
+    const y = wireframe[i + 1]!
+    const z = wireframe[i + 2]!
+    points.push(new AcGePoint3d(x, y, z))
+  }
+  return points
+}
+
+/**
+ * Normalizes constructor input into SAB bytes, SAT text, and version fields.
+ *
+ * @param input - Raw SAT string or {@link AcDb3dSolidOptions}.
+ * @param version - DXF group 70 version used when `input` is a string.
+ */
+function resolveSolidPayload(
+  input: string | AcDb3dSolidOptions,
+  version?: number,
+): {
+  sabBytes?: Uint8Array
+  satText: string
+  version?: number
+} {
+  if (typeof input === 'string') {
+    return { satText: input, version }
+  }
+  return {
+    sabBytes: input.sabBytes,
+    satText: input.satText ?? input.acisData ?? '',
+    version: input.version ?? version,
+  }
+}
+
 /**
  * Represents a 3D solid (ACIS/ASM B-rep) entity, such as those created by
  * AutoCAD's BOX, WEDGE, EXTRUDE, or boolean solid-modeling commands.
  *
- * Full B-rep tessellation (rendering the solid's actual trimmed
- * NURBS/planar faces) is not yet supported — that requires implementing (or
- * embedding) a real ACIS/ASM geometry kernel, which is out of scope here.
- *
- * Instead, this renders a wireframe bounding box derived from every vertex
- * position embedded in the entity's raw ACIS SAT data, so the solid is at
- * least visible at its correct location and approximate size rather than
- * silently missing from the drawing. The `point` record format is stable
- * across ACIS SAT versions and independent of the (much more variable)
- * topology record layouts, which is why this approach works without a full
- * B-rep parser. When `acisData` holds binary ASM/SAB data instead of SAT
- * text (common in DWG 2013+), no points are found and this renders nothing.
+ * Full B-rep tessellation is not yet supported. When binary SAB or SAT text is
+ * available, this entity renders a best-effort wireframe derived from decoded
+ * edges and curves; otherwise it falls back to a bounding-box wireframe built
+ * from embedded `point` records in the SAT stream.
  */
 export class AcDb3dSolid extends AcDbEntity {
   /** The entity type name */
@@ -66,29 +156,55 @@ export class AcDb3dSolid extends AcDbEntity {
     return '3DSOLID'
   }
 
-  /** Raw ACIS SAT text (or ASM/SAB binary payload) for this solid. */
+  /** Raw ACIS SAT text preserved for DXF round-trip and future B-rep parsing. */
   private _acisData: string
   /** DXF group 70 ACIS version number, when present. */
   private _version?: number
-  /** Vertex positions extracted from `point` records in {@link _acisData}. */
+  /** Vertex positions used for extents and fallback bounding-box rendering. */
   private _points: AcGePoint3d[]
+  /** Line-segment endpoint pairs for wireframe rendering (`[x,y,z,...]`). */
+  private _wireframe: Float32Array
 
   /**
    * Creates a new 3D solid entity from raw ACIS data.
    *
-   * @param acisData - Raw ACIS SAT text (group 1/3 lines) or ASM/SAB binary payload.
+   * @param acisData - Raw ACIS SAT text (group 1/3 lines).
    * @param version - DXF group 70 ACIS version number, when present.
    */
-  constructor(acisData: string, version?: number) {
+  constructor(acisData: string, version?: number)
+  /**
+   * Creates a new 3D solid entity from binary SAB and/or SAT text payloads.
+   *
+   * @param options - Construction options with optional SAB bytes and SAT text.
+   */
+  constructor(options: AcDb3dSolidOptions)
+  constructor(
+    acisDataOrOptions: string | AcDb3dSolidOptions,
+    version?: number,
+  ) {
     super()
-    this._acisData = acisData
-    this._version = version
-    this._points = extractAcisPointCloud(acisData)
+    const payload = resolveSolidPayload(acisDataOrOptions, version)
+    this._acisData = payload.satText
+    this._version = payload.version
+
+    let wireframe = new Float32Array(0)
+    if (payload.sabBytes && payload.sabBytes.length > 0) {
+      wireframe = acDbAcisWireframeSegmentsFromSab(payload.sabBytes) ?? new Float32Array(0)
+    }
+    if (wireframe.length === 0 && payload.satText) {
+      wireframe = acDbAcisWireframeSegmentsFromSatText(payload.satText)
+    }
+    this._wireframe = wireframe
+
+    if (wireframe.length > 0) {
+      this._points = pointsFromWireframe(wireframe)
+    } else {
+      this._points = extractAcisPointCloud(payload.satText)
+    }
   }
 
   /**
-   * Raw ACIS SAT text (or ASM/SAB binary payload) for this solid, preserved
-   * for future full B-rep parsing support.
+   * Raw ACIS SAT text for this solid, preserved for future full B-rep parsing.
    */
   get acisData(): string {
     return this._acisData
@@ -100,11 +216,11 @@ export class AcDb3dSolid extends AcDbEntity {
   }
 
   /**
-   * Whether any vertex positions could be extracted from {@link acisData}.
-   * False when the data is binary (ASM/SAB) rather than SAT text.
+   * Whether wireframe segments or fallback point data could be extracted from
+   * the supplied SAB/SAT payload.
    */
   get hasRenderableGeometry(): boolean {
-    return this._points.length > 0
+    return this._wireframe.length > 0 || this._points.length > 0
   }
 
   /** @inheritdoc */
@@ -116,28 +232,55 @@ export class AcDb3dSolid extends AcDbEntity {
   }
 
   /**
-   * Transforms this solid by the specified matrix.
+   * Transforms the extracted wireframe and point cloud by the specified matrix.
    *
-   * Only the extracted point cloud (and thus the wireframe bounding box) is
-   * transformed; {@link acisData} itself is left untouched since it isn't
-   * fully parsed.
+   * {@link acisData} itself is left untouched since it isn't fully parsed.
+   *
+   * @param matrix - 4×4 transformation matrix.
+   * @returns This instance (for chaining).
    */
   transformBy(matrix: AcGeMatrix3d) {
     this._points.forEach(point => point.applyMatrix4(matrix))
+    if (this._wireframe.length > 0) {
+      const transformed = new Float32Array(this._wireframe.length)
+      for (let i = 0; i < this._wireframe.length; i += 3) {
+        const point = new AcGePoint3d(
+          this._wireframe[i]!,
+          this._wireframe[i + 1]!,
+          this._wireframe[i + 2]!,
+        )
+        point.applyMatrix4(matrix)
+        transformed[i] = point.x
+        transformed[i + 1] = point.y
+        transformed[i + 2] = point.z
+      }
+      this._wireframe = transformed
+    }
     return this
   }
 
   /**
-   * Draws a wireframe bounding box around the solid's extracted point cloud.
+   * Draws decoded wireframe segments when available; otherwise draws a bounding
+   * box around extracted `point` records.
    *
-   * @param renderer - The renderer to use for drawing
-   * @returns The rendered wireframe entity, or `undefined` when no points
-   * could be extracted from {@link acisData}.
+   * @param renderer - The renderer to use for drawing.
+   * @returns The rendered wireframe entity, or `undefined` when no geometry
+   * could be extracted.
    */
   subWorldDraw(renderer: AcGiRenderer) {
+    if (this._wireframe.length >= 6) {
+      const vertexCount = this._wireframe.length / 3
+      const indices = new Uint16Array(vertexCount)
+      for (let i = 0; i < vertexCount; i++) {
+        indices[i] = i
+      }
+      return renderer.lineSegments(this._wireframe, 3, indices)
+    }
+
     if (this._points.length === 0) {
       return undefined
     }
+
     const box = this.geometricExtents
     const min = box.min
     const max = box.max
@@ -157,11 +300,10 @@ export class AcDb3dSolid extends AcDbEntity {
       buffer[i * 3 + 1] = corner.y
       buffer[i * 3 + 2] = corner.z
     })
-    // 12 edges of a box, referencing the 8 corners above.
     const indices = new Uint16Array([
-      0, 1, 1, 2, 2, 3, 3, 0, // bottom face
-      4, 5, 5, 6, 6, 7, 7, 4, // top face
-      0, 4, 1, 5, 2, 6, 3, 7 // vertical edges
+      0, 1, 1, 2, 2, 3, 3, 0,
+      4, 5, 5, 6, 6, 7, 7, 4,
+      0, 4, 1, 5, 2, 6, 3, 7
     ])
     return renderer.lineSegments(buffer, 3, indices)
   }
@@ -178,13 +320,11 @@ export class AcDb3dSolid extends AcDbEntity {
     if (this._version != null) {
       filer.writeInt16(70, this._version)
     }
-    // ACIS text is written as chunked group-3 continuation lines (max 255
-    // chars each per the DXF spec), terminated by a final group-1 line.
     const maxChunkLength = 255
     const lines = this._acisData.split('\n')
     for (let i = 0; i < lines.length; i++) {
       const isLast = i === lines.length - 1
-      let line = lines[i]
+      let line = lines[i]!
       while (line.length > maxChunkLength) {
         filer.writeString(3, line.slice(0, maxChunkLength))
         line = line.slice(maxChunkLength)

--- a/packages/data-model/src/entity/index.ts
+++ b/packages/data-model/src/entity/index.ts
@@ -1,7 +1,7 @@
 export { AcDb2dPolyline, AcDbPoly2dType } from './AcDb2dPolyline'
 export { AcDb2dVertex, AcDb2dVertexType } from './AcDb2dVertex'
 export { AcDb3dPolyline, AcDbPoly3dType } from './AcDb3dPolyline'
-export { AcDb3dSolid } from './AcDb3dSolid'
+export { AcDb3dSolid, type AcDb3dSolidOptions } from './AcDb3dSolid'
 export { AcDb3dVertex, AcDb3dVertexType } from './AcDb3dVertex'
 export { AcDbArc } from './AcDbArc'
 export { AcDbAttribute } from './AcDbAttribute'

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@mlightcad/data-model'
 
 import { AcDbEntityConverter } from '../src/AcDbEntitiyConverter'
+import type { DxfObjectByHandle } from '../src/Acsh3dSolidResolver'
 
 describe('AcDbEntityConverter', () => {
   it('returns null for unsupported type', () => {
@@ -493,5 +494,43 @@ describe('AcDbEntityConverter', () => {
 
     expect(result).toBeInstanceOf(AcDb3dSolid)
     expect((result as AcDb3dSolid).hasRenderableGeometry).toBe(false)
+  })
+
+  it('resolves 3DSOLID via ACSH history when inline ACIS data is absent', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const objectByHandle: DxfObjectByHandle = {
+      '157': {
+        name: 'ACSH_HISTORY_CLASS',
+        handle: '157',
+        ownerObjectId: '154',
+        evalGraphHardId: '156',
+      } as any,
+      '156': {
+        name: 'ACAD_EVALUATION_GRAPH',
+        handle: '156',
+        ownerObjectId: '157',
+        nodeObjectHardIds: ['155'],
+      } as any,
+      '155': {
+        name: 'ACSH_BOX_CLASS',
+        handle: '155',
+        ownerObjectId: '156',
+        transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        length: 2,
+        width: 2,
+        height: 2,
+      } as any,
+    }
+
+    converter.setObjectByHandle(objectByHandle)
+
+    const result = converter.convert({
+      type: '3DSOLID',
+      historyObjectSoftId: '157',
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDb3dSolid)
+    expect((result as AcDb3dSolid).hasRenderableGeometry).toBe(true)
   })
 })

--- a/packages/dxf-json-converter/__tests__/Acsh3dSolidResolver.spec.ts
+++ b/packages/dxf-json-converter/__tests__/Acsh3dSolidResolver.spec.ts
@@ -1,0 +1,41 @@
+import type { DxfObjectByHandle } from '../src/Acsh3dSolidResolver'
+import { resolveAcshSolidAcisData } from '../src/Acsh3dSolidResolver'
+
+describe('resolveAcshSolidAcisData', () => {
+  it('returns synthetic SAT point records from ACSH history chain', () => {
+    const objectByHandle: DxfObjectByHandle = {
+      '157': {
+        name: 'ACSH_HISTORY_CLASS',
+        handle: '157',
+        ownerObjectId: '154',
+        evalGraphHardId: '156',
+      } as any,
+      '156': {
+        name: 'ACAD_EVALUATION_GRAPH',
+        handle: '156',
+        ownerObjectId: '157',
+        nodeObjectHardIds: ['155'],
+      } as any,
+      '155': {
+        name: 'ACSH_BOX_CLASS',
+        handle: '155',
+        ownerObjectId: '156',
+        transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        length: 4,
+        width: 6,
+        height: 8,
+      } as any,
+    }
+
+    const acisData = resolveAcshSolidAcisData('157', objectByHandle)
+
+    expect(acisData).toContain('point $-1')
+    expect(acisData).toContain('End-of-ACIS-data')
+    expect(acisData.match(/point \$/g)?.length).toBe(8)
+  })
+
+  it('returns empty string when history object is missing', () => {
+    expect(resolveAcshSolidAcisData('157', {})).toBe('')
+    expect(resolveAcshSolidAcisData(undefined, {})).toBe('')
+  })
+})

--- a/packages/dxf-json-converter/__tests__/condominium-3dsolid.spec.ts
+++ b/packages/dxf-json-converter/__tests__/condominium-3dsolid.spec.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'node:fs'
+
+import {
+  AcDb3dSolid,
+  AcDbDatabase,
+  AcDbDatabaseConverterManager,
+  AcDbFileType,
+  acdbHostApplicationServices
+} from '@mlightcad/data-model'
+
+import { AcDbDxfConverter } from '../src/AcDbDxfConverter'
+
+jest.mock('@mlightcad/data-model', () => {
+  const actual = jest.requireActual('@mlightcad/data-model')
+  const { AcDbDxfParser: Parser } = jest.requireActual('../src/AcDbDxfParser')
+  return {
+    ...actual,
+    createWorkerApi: () => ({
+      execute: async (data: ArrayBuffer) => ({
+        success: true,
+        data: new Parser().parse(data)
+      }),
+      destroy: () => {}
+    })
+  }
+})
+
+const CONDOMINIUM_DXF =
+  process.env.CONDOMINIUM_DXF ??
+  'C:/Users/MI/Downloads/visualization_-_condominium_with_skylight.dxf'
+
+const hasCondominiumFixture = existsSync(CONDOMINIUM_DXF)
+
+describe('condominium 3DSOLID integration', () => {
+  ;(hasCondominiumFixture ? it : it.skip)(
+    'loads SAB wireframe geometry for model-space 3DSOLIDs',
+    async () => {
+    AcDbDatabaseConverterManager.instance.register(
+      AcDbFileType.DXF,
+      new AcDbDxfConverter({ useWorker: true })
+    )
+
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const bytes = new TextEncoder().encode(
+      readFileSync(CONDOMINIUM_DXF, 'utf8')
+    )
+    await db.read(bytes.buffer, { readOnly: true, minimumChunkSize: 1 })
+
+    const solids = [...db.tables.blockTable.modelSpace.newIterator()].filter(
+      entity => entity instanceof AcDb3dSolid
+    )
+
+    const renderable = solids.filter(solid => solid.hasRenderableGeometry)
+
+    expect(solids.length).toBe(52)
+    expect(renderable.length).toBeGreaterThanOrEqual(40)
+    },
+  )
+})

--- a/packages/dxf-json-converter/package.json
+++ b/packages/dxf-json-converter/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/dxf-json": "^1.2.5"
+    "@mlightcad/dxf-json": "^1.2.6"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -255,6 +255,8 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
     progress?: AcDbConversionProgressCallback
   ) {
     const converter = new AcDbEntityConverter()
+    converter.setObjectByHandle(dxf.objects.byHandle ?? {})
+    converter.setAcdsDataByHandle(dxf.acdsData?.byOwnerHandle ?? {})
 
     // Create an instance of AcDbBatchProcessing
     let entities = dxf.entities
@@ -349,6 +351,8 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
    * @param checkOwner - The flag whether to check the owner of entity is the passed
    * blockTableRecord. If yes, convert it and append it to the block table record.
    * Otherwise, ignore the entity.
+   * @param objectByHandle - OBJECTS-section entries for ACSH `3DSOLID` resolution.
+   * @param acdsDataByHandle - ACDSDATA binary ASM payloads keyed by entity handle.
    *
    * @example
    * ```typescript
@@ -358,9 +362,13 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
   private async processEntitiesInBlock(
     entities: CommonDxfEntity[],
     blockTableRecord: AcDbBlockTableRecord,
-    checkOwner = false
+    checkOwner = false,
+    objectByHandle: ParsedDxf['objects']['byHandle'] = {},
+    acdsDataByHandle: Record<string, Uint8Array> = {},
   ) {
     const converter = new AcDbEntityConverter()
+    converter.setObjectByHandle(objectByHandle)
+    converter.setAcdsDataByHandle(acdsDataByHandle)
     const entityCount = entities.length
     const dbEntities: AcDbEntity[] = []
     const btrId = blockTableRecord.objectId
@@ -425,12 +433,24 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       dbBlock.origin.copy(block.position)
       if (block.entities) {
         // Process entities in user-defined blocks
-        this.processEntitiesInBlock(block.entities, dbBlock)
+        this.processEntitiesInBlock(
+          block.entities,
+          dbBlock,
+          false,
+          model.objects?.byHandle ?? {},
+          model.acdsData?.byOwnerHandle ?? {},
+        )
       } else {
         // Process paper space block definiton. Entities in model space are
         // handled in method processEntities
         if (dbBlock.isPaperSapce) {
-          this.processEntitiesInBlock(model.entities, dbBlock, true)
+          this.processEntitiesInBlock(
+            model.entities,
+            dbBlock,
+            true,
+            model.objects?.byHandle ?? {},
+            model.acdsData?.byOwnerHandle ?? {},
+          )
         }
       }
     }

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -132,6 +132,9 @@ import {
   RadialDiameterDimensionEntity
 } from '@mlightcad/dxf-json/types'
 
+import type { DxfObjectByHandle } from './Acsh3dSolidResolver'
+import { resolveAcshSolidAcisData } from './Acsh3dSolidResolver'
+
 type ParsedMLeaderBreak = {
   index?: number
   start: AcGePoint3dLike
@@ -157,6 +160,41 @@ type ParsedMLeaderLeader = {
 }
 
 /**
+ * Normalizes ACDSDATA `ASM_Data` values into a `Uint8Array`.
+ *
+ * JSON deserialization may yield plain arrays or numeric-keyed objects instead of
+ * typed byte arrays.
+ *
+ * @param value - Raw ACDSDATA payload from parsed DXF JSON.
+ * @returns Normalized byte array, or `undefined` when conversion fails.
+ */
+function normalizeSabBytes(
+  value?: Uint8Array | ArrayLike<number>,
+): Uint8Array | undefined {
+  if (!value) {
+    return undefined
+  }
+  if (value instanceof Uint8Array) {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return Uint8Array.from(value)
+  }
+  if (typeof value === 'object') {
+    const record = value as unknown as Record<string, number>
+    const keys = Object.keys(record).filter(key => /^\d+$/.test(key))
+    if (keys.length > 0) {
+      return Uint8Array.from(
+        keys
+          .sort((a, b) => Number(a) - Number(b))
+          .map(key => record[key]!),
+      )
+    }
+  }
+  return undefined
+}
+
+/**
  * Converts DXF entities to AcDbEntity objects.
  *
  * This class provides functionality to convert various DXF entity types
@@ -172,6 +210,31 @@ type ParsedMLeaderLeader = {
  * ```
  */
 export class AcDbEntityConverter {
+  /** OBJECTS-section entries keyed by handle for ACSH history resolution. */
+  private objectByHandle: DxfObjectByHandle = {}
+  /** ACDSDATA `ASM_Data` payloads keyed by owning entity handle. */
+  private acdsDataByHandle: Record<string, Uint8Array> = {}
+
+  /**
+   * Supplies OBJECTS-section entries keyed by handle so `3DSOLID` entities
+   * that reference `ACSH_HISTORY_CLASS` can be resolved when inline ACIS data
+   * is absent.
+   *
+   * @param objectByHandle - Parsed DXF objects indexed by handle.
+   */
+  setObjectByHandle(objectByHandle: DxfObjectByHandle) {
+    this.objectByHandle = objectByHandle
+  }
+
+  /**
+   * Supplies ACDSDATA `ASM_Data` payloads keyed by owning entity handle.
+   *
+   * @param acdsDataByHandle - Binary ASM payloads from parsed DXF ACDSDATA.
+   */
+  setAcdsDataByHandle(acdsDataByHandle: Record<string, Uint8Array> = {}) {
+    this.acdsDataByHandle = acdsDataByHandle
+  }
+
   /**
    * Converts a DXF entity to an AcDbEntity.
    *
@@ -493,14 +556,33 @@ export class AcDbEntityConverter {
   /**
    * Converts a 3DSOLID entity (ACIS/ASM B-rep solid).
    *
-   * Full B-rep tessellation is not supported yet; see {@link AcDb3dSolid} for
-   * what is rendered (a wireframe bounding box derived from the ACIS point
-   * cloud) and why. `entity.data` is missing entirely when the DXF has no
-   * ACIS payload at all, in which case an empty string still produces a
-   * valid (if geometry-less) entity rather than a converter crash.
+   * Resolves geometry from inline SAT text, ACDSDATA binary SAB payloads, or
+   * ACSH history objects in the OBJECTS section. See {@link AcDb3dSolid} for how
+   * the resolved payload is rendered.
+   *
+   * @param solid - Parsed DXF `3DSOLID` entity.
    */
   private convert3dSolid(solid: Solid3DEntity) {
-    return new AcDb3dSolid(solid.data ?? '', solid.version)
+    const handleKey = solid.handle
+      ? String(solid.handle).trim().toUpperCase()
+      : ''
+    const sabBytes = handleKey
+      ? normalizeSabBytes(this.acdsDataByHandle[handleKey])
+      : undefined
+    let satText = typeof solid.data === 'string' ? solid.data : ''
+
+    if (!sabBytes && !satText && solid.historyObjectSoftId) {
+      satText = resolveAcshSolidAcisData(
+        solid.historyObjectSoftId,
+        this.objectByHandle
+      )
+    }
+
+    return new AcDb3dSolid({
+      sabBytes,
+      satText,
+      version: solid.version
+    })
   }
 
   private convertPolyline(polyline: PolylineEntity) {

--- a/packages/dxf-json-converter/src/Acsh3dSolidResolver.ts
+++ b/packages/dxf-json-converter/src/Acsh3dSolidResolver.ts
@@ -1,0 +1,262 @@
+import type {
+  AcadEvalGraphDXFObject,
+  AcshBoxDXFObject,
+  AcshBrepDXFObject,
+  AcshConeDXFObject,
+  AcshCylinderDXFObject,
+  AcshExtrusionDXFObject,
+  AcshHistoryDXFObject,
+  AcshLoftDXFObject,
+  AcshRevolveDXFObject,
+  AcshSweepDXFObject,
+  CommonDXFObject,
+  DxfObjectByHandle,
+} from '@mlightcad/dxf-json/types'
+
+/** Local 3D point used when synthesizing SAT from ACSH primitive bounds. */
+interface Point3 {
+  /** X coordinate in model space. */
+  x: number
+  /** Y coordinate in model space. */
+  y: number
+  /** Z coordinate in model space. */
+  z: number
+}
+
+const ACIS_OBJECT_TYPES = new Set([
+  'ACSH_SWEEP_CLASS',
+  'ACSH_BREP_CLASS',
+  'ACSH_EXTRUSION_CLASS',
+  'ACSH_REVOLVE_CLASS',
+  'ACSH_LOFT_CLASS',
+])
+
+/**
+ * Resolves ACIS SAT text for a `3DSOLID` that stores geometry in the OBJECTS
+ * section via `ACSH_HISTORY_CLASS` rather than inline groups 1/3.
+ *
+ * @param historyObjectSoftId - Soft-pointer handle to `ACSH_HISTORY_CLASS`.
+ * @param objectByHandle - OBJECTS-section entries keyed by handle.
+ * @returns Resolved SAT text, or an empty string when resolution fails.
+ */
+export function resolveAcshSolidAcisData(
+  historyObjectSoftId: string | undefined,
+  objectByHandle: DxfObjectByHandle | undefined,
+): string {
+  if (!historyObjectSoftId || !objectByHandle) {
+    return ''
+  }
+
+  const history = objectByHandle[normalizeHandle(historyObjectSoftId)]
+  if (!history || history.name !== 'ACSH_HISTORY_CLASS') {
+    return ''
+  }
+
+  const evalGraphId = (history as AcshHistoryDXFObject).evalGraphHardId
+  if (!evalGraphId) {
+    return ''
+  }
+
+  const graph = objectByHandle[normalizeHandle(evalGraphId)]
+  if (!graph || graph.name !== 'ACAD_EVALUATION_GRAPH') {
+    return ''
+  }
+
+  const nodeIds = (graph as AcadEvalGraphDXFObject).nodeObjectHardIds ?? []
+  let resolvedAcis = ''
+
+  for (const nodeId of nodeIds) {
+    const node = objectByHandle[normalizeHandle(nodeId)]
+    if (!node) {
+      continue
+    }
+
+    const acisFromNode = resolveNodeAcisData(node)
+    if (acisFromNode) {
+      resolvedAcis = acisFromNode
+    }
+  }
+
+  if (resolvedAcis) {
+    return resolvedAcis
+  }
+
+  const points: Point3[] = []
+  for (const nodeId of nodeIds) {
+    const node = objectByHandle[normalizeHandle(nodeId)]
+    if (!node) {
+      continue
+    }
+    points.push(...primitiveCornerPoints(node))
+  }
+
+  if (points.length === 0) {
+    return ''
+  }
+
+  return pointsToSyntheticSat(points)
+}
+
+/**
+ * Reads inline ACIS data from one ACSH evaluation-graph node when present.
+ *
+ * @param node - ACSH primitive or B-rep node from the evaluation graph.
+ */
+function resolveNodeAcisData(node: CommonDXFObject): string {
+  if (!ACIS_OBJECT_TYPES.has(node.name)) {
+    return ''
+  }
+
+  const acisObject = node as
+    | AcshSweepDXFObject
+    | AcshBrepDXFObject
+    | AcshExtrusionDXFObject
+    | AcshRevolveDXFObject
+    | AcshLoftDXFObject
+
+  return acisObject.acisData ?? ''
+}
+
+/**
+ * Collects approximate bounding-box corner points for supported ACSH primitives.
+ *
+ * @param node - ACSH primitive node from the evaluation graph.
+ */
+function primitiveCornerPoints(node: CommonDXFObject): Point3[] {
+  switch (node.name) {
+    case 'ACSH_BOX_CLASS':
+      return boxCornerPoints(node as AcshBoxDXFObject)
+    case 'ACSH_CYLINDER_CLASS':
+      return primitiveBoundingBoxPoints(node as AcshCylinderDXFObject, cylinder => {
+        const radius = Math.max(
+          cylinder.minorRadius ?? 0,
+          cylinder.majorRadius ?? 0,
+          cylinder.topMajorRadius ?? 0,
+        )
+        const height = cylinder.height ?? cylinder.topMajorRadius ?? 0
+        return { length: radius * 2, width: radius * 2, height }
+      })
+    case 'ACSH_CONE_CLASS':
+      return primitiveBoundingBoxPoints(node as AcshConeDXFObject, cone => {
+        const radius = Math.max(
+          cone.baseRadius ?? 0,
+          cone.minorRadius ?? 0,
+          cone.topRadius ?? 0,
+          cone.majorRadius ?? 0,
+        )
+        const height = cone.height ?? cone.topMajorRadius ?? 0
+        return { length: radius * 2, width: radius * 2, height }
+      })
+    case 'ACSH_WEDGE_CLASS':
+      return primitiveBoundingBoxPoints(
+        node as { transform?: number[]; length?: number; width?: number; height?: number },
+        wedge => ({
+          length: wedge.length ?? 0,
+          width: wedge.width ?? 0,
+          height: wedge.height ?? 0,
+        }),
+      )
+    default:
+      return []
+  }
+}
+
+/**
+ * Builds eight axis-aligned box corners for a primitive and applies its transform.
+ *
+ * @param primitive - ACSH primitive with optional 4×4 transform matrix.
+ * @param dimensions - Callback that derives local length/width/height.
+ */
+function primitiveBoundingBoxPoints<T extends { transform?: number[] }>(
+  primitive: T,
+  dimensions: (primitive: T) => { length: number; width: number; height: number },
+): Point3[] {
+  const { length, width, height } = dimensions(primitive)
+  if (length <= 0 || width <= 0 || height <= 0) {
+    return []
+  }
+  return boxCornerPoints({
+    name: 'ACSH_BOX_CLASS',
+    handle: '',
+    ownerObjectId: '0',
+    length,
+    width,
+    height,
+    transform: primitive.transform,
+  })
+}
+
+/** Normalizes a DXF handle string for map lookups (trim + uppercase). */
+function normalizeHandle(handle: string): string {
+  return String(handle).trim().toUpperCase()
+}
+
+/**
+ * Returns eight local box corners for an `ACSH_BOX_CLASS`, transformed when a
+ * 4×4 matrix is present.
+ *
+ * @param box - ACSH box primitive with length, width, height, and transform.
+ */
+function boxCornerPoints(box: AcshBoxDXFObject): Point3[] {
+  const length = box.length ?? 0
+  const width = box.width ?? 0
+  const height = box.height ?? 0
+  if (length <= 0 || width <= 0 || height <= 0) {
+    return []
+  }
+
+  const halfLength = length / 2
+  const halfWidth = width / 2
+  const halfHeight = height / 2
+  const localCorners: Point3[] = [
+    { x: -halfLength, y: -halfWidth, z: -halfHeight },
+    { x: halfLength, y: -halfWidth, z: -halfHeight },
+    { x: halfLength, y: halfWidth, z: -halfHeight },
+    { x: -halfLength, y: halfWidth, z: -halfHeight },
+    { x: -halfLength, y: -halfWidth, z: halfHeight },
+    { x: halfLength, y: -halfWidth, z: halfHeight },
+    { x: halfLength, y: halfWidth, z: halfHeight },
+    { x: -halfLength, y: halfWidth, z: halfHeight },
+  ]
+
+  const matrix = box.transform
+  if (!matrix || matrix.length !== 16) {
+    return localCorners
+  }
+
+  return localCorners.map(corner => transformPoint(matrix, corner))
+}
+
+/**
+ * Applies a 4×4 column-major transform matrix to one point.
+ *
+ * @param matrix - 16-element transform matrix.
+ * @param point - Local-space point to transform.
+ */
+function transformPoint(matrix: number[], point: Point3): Point3 {
+  const x = point.x
+  const y = point.y
+  const z = point.z
+  const w = matrix[12] * x + matrix[13] * y + matrix[14] * z + matrix[15]
+  const scale = w !== 0 && w !== 1 ? 1 / w : 1
+  return {
+    x: (matrix[0] * x + matrix[1] * y + matrix[2] * z + matrix[3]) * scale,
+    y: (matrix[4] * x + matrix[5] * y + matrix[6] * z + matrix[7]) * scale,
+    z: (matrix[8] * x + matrix[9] * y + matrix[10] * z + matrix[11]) * scale,
+  }
+}
+
+/**
+ * Synthesizes minimal SAT `point` records from corner samples for fallback display.
+ *
+ * @param points - World-space corner points collected from ACSH primitives.
+ */
+function pointsToSyntheticSat(points: Point3[]): string {
+  const lines = points.map(
+    point => `point $-1 ${point.x} ${point.y} ${point.z} #`,
+  )
+  lines.push('End-of-ACIS-data')
+  return lines.join('\n')
+}
+
+export type { CommonDXFObject, DxfObjectByHandle }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/dxf-json-converter:
     dependencies:
       '@mlightcad/dxf-json':
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^1.2.6
+        version: 1.2.6
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1403,8 +1403,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.2.5':
-    resolution: {integrity: sha512-yUwYrRP321Pzjun4h69KFz5YnGoqA7iKZvP+Y93F4yMe2avko5yd/iaNxAZxCdrO6JeOsi3rcEaYBtg6UDiK8Q==}
+  '@mlightcad/dxf-json@1.2.6':
+    resolution: {integrity: sha512-7iQFRrXOr7TAT/5ELYncifV4bQgdA0KCGyu7P/2xWJH0+U5LZgxWdXJRBiAepcJPRJihNqdlweDwwJk7XGUOvA==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -6353,7 +6353,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.2.5':
+  '@mlightcad/dxf-json@1.2.6':
     dependencies:
       '@fxts/core': 1.26.0
 


### PR DESCRIPTION
## Summary

- Add ACIS/ASM SAB binary decoder and B-rep geometry extraction in `data-model`, enabling edge-based wireframe rendering for `AcDb3dSolid` (straight, ellipse, intcurve edges; sphere face scaffold fallback).
- Extend `dxf-json-converter` to resolve `3DSOLID` geometry from ACDSDATA binary payloads and ACSH history objects in the OBJECTS section (`Acsh3dSolidResolver`), with synthetic SAT fallback from primitive bounding boxes.
- Bump `@mlightcad/dxf-json` to `^1.2.6` for ACSH/ACDSDATA parsing support.

## Test plan

- [x] `pnpm test -- --testPathPattern="AcDb3dSolid|Acsh3dSolidResolver|condominium-3dsolid|AcDbEntityConverter"` (27 tests passed)
- [ ] Verify 3DSOLID wireframe rendering in the example app with a DXF containing ACSH solids
- [ ] Optional: set `CONDOMINIUM_DXF` env var to run the integration test against a real condominium DXF fixture