### PR TITLE
feat(data-model): add block xref flags and unresolved detection

### DIFF
--- a/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
@@ -1,8 +1,25 @@
-import { AcDbBlockTableRecord } from '../src/database/AcDbBlockTableRecord'
+import { AcDbBlockTableRecord, AcDbBlockTableRecordFlag } from '../src/database/AcDbBlockTableRecord'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
 
 describe('AcDbBlockTableRecord', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbBlockTableRecord())
+  })
+
+  it('detects unresolved xrefs from flags and empty content', () => {
+    const xref = new AcDbBlockTableRecord()
+    xref.name = 'BASE'
+    xref.flags = AcDbBlockTableRecordFlag.Xref
+    xref.pathName = 'C:\\drawings\\base.dwg'
+    expect(xref.isXref).toBe(true)
+    expect(xref.isOverlayReference).toBe(false)
+    expect(xref.isUnresolvedXref).toBe(true)
+
+    const overlay = new AcDbBlockTableRecord()
+    overlay.flags =
+      AcDbBlockTableRecordFlag.XrefOverlay | AcDbBlockTableRecordFlag.Resolved
+    expect(overlay.isXref).toBe(true)
+    expect(overlay.isOverlayReference).toBe(true)
+    expect(overlay.isUnresolvedXref).toBe(false)
   })
 })

