### PR TITLE
fix(data-model): fix DXF group codes and SHAPE round-trip identity

### DIFF
--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -622,6 +622,8 @@ describe('AcDbHatch', () => {
     expect(dxf).toContain('\n52\n')
     expect(dxf).toContain('\n41\n2.5\n')
     expect(dxf).toContain('\n78\n1\n')
+    // Pattern line base/offset use codes 43/44 and 45/46 (not 43/53, 45/55).
+    expect(dxf).toContain('\n53\n45\n43\n0\n44\n0\n45\n1\n46\n1\n79\n2\n')
     expect(dxf).toContain('\n79\n2\n')
     expect(dxf).toContain('\n98\n0\n')
   })

--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -333,7 +333,7 @@ describe('AcDbMText', () => {
     expect(dxfWithoutBackground).toContain('30\n3')
     expect(dxfWithoutBackground).toContain('40\n2')
     expect(dxfWithoutBackground).toContain('41\n10')
-    expect(dxfWithoutBackground).not.toContain('414\n')
+    expect(dxfWithoutBackground).not.toContain('42\n')
     expect(dxfWithoutBackground).toContain('1\na\\Pb\\Pc\\Pd')
     expect(dxfWithoutBackground).toContain('7\nMyTextStyle')
     expect(dxfWithoutBackground).toContain('50\n90')
@@ -368,7 +368,7 @@ describe('AcDbMText', () => {
     expect(dxfWithBackground).toContain('45\n2.5')
   })
 
-  it('writes actual text width as DXF group 414 when extentsWidth is set', () => {
+  it('writes actual text width as DXF group 42 when extentsWidth is set', () => {
     createWorkingDb()
     const mtext = new AcDbMText()
     mtext.ownerId = 'ABC'
@@ -380,6 +380,7 @@ describe('AcDbMText', () => {
     const filer = new AcDbDxfFiler()
     mtext.dxfOutFields(filer)
 
-    expect(filer.toString()).toContain('414\n18.5')
+    expect(filer.toString()).toContain('42\n18.5')
+    expect(filer.toString()).not.toContain('414\n')
   })
 })

--- a/packages/data-model/__tests__/AcDbPolyline.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolyline.spec.ts
@@ -617,6 +617,39 @@ describe('AcDbPolyline', () => {
     expect(getDxfGroupValues(dxf, 20)).toEqual(['2', '4'])
   })
 
+  it('writes constant width as group 43 for uniform thick polylines', () => {
+    const polyline = new AcDbPolyline()
+    attachEntityToNewModelSpace(polyline)
+
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0), 0, 40, 40)
+    polyline.addVertexAt(1, new AcGePoint2d(100, 0), 0, 40, 40)
+
+    const filer = new AcDbDxfFiler()
+    polyline.dxfOutFields(filer)
+
+    const dxf = filer.toString()
+    expect(getDxfGroupValues(dxf, 43)).toEqual(['40'])
+    expect(getDxfGroupValues(dxf, 40)).toEqual([])
+    expect(getDxfGroupValues(dxf, 41)).toEqual([])
+  })
+
+  it('writes per-vertex widths and bulges when width is not constant', () => {
+    const polyline = new AcDbPolyline()
+    attachEntityToNewModelSpace(polyline)
+
+    polyline.addVertexAt(0, new AcGePoint2d(0, 0), 0.5, 10, 20)
+    polyline.addVertexAt(1, new AcGePoint2d(100, 0), 0, 5, 5)
+
+    const filer = new AcDbDxfFiler()
+    polyline.dxfOutFields(filer)
+
+    const dxf = filer.toString()
+    expect(getDxfGroupValues(dxf, 43)).toEqual([])
+    expect(getDxfGroupValues(dxf, 40)).toEqual(['10', '5'])
+    expect(getDxfGroupValues(dxf, 41)).toEqual(['20', '5'])
+    expect(getDxfGroupValues(dxf, 42)).toEqual(['0.5'])
+  })
+
   it('writes closed flag as 0 in dxf fields when polyline is open', () => {
     const polyline = new AcDbPolyline()
     attachEntityToNewModelSpace(polyline)

--- a/packages/data-model/__tests__/AcDbShape.spec.ts
+++ b/packages/data-model/__tests__/AcDbShape.spec.ts
@@ -121,6 +121,38 @@ describe('AcDbShape', () => {
     expect(dxf).toContain('39\n0.5\n')
   })
 
+  it('writes shapeNumber as DXF group 2 when name is empty', () => {
+    createWorkingDb()
+    const shape = new AcDbShape()
+    shape.shapeNumber = 9
+    shape.styleName = 'TECOGISSHAPE0'
+    shape.position = { x: 1, y: 2, z: 0 }
+    shape.size = 0.01
+    shape.ownerId = '0'
+    const filer = new AcDbDxfFiler()
+
+    shape.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('2\n9\n')
+    expect(dxf).not.toContain('2\n0\n')
+    expect(dxf).toContain('3\nTECOGISSHAPE0\n')
+  })
+
+  it('prefers shape name over shapeNumber for DXF group 2', () => {
+    createWorkingDb()
+    const shape = new AcDbShape()
+    shape.name = '_GV_'
+    shape.shapeNumber = 9
+    shape.ownerId = '0'
+    const filer = new AcDbDxfFiler()
+
+    shape.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('2\n_GV_\n')
+  })
+
   it('transforms position, size, and orientation', () => {
     createWorkingDb()
     const shape = new AcDbShape()
@@ -201,5 +233,27 @@ describe('AcDbShape', () => {
       obliqueAngle: 10
     })
     expect(delay).toBe(true)
+  })
+
+  it('passes numeric shape name to renderer as shapeNumber only', () => {
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const shape = new AcDbShape()
+    shape.database = db
+    shape.name = '9'
+    shape.size = 0.01
+    shape.position = new AcGePoint3d(1, 2, 0)
+
+    const renderer = {
+      shape: jest.fn(() => ({ objectId: 'S1' }))
+    } as unknown as { shape: jest.Mock }
+
+    shape.subWorldDraw(renderer as never)
+
+    const [shapeData] = renderer.shape.mock.calls[0]
+    expect(shapeData.name).toBeUndefined()
+    expect(shapeData.shapeNumber).toBe(9)
   })
 })

--- a/packages/data-model/__tests__/AcDbTextStyleTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextStyleTableRecord.spec.ts
@@ -1,3 +1,4 @@
+import { AcDbDxfFiler } from '../src/base'
 import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
@@ -66,5 +67,26 @@ describe('AcDbTextStyleTableRecord', () => {
     record.isVertical = false
     expect(record.isVertical).toBe(false)
     expect(record.textStyle.standardFlag).toBe(0)
+  })
+
+  it('appends .shx to shape-file font names when writing DXF', () => {
+    const record = new AcDbTextStyleTableRecord({
+      name: 'TECOGISSHAPE0',
+      standardFlag: 1,
+      fixedTextHeight: 0,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: 0,
+      font: 'tecosymbol',
+      bigFont: ''
+    })
+    record.ownerId = '0'
+    const filer = new AcDbDxfFiler()
+
+    record.dxfOutFields(filer)
+    const dxf = filer.toString()
+
+    expect(dxf).toContain('3\ntecosymbol.shx\n')
   })
 })

