### PR TITLE
fix(geometry-engine): preserve circular arc endpoints when reversing loop edges

### DIFF
--- a/packages/geometry-engine/__tests__/AcGeLoop2d.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeLoop2d.spec.ts
@@ -105,7 +105,38 @@ describe('AcGeLoop2d', () => {
 
     const arc = new AcGeCircArc2d({ x: 0, y: 0 }, 1, 0, Math.PI / 2, false)
     const reversedArc = reverseEdge(arc) as AcGeCircArc2d
-    expect(reversedArc.startAngle).toBeCloseTo(arc.endAngle, 8)
+    // Physical endpoints must be swapped; public angles are mirrored when clockwise.
+    expect(reversedArc.startPoint.x).toBeCloseTo(arc.endPoint.x, 8)
+    expect(reversedArc.startPoint.y).toBeCloseTo(arc.endPoint.y, 8)
+    expect(reversedArc.endPoint.x).toBeCloseTo(arc.startPoint.x, 8)
+    expect(reversedArc.endPoint.y).toBeCloseTo(arc.startPoint.y, 8)
+    expect(reversedArc.clockwise).toBe(!arc.clockwise)
+
+    const clockwiseArc = new AcGeCircArc2d(
+      { x: 0, y: 0 },
+      1,
+      0,
+      Math.PI / 2,
+      true
+    )
+    const reversedClockwiseArc = reverseEdge(clockwiseArc) as AcGeCircArc2d
+    expect(reversedClockwiseArc.startPoint.x).toBeCloseTo(
+      clockwiseArc.endPoint.x,
+      8
+    )
+    expect(reversedClockwiseArc.startPoint.y).toBeCloseTo(
+      clockwiseArc.endPoint.y,
+      8
+    )
+    expect(reversedClockwiseArc.endPoint.x).toBeCloseTo(
+      clockwiseArc.startPoint.x,
+      8
+    )
+    expect(reversedClockwiseArc.endPoint.y).toBeCloseTo(
+      clockwiseArc.startPoint.y,
+      8
+    )
+    expect(reversedClockwiseArc.clockwise).toBe(false)
 
     const ellipse = new AcGeEllipseArc2d(
       { x: 0, y: 0 },
@@ -150,6 +181,47 @@ describe('AcGeLoop2d', () => {
     })
     const reversedNoWeights = reverseEdge(splineNoWeights) as AcGeSpline3d
     expect(reversedNoWeights.weights.length).toBeGreaterThan(0)
+  })
+
+  it('reverses circular arcs without reflecting endpoints around the center', () => {
+    // Regression for https://github.com/mlightcad/cad-viewer/issues/432
+    // Swapping public angles + flipping clockwise used to mirror Y around the center.
+    const reverseEdge = (
+      AcGeLoop2d as unknown as {
+        reverseEdge: (edge: AcGeCircArc2d) => AcGeCircArc2d
+      }
+    ).reverseEdge
+
+    const center = { x: 348.92244, y: 368.76477 }
+    const radius = 22.28497
+    // Physical start below center, end above — matches the reflected Y values in #432.
+    const arc = new AcGeCircArc2d(center, radius, -Math.PI / 2, Math.PI / 2, false)
+    expect(arc.startPoint.y).toBeCloseTo(center.y - radius, 5)
+    expect(arc.endPoint.y).toBeCloseTo(center.y + radius, 5)
+
+    const reversed = reverseEdge(arc)
+    expect(reversed.startPoint.x).toBeCloseTo(arc.endPoint.x, 6)
+    expect(reversed.startPoint.y).toBeCloseTo(arc.endPoint.y, 6)
+    expect(reversed.endPoint.x).toBeCloseTo(arc.startPoint.x, 6)
+    expect(reversed.endPoint.y).toBeCloseTo(arc.startPoint.y, 6)
+    // Must not produce the complementary arc reflected across the center.
+    expect(Math.abs(reversed.startPoint.y - (2 * center.y - arc.endPoint.y))).toBeGreaterThan(
+      1
+    )
+
+    // buildFromEdges must reverse the arc to connect without reflecting it.
+    const line = new AcGeLine2d(
+      { x: arc.endPoint.x - 1, y: arc.endPoint.y },
+      { x: arc.endPoint.x, y: arc.endPoint.y }
+    )
+    const loops = AcGeLoop2d.buildFromEdges([line, arc], 1e-3)
+    expect(loops).toHaveLength(1)
+    expect(loops[0].numberOfEdges).toBe(2)
+    const connectedArc = loops[0].curves[1] as AcGeCircArc2d
+    expect(connectedArc.startPoint.x).toBeCloseTo(arc.endPoint.x, 6)
+    expect(connectedArc.startPoint.y).toBeCloseTo(arc.endPoint.y, 6)
+    expect(connectedArc.endPoint.x).toBeCloseTo(arc.startPoint.x, 6)
+    expect(connectedArc.endPoint.y).toBeCloseTo(arc.startPoint.y, 6)
   })
 
   it('clones loop with independent edge instances', () => {

--- a/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
+++ b/packages/geometry-engine/src/geometry/AcGeLoop2d.ts
@@ -5,6 +5,7 @@ import {
   AcGePoint2d,
   AcGePoint3d
 } from '../math'
+import { AcGeMathUtil } from '../util'
 import { AcGeCircArc2d } from './AcGeCircArc2d'
 import { AcGeCurve2d } from './AcGeCurve2d'
 import { AcGeEllipseArc2d } from './AcGeEllipseArc2d'
@@ -297,13 +298,7 @@ export class AcGeLoop2d extends AcGeCurve2d {
       return new AcGeLine2d(edge.endPoint, edge.startPoint)
     }
     if (edge instanceof AcGeCircArc2d) {
-      return new AcGeCircArc2d(
-        edge.center,
-        edge.radius,
-        edge.endAngle,
-        edge.startAngle,
-        !edge.clockwise
-      )
+      return AcGeLoop2d.reverseCircArcEdge(edge)
     }
     if (edge instanceof AcGeEllipseArc2d) {
       return new AcGeEllipseArc2d(
@@ -321,6 +316,42 @@ export class AcGeLoop2d extends AcGeCurve2d {
       return AcGeLoop2d.reverseSplineEdge(edge)
     }
     return edge
+  }
+
+  /**
+   * Reverse a circular arc while preserving physical endpoints.
+   *
+   * `AcGeCircArc2d` uses mirrored public angles when `clockwise` is true, so simply
+   * swapping `startAngle`/`endAngle` and flipping `clockwise` produces a reflected
+   * complementary arc. Rebuild from physical endpoint angles instead.
+   */
+  private static reverseCircArcEdge(edge: AcGeCircArc2d): AcGeCircArc2d {
+    const start = edge.startPoint
+    const end = edge.endPoint
+    const newClockwise = !edge.clockwise
+    // New start is the old end; new end is the old start.
+    const physicalStartAngle = Math.atan2(
+      end.y - edge.center.y,
+      end.x - edge.center.x
+    )
+    const physicalEndAngle = Math.atan2(
+      start.y - edge.center.y,
+      start.x - edge.center.x
+    )
+    // Match AcGeCircArc2d clockwise public-angle convention (mirror ≈ negation).
+    const toPublicAngle = (angle: number) => {
+      const normalized = AcGeMathUtil.normalizeAngle(angle)
+      return newClockwise
+        ? AcGeMathUtil.normalizeAngle(-normalized)
+        : normalized
+    }
+    return new AcGeCircArc2d(
+      edge.center,
+      edge.radius,
+      toPublicAngle(physicalStartAngle),
+      toPublicAngle(physicalEndAngle),
+      newClockwise
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix `AcGeLoop2d.reverseEdge` for circular arcs so reversing swaps physical endpoints instead of mirroring them around the center (regression for mlightcad/cad-viewer#432).
- Rebuild reversed `AcGeCircArc2d` edges from endpoint angles using the clockwise public-angle convention, matching `AcGeCircArc2d.transform`.
- Add unit coverage for counterclockwise/clockwise reverses and a `buildFromEdges` regression case.

## Test plan
- [x] `pnpm exec jest packages/geometry-engine/__tests__/AcGeLoop2d.spec.ts --no-coverage`
- [ ] Confirm hatch/boundary loops that reverse arcs no longer flip endpoints across the arc center