### PR TITLE
fix(data-model): make the CLASSES conversion stage optional

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabaseConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabaseConverter.spec.ts
@@ -1,0 +1,38 @@
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
+import { AcDbDatabaseConverter } from '../src/database/AcDbDatabaseConverter'
+
+class LegacyConverter extends AcDbDatabaseConverter<unknown> {
+  // Simulates a converter compiled before the CLASSES stage existed:
+  // it overrides nothing beyond what the abstract base requires.
+}
+
+describe('AcDbDatabaseConverter', () => {
+  it('treats the CLASSES stage as optional for legacy converters', () => {
+    const converter = new LegacyConverter()
+    const db = new AcDbDatabase()
+
+    // The HEADER task calls processClasses unconditionally; a legacy
+    // converter without an override must not abort the conversion
+    // (regression: mlightcad/cad-viewer#437).
+    expect(() =>
+      (
+        converter as unknown as {
+          processClasses(model: unknown, db: AcDbDatabase): void
+        }
+      ).processClasses({}, db)
+    ).not.toThrow()
+  })
+
+  it('keeps mandatory stages throwing for unimplemented converters', () => {
+    const converter = new LegacyConverter()
+    const db = new AcDbDatabase()
+
+    expect(() =>
+      (
+        converter as unknown as {
+          processHeader(model: unknown, db: AcDbDatabase): void
+        }
+      ).processHeader({}, db)
+    ).toThrow()
+  })
+})

--- a/packages/data-model/src/database/AcDbDatabaseConverter.ts
+++ b/packages/data-model/src/database/AcDbDatabaseConverter.ts
@@ -738,8 +738,16 @@ export abstract class AcDbDatabaseConverter<TModel = unknown> {
     throw new Error('Not impelemented yet!')
   }
 
+  /**
+   * Optional stage: CLASSES metadata only augments the database and older
+   * converters predate it. A throwing default (like the mandatory stages
+   * above) would break any converter compiled before this stage existed —
+   * the HEADER task calls it unconditionally, so a data-model upgrade
+   * without a matching converter upgrade aborted every file open with
+   * "Error occurred in conversion stage HEADER" (mlightcad/cad-viewer#437).
+   */
   protected processClasses(_model: TModel, _db: AcDbDatabase) {
-    throw new Error('Not impelemented yet!')
+    // No-op by default; converters that extract CLASSES override this.
   }
 
   protected processBlockTables(_model: TModel, _db: AcDbDatabase) {


### PR DESCRIPTION
## Summary

Fixes the regression reported in mlightcad/cad-viewer#437 ("files no longer open after updating to 1.5.7").

819ae93 (#144, released in v1.10.6) added `processClasses` to the HEADER conversion task with a throwing default, like the mandatory stages. But the CLASSES stage only augments the database with class metadata, and any converter compiled before the stage existed has no override. The HEADER task calls `processClasses` unconditionally, so a `@mlightcad/data-model` upgrade without a lockstep converter upgrade (a partial lockfile update, or a converter release whose `^` range floats data-model forward) aborts **every** file open:

```
Error occurred in conversion stage HEADER: Error: Not impelemented yet!
    at AcDbDatabaseConverter.processClasses
```

## Change

- `processClasses` base default is now a no-op instead of throwing. Converters that extract CLASSES (dxf-json, libredwg, libdxfrw) already override it and are unaffected.
- Mandatory stages keep their throwing defaults.
- New unit test locks the contract: CLASSES optional, HEADER still mandatory.

## Tests

- `packages/data-model`: 724/724 passing.