--- a/packages/data-model/src/database/AcDbBlockTable.ts
+++ b/packages/data-model/src/database/AcDbBlockTable.ts
@@ -100,6 +100,26 @@ export class AcDbBlockTable extends AcDbSymbolTable<AcDbBlockTableRecord> {
   }
 
   /**
+   * Returns all block table records that are external references (or overlays).
+   */
+  getXrefs(): AcDbBlockTableRecord[] {
+    const result: AcDbBlockTableRecord[] = []
+    for (const btr of this.newIterator()) {
+      if (btr.isXref) {
+        result.push(btr)
+      }
+    }
+    return result
+  }
+
+  /**
+   * Returns xref block table records whose external content has not been loaded.
+   */
+  getUnresolvedXrefs(): AcDbBlockTableRecord[] {
+    return this.getXrefs().filter(btr => btr.isUnresolvedXref)
+  }
+
+  /**
    * Normalizes the specified block table record name if it is one paper spacce or model space
    * block table record.
    *

--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -35,6 +35,30 @@ export enum AcDbBlockScaling {
 }
 
 /**
+ * Block-type flags for {@link AcDbBlockTableRecord} (DXF group code 70 on BLOCK).
+ *
+ * Bit values may be combined.
+ */
+export enum AcDbBlockTableRecordFlag {
+  /** No special block type flags apply */
+  None = 0,
+  /** Anonymous block (hatch, associative dimension, etc.) */
+  Anonymous = 1,
+  /** Block has non-constant attribute definitions */
+  HasNonConstantAttributes = 2,
+  /** External reference (xref) */
+  Xref = 4,
+  /** Xref overlay */
+  XrefOverlay = 8,
+  /** Externally dependent */
+  ExternallyDependent = 16,
+  /** Resolved external reference (or dependent of one) */
+  Resolved = 32,
+  /** Referenced external reference */
+  Referenced = 64
+}
+
+/**
  * Interface defining the attributes for block table records.
  */
 export interface AcDbBlockTableRecordAttrs extends AcDbSymbolTableRecordAttrs {
@@ -42,12 +66,22 @@ export interface AcDbBlockTableRecordAttrs extends AcDbSymbolTableRecordAttrs {
   origin: AcGePoint3d
   /** The object id of the associated AcDbLayout object in the Layouts dictionary */
   layoutId: AcDbObjectId
-  /** Block insertion units (DXF group code 70) */
+  /** Block insertion units (DXF group code 70 on BLOCK_RECORD) */
   blockInsertUnits: AcDbUnitsValue
   /** Block explodability flag (DXF group code 280) */
   explodability: number
   /** Block scalability flag (DXF group code 281) */
   blockScaling: AcDbBlockScaling
+  /**
+   * Block-type flags (DXF group code 70 on BLOCK / BLOCK_HEADER).
+   * See {@link AcDbBlockTableRecordFlag}.
+   */
+  flags: number
+  /**
+   * Path name of the externally referenced drawing when this block is an xref
+   * (DXF group code 1 on BLOCK). Empty when not an xref or the path is unknown.
+   */
+  pathName: string
   /** Binary data for bitmap preview (DXF group code 310, optional) */
   bmpPreview?: string
 }
@@ -122,6 +156,8 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
     defaults(attrs, {
       origin: new AcGePoint3d(),
       layoutId: '',
+      flags: AcDbBlockTableRecordFlag.None,
+      pathName: '',
       blockInsertUnits: 0,
       explodability: 1,
       blockScaling: AcDbBlockScaling.Uniform,
@@ -209,6 +245,63 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
   }
   set layoutId(value: AcDbObjectId) {
     this.setAttr('layoutId', value)
+  }
+
+  /**
+   * Gets or sets block-type flags (DXF BLOCK group code 70).
+   *
+   * @see {@link AcDbBlockTableRecordFlag}
+   */
+  get flags() {
+    return this.getAttr('flags')
+  }
+  set flags(value: number) {
+    this.setAttr('flags', value)
+  }
+
+  /**
+   * Gets or sets the path of the externally referenced drawing.
+   *
+   * Corresponds to DXF BLOCK group code 1. Empty when this is not an xref.
+   */
+  get pathName() {
+    return this.getAttr('pathName')
+  }
+  set pathName(value: string) {
+    this.setAttr('pathName', value)
+  }
+
+  /**
+   * True when this block is an external reference or an xref overlay.
+   */
+  get isXref() {
+    return (
+      (this.flags &
+        (AcDbBlockTableRecordFlag.Xref |
+          AcDbBlockTableRecordFlag.XrefOverlay)) !==
+      0
+    )
+  }
+
+  /**
+   * True when this block is an xref overlay (flag bit 8).
+   */
+  get isOverlayReference() {
+    return (this.flags & AcDbBlockTableRecordFlag.XrefOverlay) !== 0
+  }
+
+  /**
+   * True when this is an xref whose content has not been loaded into the block.
+   *
+   * Uses the Resolved flag when set by the converter; otherwise treats an empty
+   * xref block as unresolved (the web converters do not yet bind xref content).
+   */
+  get isUnresolvedXref() {
+    if (!this.isXref) return false
+    if ((this.flags & AcDbBlockTableRecordFlag.Resolved) !== 0) {
+      return false
+    }
+    return this._entities.length === 0
   }
 
   /**
@@ -466,9 +559,12 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
     filer.writeString(8, '0')
     filer.writeSubclassMarker('AcDbBlockBegin')
     filer.writeString(2, this.name)
-    filer.writeInt16(70, 0)
+    filer.writeInt16(70, this.flags)
     filer.writePoint3d(10, this.origin)
     filer.writeString(3, this.name)
+    if (this.pathName) {
+      filer.writeString(1, this.pathName)
+    }
     return this
   }
 

--- a/packages/data-model/src/database/index.ts
+++ b/packages/data-model/src/database/index.ts
@@ -17,7 +17,11 @@ export type {
 export { AcDbOpenDatabaseError } from './AcDbOpenDatabaseError'
 export type { AcDbOpenDatabaseErrorCode } from './AcDbOpenDatabaseError'
 export { AcDbBlockTable } from './AcDbBlockTable'
-export { AcDbBlockScaling, AcDbBlockTableRecord } from './AcDbBlockTableRecord'
+export {
+  AcDbBlockScaling,
+  AcDbBlockTableRecord,
+  AcDbBlockTableRecordFlag
+} from './AcDbBlockTableRecord'
 export type { AcDbBlockTableRecordAttrs } from './AcDbBlockTableRecord'
 export { AcDbDatabaseConverter } from './AcDbDatabaseConverter'
 export type {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -43,6 +43,7 @@ export {
   AcDbBlockScaling,
   AcDbBlockTable,
   AcDbBlockTableRecord,
+  AcDbBlockTableRecordFlag,
   AcDbDatabase,
   AcDbDatabaseConverter,
   AcDbDatabaseConverterManager,

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -5,6 +5,7 @@ import {
   AcDbBlockReference,
   AcDbBlockScaling,
   AcDbBlockTableRecord,
+  AcDbBlockTableRecordFlag,
   AcDbConversionProgressCallback,
   AcDbDatabase,
   AcDbDatabaseConverter,
@@ -431,6 +432,15 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       // processBlockTables may create the record first without a base point.
       // Always sync origin from the BLOCKS section before expanding entities.
       dbBlock.origin.copy(block.position)
+      const blockFlags = block.type ?? 0
+      dbBlock.flags = blockFlags
+      if (block.xrefPath) {
+        dbBlock.pathName = block.xrefPath
+        // Some files only carry the path without flag bits; treat as xref.
+        if (!dbBlock.isXref) {
+          dbBlock.flags = blockFlags | AcDbBlockTableRecordFlag.Xref
+        }
+      }
       if (block.entities) {
         // Process entities in user-defined blocks
         this.processEntitiesInBlock(

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -479,6 +479,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         dbBlock.name = btr.name
         dbBlock.ownerId = btr.ownerHandle
         dbBlock.layoutId = btr.layout
+        dbBlock.flags = btr.flags ?? 0
         dbBlock.blockInsertUnits = btr.insertionUnits
         dbBlock.explodability = btr.explodability
         dbBlock.blockScaling = btr.scalability as AcDbBlockScaling


### PR DESCRIPTION
## Summary
- Add `AcDbBlockTableRecordFlag`, `flags`/`pathName`, and helpers (`isXref`, `isOverlayReference`, `isUnresolvedXref`) on block table records, plus `getXrefs` / `getUnresolvedXrefs` on `AcDbBlockTable`.
- Wire DXF converter to populate flags/xref path (and treat path-only blocks as xrefs); map LibreDwg `flags` onto block records; write flags/path on DXF round-trip.
- Cover unresolved/overlay detection with unit tests.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts`
- [ ] Open a DXF/DWG that contains unresolved xrefs and confirm `blockTable.getUnresolvedXrefs()` returns them with `pathName` when available
- [ ] Confirm non-xref blocks are unchanged in flags default (0) and DXF write of group 70