--- a/packages/data-model/src/database/AcDbTextStyleTableRecord.ts
+++ b/packages/data-model/src/database/AcDbTextStyleTableRecord.ts
@@ -287,6 +287,23 @@ export class AcDbTextStyleTableRecord extends AcDbSymbolTableRecord<AcDbTextStyl
   }
 
   /**
+   * Font file name as written to DXF group 3.
+   *
+   * Shape-file STYLE entries used by SHAPE entities need a `.shx` extension in
+   * DXF (CadLib / AutoCAD); DWG often stores the bare base name.
+   */
+  private get dxfFontFileName(): string {
+    const fileName = this.fileName?.trim() ?? ''
+    if (!fileName || !this.isShapeFile) {
+      return fileName
+    }
+    if (/\.[^./\\]+$/i.test(fileName)) {
+      return fileName
+    }
+    return `${fileName}.shx`
+  }
+
+  /**
    * Writes DXF fields for this object.
    *
    * @param filer - DXF output writer.
@@ -302,7 +319,7 @@ export class AcDbTextStyleTableRecord extends AcDbSymbolTableRecord<AcDbTextStyl
     filer.writeAngle(50, this.obliquingAngle)
     filer.writeInt16(71, this.getAttr('textGenerationFlag'))
     filer.writeDouble(42, this.priorSize)
-    filer.writeString(3, this.fileName)
+    filer.writeString(3, this.dxfFontFileName)
     filer.writeString(4, this.bigFontFileName)
     return this
   }

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -1763,9 +1763,12 @@ export class AcDbHatch extends AcDbEntity {
     filer.writeInt16(77, 0)
     filer.writeInt16(78, this.definitionLines.length)
     this.definitionLines.forEach(line => {
+      // Hatch pattern lines use 43/44 and 45/46 (not code+10 point pairs).
       filer.writeAngle(53, line.angle)
-      filer.writePoint2d(43, line.base)
-      filer.writePoint2d(45, line.offset)
+      filer.writeDouble(43, line.base.x)
+      filer.writeDouble(44, line.base.y)
+      filer.writeDouble(45, line.offset.x)
+      filer.writeDouble(46, line.offset.y)
       filer.writeInt16(79, line.dashLengths.length)
       line.dashLengths.forEach(length => filer.writeDouble(49, length))
     })

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -715,7 +715,7 @@ export class AcDbMText extends AcDbEntity {
   }
 
   private encodeMTextContentsForDxf(contents: string): string {
-    return contents.replace(/\r\n|\r|\n/g, '\\P')
+    return (contents ?? '').replace(/\r\n|\r|\n/g, '\\P')
   }
 
   /**
@@ -731,10 +731,13 @@ export class AcDbMText extends AcDbEntity {
     filer.writeDouble(40, this.height)
     filer.writeDouble(41, this.width)
     if (this.extentsWidth > 0) {
-      filer.writeDouble(414, this.extentsWidth)
+      filer.writeDouble(42, this.extentsWidth)
     }
     // MTEXT contents use \P for paragraph breaks; raw newlines must not appear in DXF.
-    filer.writeString(1, this.encodeMTextContentsForDxf(this.contents))
+    filer.writeString(
+      1,
+      this.encodeMTextContentsForDxf(this.contents ?? '')
+    )
     filer.writeString(7, this.styleName)
     filer.writeAngle(50, this.rotation)
     filer.writeVector3d(11, this.direction)

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -641,11 +641,63 @@ export class AcDbPolyline extends AcDbCurve {
     filer.writeSubclassMarker('AcDbPolyline')
     filer.writeInt32(90, this.numberOfVertices)
     filer.writeInt16(70, this.closed ? 1 : 0)
+
+    const constantWidth = this.resolveConstantWidth()
+    if (constantWidth != null) {
+      // Group 43 replaces per-vertex 40/41 when every segment has the same width.
+      filer.writeDouble(43, constantWidth)
+    }
     filer.writeDouble(38, this.elevation)
-    for (let i = 0; i < this.numberOfVertices; ++i) {
+
+    const vertices = this._geo.vertices
+    for (let i = 0; i < vertices.length; ++i) {
+      const vertex = vertices[i]
       filer.writePoint2d(10, this.getPoint2dAt(i))
+      if (constantWidth == null) {
+        if (vertex.startWidth != null) {
+          filer.writeDouble(40, vertex.startWidth)
+        }
+        if (vertex.endWidth != null) {
+          filer.writeDouble(41, vertex.endWidth)
+        }
+      }
+      const bulge = vertex.bulge ?? 0
+      if (bulge !== 0) {
+        filer.writeDouble(42, bulge)
+      }
     }
     return this
+  }
+
+  /**
+   * Returns a single constant width when every vertex uses that same start and
+   * end width; otherwise `undefined` so per-vertex 40/41 codes are written.
+   */
+  private resolveConstantWidth(): number | undefined {
+    const vertices = this._geo.vertices
+    if (vertices.length === 0) return undefined
+
+    let common: number | undefined
+    for (const vertex of vertices) {
+      const startWidth = vertex.startWidth
+      const endWidth = vertex.endWidth
+      if (startWidth == null && endWidth == null) {
+        if (common != null && common !== 0) return undefined
+        common = common ?? 0
+        continue
+      }
+      const start = startWidth ?? 0
+      const end = endWidth ?? 0
+      if (start !== end) return undefined
+      if (common == null) {
+        common = start
+      } else if (common !== start) {
+        return undefined
+      }
+    }
+
+    // Default LWPOLYLINE width is 0; omit group 43 unless there is actual width.
+    return common != null && common !== 0 ? common : undefined
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbShape.ts
+++ b/packages/data-model/src/entity/AcDbShape.ts
@@ -494,8 +494,7 @@ export class AcDbShape extends AcDbEntity {
       : undefined
 
     const shapeData: AcGiShapeData = {
-      name: this._name.trim() || undefined,
-      shapeNumber: this._shapeNumber !== 0 ? this._shapeNumber : undefined,
+      ...this.renderGlyphIdentity(),
       size: this.size,
       position: this._position,
       rotation: this._rotation,
@@ -504,6 +503,30 @@ export class AcDbShape extends AcDbEntity {
     }
 
     return renderer.shape(shapeData, style, delay)
+  }
+
+  /**
+   * Glyph identity passed to renderers.
+   *
+   * Purely numeric names are treated as shape codes (common for DWG→DXF
+   * exports). Renderers look up by name only when a non-numeric name is set,
+   * so keeping `"9"` as a name would hide glyphs that exist only by code.
+   */
+  private renderGlyphIdentity(): Pick<AcGiShapeData, 'name' | 'shapeNumber'> {
+    const trimmedName = this._name.trim()
+    const asNumber = Number(trimmedName)
+    if (
+      trimmedName !== '' &&
+      Number.isInteger(asNumber) &&
+      asNumber !== 0 &&
+      String(asNumber) === trimmedName
+    ) {
+      return { shapeNumber: asNumber }
+    }
+    return {
+      name: trimmedName || undefined,
+      shapeNumber: this._shapeNumber !== 0 ? this._shapeNumber : undefined
+    }
   }
 
   /**
@@ -522,12 +545,31 @@ export class AcDbShape extends AcDbEntity {
     return style?.textStyle
   }
 
+  /**
+   * DXF group 2 identity for this shape.
+   *
+   * Autodesk documents group 2 as the shape name. DWG stores only the numeric
+   * shape index; CadLib / libredwg treat post-R12 DXF group 2 as that index
+   * when no name is available. Prefer an explicit name (DXF-sourced), otherwise
+   * fall back to the shape number so round-trips from DWG stay resolvable.
+   */
+  private get dxfShapeIdentity(): string {
+    const trimmedName = this._name.trim()
+    if (trimmedName) {
+      return trimmedName
+    }
+    return this._shapeNumber !== 0 ? String(this._shapeNumber) : ''
+  }
+
   override dxfOutFields(filer: AcDbDxfFiler) {
     super.dxfOutFields(filer)
     filer.writeSubclassMarker('AcDbShape')
     filer.writePoint3d(10, this.position)
     filer.writeDouble(40, this.size)
-    filer.writeString(2, this.name)
+    const shapeId = this.dxfShapeIdentity
+    if (shapeId) {
+      filer.writeString(2, shapeId)
+    }
     filer.writeAngle(50, this.rotation)
     filer.writeDouble(41, this.widthFactor)
     filer.writeAngle(51, this.oblique)

--- a/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts
@@ -410,6 +410,25 @@ describe('AcDbEntityConverter', () => {
     expect(shape.normal).toMatchObject({ x: 0, y: 0, z: 1 })
   })
 
+  it('converts numeric DXF shape name into shapeNumber', () => {
+    acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
+    const converter = new AcDbEntityConverter()
+    const result = converter.convert({
+      type: 'SHAPE',
+      subclassMarker: 'AcDbShape',
+      layer: '0',
+      handle: '19AAD4',
+      insertionPoint: { x: 0, y: 0, z: 0 },
+      size: 0.01,
+      shapeName: '9'
+    } as any)
+
+    expect(result).toBeInstanceOf(AcDbShape)
+    const shape = result as AcDbShape
+    expect(shape.name).toBe('')
+    expect(shape.shapeNumber).toBe(9)
+  })
+
   it('converts ACAD_PROXY_ENTITY with graphics data to AcDbProxyEntity', () => {
     acdbHostApplicationServices().workingDatabase = new AcDbDatabase()
     const converter = new AcDbEntityConverter()

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -540,7 +540,25 @@ export class AcDbEntityConverter {
     const dbEntity = new AcDbShape()
     dbEntity.position.copy(shape.insertionPoint)
     dbEntity.size = shape.size
-    dbEntity.name = shape.shapeName
+    const shapeName = shape.shapeName?.trim() ?? ''
+    // Post-R12 DXF exports from DWG may write the numeric shape index as group 2.
+    // Keep name empty in that case so renderers look up by code (DWG semantics);
+    // a numeric string like "9" is almost never a real SHX shape name.
+    const asNumber = Number(shapeName)
+    if (
+      shapeName !== '' &&
+      Number.isInteger(asNumber) &&
+      asNumber !== 0 &&
+      String(asNumber) === shapeName
+    ) {
+      dbEntity.shapeNumber = asNumber
+    } else {
+      dbEntity.name = shapeName
+    }
+    const styleName = (shape as ShapeEntity & { styleName?: string }).styleName
+    if (styleName) {
+      dbEntity.styleName = styleName
+    }
     dbEntity.rotation = AcGeMathUtil.degToRad(shape.rotation || 0)
     dbEntity.widthFactor = shape.xScale ?? 1
     dbEntity.oblique = AcGeMathUtil.degToRad(shape.obliqueAngle || 0)


### PR DESCRIPTION
## Summary

### DXF group codes (hatch / mtext / polyline)
- Hatch pattern line base/offset now uses groups **43/44** and **45/46** (was incorrectly emitted via `writePoint2d` as 43/53 and 45/55).
- MText actual character width (`extentsWidth`) writes group **42** per the DXF spec (was invalid 414); null `contents` is guarded.
- LWPOLYLINE emits constant width as group **43** when uniform; otherwise per-vertex **40/41** and non-zero bulges as **42**.

### SHAPE identity and style-file fonts
- Treat purely numeric DXF SHAPE group **2** as `shapeNumber` (DWG semantics) on convert; keep empty `name` so renderers look up by code.
- On DXF write, prefer an explicit shape name for group 2; if name is empty, fall back to the numeric shape code.
- Pass purely numeric glyph names to the renderer as `shapeNumber` only (not as a string name).
- Append `.shx` to shape-file STYLE font names on DXF write when DWG stored the bare base name.
- Map `styleName` when converting SHAPE entities from DXF JSON.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbHatch.spec.ts packages/data-model/__tests__/AcDbMText.spec.ts packages/data-model/__tests__/AcDbPolyline.spec.ts`
- [x] `pnpm test -- packages/data-model/__tests__/AcDbShape.spec.ts packages/data-model/__tests__/AcDbTextStyleTableRecord.spec.ts packages/dxf-json-converter/__tests__/AcDbEntityConverter.spec.ts`
- [ ] Spot-check round-trip in AutoCAD / compatible viewer: hatched drawing, wide LWPOLYLINE, MText with extentsWidth, and SHAPE entities from DWG-exported DXF