### PR TITLE
fix(data-model): assign TEMP handles to unbound AcDbObjects

### DIFF
--- a/packages/data-model/__tests__/AcDbObject.spec.ts
+++ b/packages/data-model/__tests__/AcDbObject.spec.ts
@@ -1,8 +1,39 @@
-import { AcDbObject } from '../src/base/AcDbObject'
+import { AcDbObject, TEMP_OBJECT_ID_PREFIX } from '../src/base/AcDbObject'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
+import { AcDbDatabase } from '../src/database/AcDbDatabase'
 import { expectDetachedClone } from '../test-utils/cloneTestUtils'
+
+function getWorkingDatabaseSlot(): {
+  get: () => AcDbDatabase | null
+  set: (db: AcDbDatabase | null) => void
+} {
+  const services = acdbHostApplicationServices() as unknown as {
+    _workingDatabase: AcDbDatabase | null
+  }
+  return {
+    get: () => services._workingDatabase,
+    set: (db) => {
+      services._workingDatabase = db
+    }
+  }
+}
 
 describe('AcDbObject', () => {
   it('creates a detached clone with a new objectId', () => {
     expectDetachedClone(() => new AcDbObject())
+  })
+
+  it('assigns a TEMP_ handle when not yet bound to a database, even if a working database exists', () => {
+    const slot = getWorkingDatabaseSlot()
+    const previousDb = slot.get()
+    const working = new AcDbDatabase()
+    slot.set(working)
+    try {
+      const obj = new AcDbObject()
+      expect(obj.objectId.startsWith(TEMP_OBJECT_ID_PREFIX)).toBe(true)
+      expect(obj.isTemp).toBe(true)
+    } finally {
+      slot.set(previousDb)
+    }
   })
 })

--- a/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
+++ b/packages/data-model/__tests__/AcDbPolygonMesh.spec.ts
@@ -39,7 +39,9 @@ describe('AcDbPolygonMesh', () => {
     expect(mesh.closedN).toBe(false)
     expect(mesh.closed).toBe(true)
     expect(mesh.numberOfVertices).toBe(4)
-    expect(mesh.objectId.startsWith('TEMP_')).toBe(false)
+    // Detached entities keep TEMP_ ids until committed to a database, even when
+    // a working database is present.
+    expect(mesh.objectId.startsWith('TEMP_')).toBe(true)
 
     mesh.closed = false
     expect(mesh.closed).toBe(false)

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -89,12 +89,15 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
     this._attrs = new AcCmObject<ATTRS>(attrs, defaultAttrs)
     this._xDataMap = new Map()
 
-    // Generate objectId from database if not provided
+    // Generate objectId if not provided. Only use a real database handle when this
+    // object is already bound to a database (`_database`). Falling back to the
+    // global working database here would mint a non-TEMP handle for a detached
+    // object, which then fails assertOpenForWrite during secondary-database
+    // imports (e.g. XATTACH) while the host document is recording undo.
     if (!this._attrs.get('objectId')) {
-      try {
-        this._attrs.set('objectId', this.database.generateHandle())
-      } catch {
-        // Fallback: generate a temporary handle, will be reassigned when added to database
+      if (this._database) {
+        this._attrs.set('objectId', this._database.generateHandle())
+      } else {
         this._attrs.set('objectId', this.generateTemporaryHandle())
       }
     }

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -258,14 +258,25 @@ export class AcDbBlockReference extends AcDbEntity {
   /**
    * Propagates this INSERT's database association to all attached attributes.
    *
+   * Also refreshes each attribute's {@link AcDbObject.ownerId} and commits a
+   * real database handle. Attributes may have been appended while this INSERT
+   * still had a TEMP_ id; once the INSERT is committed those stale owner ids
+   * (and TEMP_ attribute handles) must be replaced so DXF round-trips and
+   * owner lookups keep working.
+   *
    * @internal
    */
   syncAttributeDatabases() {
     try {
       const db = this.database
+      const next = new Map<string, AcDbAttribute>()
       this._attribs.forEach(attrib => {
         attrib.database = db
+        attrib.ownerId = this.objectId
+        db.commitObjectHandle(attrib)
+        next.set(attrib.objectId, attrib)
       })
+      this._attribs = next
     } catch {
       // INSERT not yet associated with a database.
     }


### PR DESCRIPTION
## Summary
- Stop falling back to the global working database when minting handles in `AcDbObject` construction; unbound objects now always get `TEMP_` ids until they are added to a database.
- This prevents `assertOpenForWrite` failures during secondary-database imports (e.g. XATTACH) while the host document is recording undo.
- Add a regression test that verifies TEMP handles are assigned even when a working database is present.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbObject.spec.ts`
- [ ] Manually verify XATTACH / secondary-database import no longer throws on symbol-table mutations under an active undo transaction