### PR TITLE
feat(data-model): support OLE frames and layer filters

### DIFF
--- a/packages/data-model/__tests__/AcDbOle2Frame.spec.ts
+++ b/packages/data-model/__tests__/AcDbOle2Frame.spec.ts
@@ -1,0 +1,180 @@
+import { AcGeMatrix3d, AcGePoint3d } from '@mlightcad/geometry-engine'
+
+import { AcDbOle2Frame } from '../src/entity'
+import { acdbExtractOleImageBlob } from '../src/misc/AcDbOleImageExtractor'
+
+/**
+ * Builds a minimal 1x1 24-bit BMP (white pixel).
+ */
+function createMinimalBmp() {
+  // BITMAPFILEHEADER (14) + BITMAPINFOHEADER (40) + pixel row (4 bytes padded)
+  const bmp = new Uint8Array(58)
+  const view = new DataView(bmp.buffer)
+  bmp[0] = 0x42 // B
+  bmp[1] = 0x4d // M
+  view.setUint32(2, 58, true) // bfSize
+  view.setUint32(10, 54, true) // bfOffBits
+  view.setUint32(14, 40, true) // biSize
+  view.setInt32(18, 1, true) // biWidth
+  view.setInt32(22, 1, true) // biHeight
+  view.setUint16(26, 1, true) // biPlanes
+  view.setUint16(28, 24, true) // biBitCount
+  view.setUint32(34, 4, true) // biSizeImage
+  // Pixel BGR + pad
+  bmp[54] = 0xff
+  bmp[55] = 0xff
+  bmp[56] = 0xff
+  bmp[57] = 0x00
+  return bmp
+}
+
+describe('acdbExtractOleImageBlob', () => {
+  it('extracts a BMP embedded directly in the OLE payload', () => {
+    const bmp = createMinimalBmp()
+    const padded = new Uint8Array(32 + bmp.length)
+    padded.set([0x01, 0x55, 0x80], 0)
+    padded.set(bmp, 32)
+
+    const blob = acdbExtractOleImageBlob(padded)
+    expect(blob).toBeDefined()
+    expect(blob?.type).toBe('image/bmp')
+    expect(blob?.size).toBe(bmp.length)
+  })
+
+  it('extracts a packed DIB by wrapping it as BMP', () => {
+    const dib = new Uint8Array(44)
+    const view = new DataView(dib.buffer)
+    view.setUint32(0, 40, true) // biSize
+    view.setInt32(4, 1, true) // width
+    view.setInt32(8, 1, true) // height
+    view.setUint16(12, 1, true) // planes
+    view.setUint16(14, 24, true) // bitCount
+    view.setUint32(20, 4, true) // sizeImage
+    dib[40] = 0x11
+    dib[41] = 0x22
+    dib[42] = 0x33
+    dib[43] = 0x00
+
+    const blob = acdbExtractOleImageBlob(dib)
+    expect(blob).toBeDefined()
+    expect(blob?.type).toBe('image/bmp')
+    expect(blob?.size).toBe(14 + dib.length)
+  })
+
+  it('returns undefined for non-image payloads', () => {
+    expect(acdbExtractOleImageBlob(new Uint8Array([1, 2, 3, 4]))).toBeUndefined()
+    expect(acdbExtractOleImageBlob(undefined)).toBeUndefined()
+  })
+})
+
+describe('AcDbOle2Frame image drawing', () => {
+  it('draws extracted image through renderer.image', () => {
+    const ole = new AcDbOle2Frame()
+    ole.upperLeftCorner = new AcGePoint3d(0, 10, 0)
+    ole.lowerRightCorner = new AcGePoint3d(20, 0, 0)
+    ole.setOleObject(createMinimalBmp())
+
+    expect(ole.image).toBeDefined()
+    expect(ole.image?.type).toBe('image/bmp')
+
+    const renderer = {
+      lines: jest.fn((_points: AcGePoint3d[]) => ({ kind: 'lines' })),
+      image: jest.fn(
+        (
+          _blob: Blob,
+          _style: { boundary: AcGePoint3d[]; roation: number }
+        ) => ({
+          kind: 'image'
+        })
+      )
+    }
+    const drawable = ole.subWorldDraw(renderer as never)
+    expect(drawable).toEqual({ kind: 'image' })
+    expect(renderer.image).toHaveBeenCalledTimes(1)
+    expect(renderer.lines).not.toHaveBeenCalled()
+
+    const [blob, style] = renderer.image.mock.calls[0]
+    expect(blob).toBe(ole.image)
+    expect(style.boundary).toHaveLength(5)
+    expect(style.boundary[0]).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(style.boundary[1]).toMatchObject({ x: 20, y: 0, z: 0 })
+    expect(style.boundary[2]).toMatchObject({ x: 20, y: 10, z: 0 })
+    expect(style.boundary[3]).toMatchObject({ x: 0, y: 10, z: 0 })
+  })
+
+  it('falls back to frame outline when no image is present', () => {
+    const ole = new AcDbOle2Frame()
+    ole.upperLeftCorner = new AcGePoint3d(0, 5, 0)
+    ole.lowerRightCorner = new AcGePoint3d(5, 0, 0)
+
+    const renderer = {
+      lines: jest.fn((_points: AcGePoint3d[]) => ({ kind: 'lines' })),
+      image: jest.fn(
+        (
+          _blob: Blob,
+          _style: { boundary: AcGePoint3d[]; roation: number }
+        ) => ({
+          kind: 'image'
+        })
+      )
+    }
+    const drawable = ole.subWorldDraw(renderer as never)
+    expect(drawable).toEqual({ kind: 'lines' })
+    expect(renderer.image).not.toHaveBeenCalled()
+    expect(renderer.lines).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps transformed image and frame boundaries aligned', () => {
+    const ole = new AcDbOle2Frame()
+    ole.upperLeftCorner = new AcGePoint3d(0, 10, 0)
+    ole.lowerRightCorner = new AcGePoint3d(20, 0, 0)
+    ole.setOleObject(createMinimalBmp())
+    ole.transformBy(new AcGeMatrix3d().makeRotationZ(Math.PI / 2))
+
+    const imageRenderer = {
+      lines: jest.fn(),
+      image: jest.fn(
+        (
+          _blob: Blob,
+          _style: { boundary: AcGePoint3d[]; roation: number }
+        ) => ({
+          kind: 'image'
+        })
+      )
+    }
+    ole.subWorldDraw(imageRenderer as never)
+
+    const outlineRenderer = {
+      lines: jest.fn((_points: AcGePoint3d[]) => ({ kind: 'lines' })),
+      image: jest.fn()
+    }
+    ole.setOleObject(new Uint8Array([0, 1, 2, 3]))
+    ole.subWorldDraw(outlineRenderer as never)
+
+    const imageBoundary = imageRenderer.image.mock.calls[0][1].boundary
+    const frameBoundary = outlineRenderer.lines.mock.calls[0][0]
+    const expectedImageBoundary = [
+      frameBoundary[3],
+      frameBoundary[2],
+      frameBoundary[1],
+      frameBoundary[0],
+      frameBoundary[3]
+    ]
+
+    expectedImageBoundary.forEach((point, index) => {
+      expect(imageBoundary[index].x).toBeCloseTo(point.x)
+      expect(imageBoundary[index].y).toBeCloseTo(point.y)
+      expect(imageBoundary[index].z).toBeCloseTo(point.z)
+    })
+  })
+
+  it('invalidates cached image when OLE payload changes', () => {
+    const ole = new AcDbOle2Frame()
+    ole.setOleObject(createMinimalBmp())
+    const first = ole.image
+    expect(first).toBeDefined()
+
+    ole.setOleObject(new Uint8Array([0, 1, 2, 3]))
+    expect(ole.image).toBeUndefined()
+  })
+})

--- a/packages/data-model/src/converter/AcDbRegenerator.ts
+++ b/packages/data-model/src/converter/AcDbRegenerator.ts
@@ -172,6 +172,24 @@ export class AcDbRegenerator extends AcDbDatabaseConverter<AcDbDatabase> {
         key: mleaderStyle.objectId
       })
     }
+
+    const layerFilters = this._database.objects.layerFilter.newIterator()
+    for (const layerFilter of layerFilters) {
+      this._database.events.dictObjetSet.dispatch({
+        database: this._database,
+        object: layerFilter,
+        key: layerFilter.objectId
+      })
+    }
+
+    const layerIndexes = this._database.objects.layerIndex.newIterator()
+    for (const layerIndex of layerIndexes) {
+      this._database.events.dictObjetSet.dispatch({
+        database: this._database,
+        object: layerIndex,
+        key: layerIndex.objectId
+      })
+    }
   }
 
   /**

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -34,10 +34,20 @@ import { AcDbFormatter } from '../misc/AcDbFormatter'
 import { AcDbLinearUnits } from '../misc/AcDbLinearUnits'
 import { AcDbUnitsValue } from '../misc/AcDbUnitsValue'
 import { AcDbDictionary } from '../object/AcDbDictionary'
+import { AcDbLayerFilter } from '../object/AcDbLayerFilter'
+import { AcDbLayerIndex } from '../object/AcDbLayerIndex'
 import { AcDbMLeaderStyle } from '../object/AcDbMLeaderStyle'
 import { AcDbMlineStyle } from '../object/AcDbMlineStyle'
 import { AcDbRasterImageDef } from '../object/AcDbRasterImageDef'
 import { AcDbXrecord } from '../object/AcDbXrecord'
+import { AcLyLayerFilterTree } from '../ly/AcLyLayerFilterTree'
+import {
+  ACAD_LAYERFILTERS_NAME,
+  ACLY_DICTIONARY_NAME,
+  acdbLayerGroupsToResultBuffer,
+  acdbSerializeLayerFilterTree,
+  type AcDbSerializedFilterNode
+} from '../ly/AcLyLayerFilterIO'
 import { AcDbBlockTable } from './AcDbBlockTable'
 import { AcDbBlockTableRecord } from './AcDbBlockTableRecord'
 import { AcDbConversionStage, AcDbStageStatus } from './AcDbDatabaseConverter'
@@ -418,6 +428,8 @@ export class AcDbDatabase extends AcDbObject {
   private _objects: {
     readonly dictionary: AcDbDictionary<AcDbDictionary>
     readonly imageDefinition: AcDbDictionary<AcDbRasterImageDef>
+    readonly layerFilter: AcDbDictionary<AcDbLayerFilter>
+    readonly layerIndex: AcDbDictionary<AcDbLayerIndex>
     readonly layout: AcDbLayoutDictionary
     readonly mleaderStyle: AcDbDictionary<AcDbMLeaderStyle>
     readonly mlineStyle: AcDbDictionary<AcDbMlineStyle>
@@ -438,6 +450,11 @@ export class AcDbDatabase extends AcDbObject {
   private _drawNoPlotLayers = true
   /** Current drawing file name (**DWGNAME**), including extension. */
   private _dwgname: string
+  /**
+   * Layer Properties Manager filter tree (`AcLy*` / .NET `LayerFilterTree`).
+   * Distinct from {@link objects.layerFilter} (`AcDbLayerFilter` index objects).
+   */
+  private _layerFilters: AcLyLayerFilterTree
 
   /** Manages transactions and undo/redo for this database. */
   readonly transactionManager: AcDbDatabaseTransactionManager
@@ -531,11 +548,14 @@ export class AcDbDatabase extends AcDbObject {
     this._objects = {
       dictionary: new AcDbDictionary(this),
       imageDefinition: new AcDbDictionary(this),
+      layerFilter: new AcDbDictionary(this),
+      layerIndex: new AcDbDictionary(this),
       layout: new AcDbLayoutDictionary(this),
       mleaderStyle: new AcDbDictionary(this),
       mlineStyle: new AcDbDictionary(this),
       xrecord: new AcDbDictionary(this)
     }
+    this._layerFilters = new AcLyLayerFilterTree()
     this.transactionManager = new AcDbDatabaseTransactionManager(this)
     this.registerBootstrapHandles()
   }
@@ -582,6 +602,43 @@ export class AcDbDatabase extends AcDbObject {
    */
   get objects() {
     return this._objects
+  }
+
+  /**
+   * Gets the Layer Properties Manager filter tree for this database.
+   *
+   * @remarks
+   * Mirrors AutoCAD .NET `Database.LayerFilters` / ObjectARX `AcLy*` filters.
+   * This is the property/group filter **tree**, not the flat
+   * {@link objects.layerFilter} dictionary used by `AcDbLayerFilter` /
+   * `AcDbLayerIndex`.
+   *
+   * Like AutoCAD, treat this value as retrieved by value: mutate the tree,
+   * then assign it back via the setter if your workflow expects that pattern.
+   *
+   * @returns The current {@link AcLyLayerFilterTree}.
+   *
+   * @example
+   * ```typescript
+   * const tree = db.layerFilters;
+   * const filter = new AcLyLayerFilter();
+   * filter.name = 'Unlocked Layers';
+   * filter.setFilterExpression('LOCKED=="False"');
+   * tree.root.addNested(filter);
+   * db.layerFilters = tree;
+   * ```
+   */
+  get layerFilters(): AcLyLayerFilterTree {
+    return this._layerFilters
+  }
+
+  /**
+   * Sets the Layer Properties Manager filter tree for this database.
+   *
+   * @param value - New filter tree.
+   */
+  set layerFilters(value: AcLyLayerFilterTree) {
+    this._layerFilters = value ?? new AcLyLayerFilterTree()
   }
 
   /**
@@ -700,6 +757,8 @@ export class AcDbDatabase extends AcDbObject {
     return [
       this.objects.dictionary,
       this.objects.imageDefinition,
+      this.objects.layerFilter,
+      this.objects.layerIndex,
       this.objects.layout,
       this.objects.mleaderStyle,
       this.objects.mlineStyle,
@@ -991,10 +1050,28 @@ export class AcDbDatabase extends AcDbObject {
   private registerBootstrapHandles() {
     this._handleRegistry.clear()
     this.registerObjectHandle(this)
-    for (const table of Object.values(this._tables)) {
+    for (const table of [
+      this._tables.blockTable,
+      this._tables.dimStyleTable,
+      this._tables.layerTable,
+      this._tables.linetypeTable,
+      this._tables.appIdTable,
+      this._tables.textStyleTable,
+      this._tables.viewTable,
+      this._tables.viewportTable
+    ]) {
       this.registerObjectHandle(table)
     }
-    for (const dictionary of Object.values(this._objects)) {
+    for (const dictionary of [
+      this._objects.dictionary,
+      this._objects.imageDefinition,
+      this._objects.layerFilter,
+      this._objects.layerIndex,
+      this._objects.layout,
+      this._objects.mleaderStyle,
+      this._objects.mlineStyle,
+      this._objects.xrecord
+    ]) {
       this.registerObjectHandle(dictionary)
     }
   }
@@ -2177,6 +2254,12 @@ export class AcDbDatabase extends AcDbObject {
     _saveThumbnailImage: boolean = false
   ) {
     this.ensureDatabaseDefaults()
+    if (
+      this._layerFilters.root.getNestedFilters().length > 0 &&
+      !this.tables.layerTable.extensionDictionary
+    ) {
+      this.tables.layerTable.extensionDictionary = this.generateHandle()
+    }
 
     const outVersion =
       version instanceof AcDbDwgVersion ? version : new AcDbDwgVersion(version)
@@ -2786,6 +2869,16 @@ export class AcDbDatabase extends AcDbObject {
       imageDef.dxfOut(filer)
     }
 
+    for (const [_, layerFilter] of this.objects.layerFilter.entries()) {
+      filer.writeStart('LAYER_FILTER')
+      layerFilter.dxfOut(filer)
+    }
+
+    for (const [_, layerIndex] of this.objects.layerIndex.entries()) {
+      filer.writeStart('LAYER_INDEX')
+      layerIndex.dxfOut(filer)
+    }
+
     for (const [_, mleaderStyle] of this.objects.mleaderStyle.entries()) {
       filer.writeStart('MLEADERSTYLE')
       mleaderStyle.dxfOut(filer)
@@ -2799,7 +2892,149 @@ export class AcDbDatabase extends AcDbObject {
       filer.writeStart('XRECORD')
       xrecord.dxfOut(filer)
     }
+
+    this.writeAcLyLayerFilterObjects(filer)
     filer.endSection()
+  }
+
+  /**
+   * Writes Layer Manager filter tree objects (`ACAD_LAYERFILTERS` /
+   * `ACLYDICTIONARY` + XRecords) into the OBJECTS section and attaches an
+   * extension dictionary to the Layer Table.
+   *
+   * @param filer - DXF output writer.
+   */
+  private writeAcLyLayerFilterObjects(filer: AcDbDxfFiler) {
+    const serialized = acdbSerializeLayerFilterTree(this._layerFilters)
+    if (serialized.nodes.length === 0) {
+      return
+    }
+
+    type BuiltDict = {
+      handle: string
+      ownerId: string
+      entries: { name: string; id: string }[]
+    }
+    type BuiltXRec = {
+      handle: string
+      ownerId: string
+      extensionDictionaryId?: string
+      data: AcDbSerializedFilterNode['data']
+    }
+
+    const dicts: BuiltDict[] = []
+    const xrecs: BuiltXRec[] = []
+    const layerTable = this.tables.layerTable
+    const layerExtHandle =
+      layerTable.extensionDictionary ?? this.generateHandle()
+    layerTable.extensionDictionary = layerExtHandle
+
+    const aclyHandle = this.generateHandle()
+    const acadHandle = this.generateHandle()
+    const rootAclyEntries: { name: string; id: string }[] = []
+    const rootAcadEntries: { name: string; id: string }[] = []
+
+    const emit = (
+      node: AcDbSerializedFilterNode,
+      parentAclyHandle: string,
+      addToLegacy: boolean
+    ): string => {
+      const xHandle = this.generateHandle()
+      let extensionDictionaryId: string | undefined
+      if (node.children.length > 0) {
+        const extHandle = this.generateHandle()
+        const childAclyHandle = this.generateHandle()
+        const childEntries: { name: string; id: string }[] = []
+        for (const child of node.children) {
+          childEntries.push({
+            name: child.key,
+            id: emit(child, childAclyHandle, false)
+          })
+        }
+        dicts.push({
+          handle: extHandle,
+          ownerId: xHandle,
+          entries: [{ name: ACLY_DICTIONARY_NAME, id: childAclyHandle }]
+        })
+        dicts.push({
+          handle: childAclyHandle,
+          ownerId: extHandle,
+          entries: childEntries
+        })
+        extensionDictionaryId = extHandle
+      }
+
+      xrecs.push({
+        handle: xHandle,
+        ownerId: parentAclyHandle,
+        extensionDictionaryId,
+        data: node.data
+      })
+      if (addToLegacy) {
+        rootAcadEntries.push({ name: node.key, id: xHandle })
+      }
+      return xHandle
+    }
+
+    for (const node of serialized.nodes) {
+      rootAclyEntries.push({
+        name: node.key,
+        id: emit(node, aclyHandle, true)
+      })
+    }
+
+    const layerExtEntries = new Map<string, string>()
+    const existingLayerExt = this.getObjectById(layerExtHandle)
+    if (existingLayerExt instanceof AcDbDictionary) {
+      for (const [key, value] of existingLayerExt.entries()) {
+        layerExtEntries.set(key, value.objectId)
+      }
+    }
+    layerExtEntries.set(ACLY_DICTIONARY_NAME, aclyHandle)
+    layerExtEntries.set(ACAD_LAYERFILTERS_NAME, acadHandle)
+
+    dicts.unshift(
+      {
+        handle: layerExtHandle,
+        ownerId: layerTable.objectId,
+        entries: Array.from(layerExtEntries, ([name, id]) => ({ name, id }))
+      },
+      {
+        handle: aclyHandle,
+        ownerId: layerExtHandle,
+        entries: rootAclyEntries
+      },
+      {
+        handle: acadHandle,
+        ownerId: layerExtHandle,
+        entries: rootAcadEntries
+      }
+    )
+
+    for (const dict of dicts) {
+      filer.writeStart('DICTIONARY')
+      filer.writeHandle(5, dict.handle)
+      filer.writeObjectId(330, dict.ownerId)
+      filer.writeSubclassMarker('AcDbDictionary')
+      filer.writeInt16(280, 1)
+      filer.writeInt16(281, 1)
+      for (const entry of dict.entries) {
+        filer.writeString(3, entry.name)
+        filer.writeObjectId(350, entry.id)
+      }
+    }
+
+    for (const item of xrecs) {
+      const xrecord = new AcDbXrecord()
+      xrecord.objectId = item.handle
+      xrecord.ownerId = item.ownerId
+      if (item.extensionDictionaryId) {
+        xrecord.extensionDictionary = item.extensionDictionaryId
+      }
+      xrecord.data = acdbLayerGroupsToResultBuffer(item.data)
+      filer.writeStart('XRECORD')
+      xrecord.dxfOut(filer)
+    }
   }
 
   /**
@@ -2878,9 +3113,12 @@ export class AcDbDatabase extends AcDbObject {
     this._tables.viewportTable.removeAll()
     this._objects.layout.removeAll()
     this._objects.imageDefinition.removeAll()
+    this._objects.layerFilter.removeAll()
+    this._objects.layerIndex.removeAll()
     this._objects.mleaderStyle.removeAll()
     this._objects.mlineStyle.removeAll()
     this._objects.xrecord.removeAll()
+    this._layerFilters = new AcLyLayerFilterTree()
     this._currentSpace = undefined
     this._extents.makeEmpty()
     this.registerBootstrapHandles()

--- a/packages/data-model/src/entity/AcDbFrame.ts
+++ b/packages/data-model/src/entity/AcDbFrame.ts
@@ -1,0 +1,15 @@
+import { AcDbEntity } from './AcDbEntity'
+
+/**
+ * Abstract base class for OLE container entities.
+ *
+ * {@link AcDbFrame} is the ObjectARX base class for {@link AcDbOleFrame} and
+ * {@link AcDbOle2Frame}. Applications typically use {@link AcDbOle2Frame}
+ * rather than this class directly.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbFrame
+ */
+export abstract class AcDbFrame extends AcDbEntity {
+  /** The entity type name */
+  static override typeName: string = 'Frame'
+}

--- a/packages/data-model/src/entity/AcDbOle2Frame.ts
+++ b/packages/data-model/src/entity/AcDbOle2Frame.ts
@@ -1,0 +1,752 @@
+import {
+  AcGeBox3d,
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGePoint3dLike,
+  AcGeVector3d,
+  AcGeVector3dLike
+} from '@mlightcad/geometry-engine'
+import { AcGiRenderer } from '@mlightcad/graphic-interface'
+
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { acdbExtractOleImageBlob } from '../misc/AcDbOleImageExtractor'
+import { AcDbOsnapMode } from '../misc/AcDbOsnapMode'
+import { bytesToHexString } from '../misc/proxyGraphic'
+import { AcDbEntity } from './AcDbEntity'
+import {
+  acdbForEachGripIndex,
+  acdbMovePointArrayGripAt
+} from './AcDbGripHelpers'
+import { AcDbOleFrame } from './AcDbOleFrame'
+import { acdbCollectVertexPathOsnapPoints } from './AcDbOsnapHelpers'
+
+/**
+ * OLE object type stored with an {@link AcDbOle2Frame} (DXF group code 71).
+ *
+ * @see https://help.autodesk.com/cloudhelp/2018/ENU/AutoCAD-DXF/files/GUID-77747CE6-82C6-4452-97ED-4CEEB38BE960.htm
+ */
+export enum AcDbOleObjectType {
+  /** Linked OLE object */
+  Link = 1,
+  /** Embedded OLE object */
+  Embedded = 2,
+  /** Static OLE object */
+  Static = 3
+}
+
+/**
+ * Tile-mode descriptor stored with an {@link AcDbOle2Frame} (DXF group code 72).
+ *
+ * Distinct from the common entity paper-space flag (group code 67).
+ */
+export enum AcDbOleTileMode {
+  /** Object resides in model space */
+  ModelSpace = 0,
+  /** Object resides in paper space */
+  PaperSpace = 1
+}
+
+/**
+ * Axis-aligned OLE frame rectangle in WCS, analogous to ObjectARX
+ * `CRectangle3d`.
+ */
+export interface AcDbOleRectangle3d {
+  /** Upper-left corner in WCS */
+  upperLeft: AcGePoint3dLike
+  /** Upper-right corner in WCS */
+  upperRight: AcGePoint3dLike
+  /** Lower-left corner in WCS */
+  lowerLeft: AcGePoint3dLike
+  /** Lower-right corner in WCS */
+  lowerRight: AcGePoint3dLike
+}
+
+/**
+ * Represents an OLE 2 frame entity in AutoCAD.
+ *
+ * {@link AcDbOle2Frame} provides a display frame for an OLE 2 object. It stores
+ * frame geometry (location, width, height, rotation), display settings, link
+ * metadata, and the embedded OLE binary payload inherited from
+ * {@link AcDbOleFrame}.
+ *
+ * Platform-specific MFC types such as `COleClientItem` are represented as opaque
+ * values in this TypeScript port.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbOle2Frame
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-__MEMBERTYPE_Methods_AcDbOle2Frame
+ *
+ * @example
+ * ```typescript
+ * const ole = new AcDbOle2Frame()
+ * ole.setLocation(new AcGePoint3d(0, 10, 0))
+ * ole.setWcsWidth(100)
+ * ole.setWcsHeight(75)
+ * ole.userType = 'Paintbrush Picture'
+ * ole.oleObjectType = AcDbOleObjectType.Embedded
+ * ```
+ */
+export class AcDbOle2Frame extends AcDbOleFrame {
+  /** The entity type name */
+  static override typeName: string = 'Ole2Frame'
+
+  override get dxfTypeName() {
+    return 'OLE2FRAME'
+  }
+
+  /** Upper-left corner of the frame in WCS. */
+  private _upperLeft = new AcGePoint3d()
+  /** Lower-right corner of the frame in WCS. */
+  private _lowerRight = new AcGePoint3d()
+  /** Rotation angle in radians. */
+  private _rotation = 0
+  /** Relative scale factor applied to the frame width. */
+  private _scaleWidth = 1
+  /** Relative scale factor applied to the frame height. */
+  private _scaleHeight = 1
+  /** Whether the aspect ratio is locked. */
+  private _lockAspect = false
+  /** Output quality value (DXF group code 73 when present). */
+  private _outputQuality = 0
+  /** Automatic output quality flag. */
+  private _autoOutputQuality = 0
+  /** OLE object type (link / embedded / static). */
+  private _oleObjectType = AcDbOleObjectType.Embedded
+  /** Tile-mode descriptor. */
+  private _tileMode = AcDbOleTileMode.ModelSpace
+  /** User-visible OLE type description (DXF group code 3). */
+  private _userType = ''
+  /** Linked OLE object name. */
+  private _linkName = ''
+  /** Linked OLE object path. */
+  private _linkPath = ''
+  /**
+   * Opaque host OLE client item.
+   *
+   * Mirrors ObjectARX `COleClientItem*`. There is no MFC host in the browser
+   * runtime, so this value is application-defined.
+   */
+  private _oleClientItem: unknown = null
+  /** Cached image decoded from the OLE binary payload. */
+  private _image?: Blob
+  /** Whether image extraction from the current OLE payload has been attempted. */
+  private _imageResolved = false
+
+  /**
+   * Creates a new OLE 2 frame entity.
+   *
+   * Objects created with this constructor must receive a valid OLE payload
+   * through {@link setOleObject} (or host-specific client-item APIs) before they
+   * represent a complete OLE entity.
+   */
+  constructor() {
+    super()
+  }
+
+  /**
+   * Gets the upper-left corner of this frame in WCS.
+   */
+  get upperLeftCorner(): AcGePoint3d {
+    return this._upperLeft
+  }
+
+  /**
+   * Sets the upper-left corner of this frame in WCS.
+   */
+  set upperLeftCorner(value: AcGePoint3dLike) {
+    this._upperLeft.copy(value)
+  }
+
+  /**
+   * Gets the lower-right corner of this frame in WCS.
+   */
+  get lowerRightCorner(): AcGePoint3d {
+    return this._lowerRight
+  }
+
+  /**
+   * Sets the lower-right corner of this frame in WCS.
+   */
+  set lowerRightCorner(value: AcGePoint3dLike) {
+    this._lowerRight.copy(value)
+  }
+
+  /**
+   * Gets the location (upper-left corner) of this OLE frame in WCS.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getLocation`.
+   */
+  getLocation(result?: AcGePoint3d): AcGePoint3d {
+    if (result) {
+      return result.copy(this._upperLeft)
+    }
+    return this._upperLeft.clone()
+  }
+
+  /**
+   * Sets the location (upper-left corner) of this OLE frame in WCS.
+   *
+   * The lower-right corner is translated by the same delta so the frame size is
+   * preserved.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setLocation`.
+   */
+  setLocation(value: AcGePoint3dLike) {
+    const dx = value.x - this._upperLeft.x
+    const dy = value.y - this._upperLeft.y
+    const dz = (value.z ?? 0) - this._upperLeft.z
+    this._upperLeft.copy(value)
+    this._lowerRight.x += dx
+    this._lowerRight.y += dy
+    this._lowerRight.z += dz
+  }
+
+  /**
+   * Gets the frame rectangle in WCS.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::position(CRectangle3d&)`.
+   */
+  position(): AcDbOleRectangle3d {
+    return {
+      upperLeft: this._upperLeft.clone(),
+      upperRight: this.cornerUpperRight(),
+      lowerLeft: this.cornerLowerLeft(),
+      lowerRight: this._lowerRight.clone()
+    }
+  }
+
+  /**
+   * Sets the frame rectangle in WCS from the given corner points.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setPosition(const CRectangle3d&)`.
+   * Only the upper-left and lower-right corners are stored; the other two
+   * corners are derived.
+   */
+  setPosition(rect: AcDbOleRectangle3d) {
+    this._upperLeft.copy(rect.upperLeft)
+    this._lowerRight.copy(rect.lowerRight)
+  }
+
+  /**
+   * Gets the frame width in WCS units.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::wcsWidth`.
+   */
+  wcsWidth(): number {
+    return Math.abs(this._lowerRight.x - this._upperLeft.x)
+  }
+
+  /**
+   * Sets the frame width in WCS units, keeping the upper-left corner fixed.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setWcsWidth`.
+   */
+  setWcsWidth(value: number) {
+    const sign = this._lowerRight.x >= this._upperLeft.x ? 1 : -1
+    this._lowerRight.x = this._upperLeft.x + sign * Math.abs(value)
+    if (this._lockAspect) {
+      this.syncHeightFromAspect()
+    }
+  }
+
+  /**
+   * Gets the frame height in WCS units.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::wcsHeight`.
+   */
+  wcsHeight(): number {
+    return Math.abs(this._upperLeft.y - this._lowerRight.y)
+  }
+
+  /**
+   * Sets the frame height in WCS units, keeping the upper-left corner fixed.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setWcsHeight`.
+   */
+  setWcsHeight(value: number) {
+    const sign = this._upperLeft.y >= this._lowerRight.y ? 1 : -1
+    this._lowerRight.y = this._upperLeft.y - sign * Math.abs(value)
+    if (this._lockAspect) {
+      this.syncWidthFromAspect()
+    }
+  }
+
+  /**
+   * Gets the relative width scale factor.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::scaleWidth`.
+   */
+  scaleWidth(): number {
+    return this._scaleWidth
+  }
+
+  /**
+   * Sets the relative width scale factor.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setScaleWidth`.
+   */
+  setScaleWidth(value: number) {
+    this._scaleWidth = value
+  }
+
+  /**
+   * Gets the relative height scale factor.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::scaleHeight`.
+   */
+  scaleHeight(): number {
+    return this._scaleHeight
+  }
+
+  /**
+   * Sets the relative height scale factor.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setScaleHeight`.
+   */
+  setScaleHeight(value: number) {
+    this._scaleHeight = value
+  }
+
+  /**
+   * Gets the rotation angle of this frame in radians.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::rotation`.
+   */
+  rotation(): number {
+    return this._rotation
+  }
+
+  /**
+   * Sets the rotation angle of this frame in radians.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setRotation`.
+   */
+  setRotation(value: number) {
+    this._rotation = value
+  }
+
+  /**
+   * Returns whether the frame aspect ratio is locked.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::lockAspect`.
+   */
+  lockAspect(): boolean {
+    return this._lockAspect
+  }
+
+  /**
+   * Sets whether the frame aspect ratio is locked.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setLockAspect`.
+   */
+  setLockAspect(value: boolean | number) {
+    this._lockAspect = !!value
+  }
+
+  /**
+   * Gets the output quality value.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::outputQuality`.
+   */
+  outputQuality(): number {
+    return this._outputQuality
+  }
+
+  /**
+   * Sets the output quality value.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setOutputQuality`.
+   */
+  setOutputQuality(value: number) {
+    this._outputQuality = value & 0xff
+  }
+
+  /**
+   * Gets the automatic output quality flag.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::autoOutputQuality`.
+   */
+  autoOutputQuality(): number {
+    return this._autoOutputQuality
+  }
+
+  /**
+   * Sets the automatic output quality flag.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setAutoOutputQuality`.
+   */
+  setAutoOutputQuality(value: number) {
+    this._autoOutputQuality = value & 0xff
+  }
+
+  /**
+   * Gets the OLE object type (link / embedded / static).
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getType`.
+   */
+  getType(): AcDbOleObjectType {
+    return this._oleObjectType
+  }
+
+  /**
+   * Sets the OLE object type (link / embedded / static).
+   */
+  setType(value: AcDbOleObjectType) {
+    this._oleObjectType = value
+  }
+
+  /**
+   * Gets the OLE object type (link / embedded / static).
+   *
+   * Prefer {@link getType} when matching ObjectARX naming.
+   */
+  get oleObjectType() {
+    return this._oleObjectType
+  }
+
+  set oleObjectType(value: AcDbOleObjectType) {
+    this._oleObjectType = value
+  }
+
+  /**
+   * Gets the tile-mode descriptor for this frame.
+   */
+  get tileMode() {
+    return this._tileMode
+  }
+
+  set tileMode(value: AcDbOleTileMode) {
+    this._tileMode = value
+  }
+
+  /**
+   * Gets the user-visible OLE type description.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getUserType`. Corresponds to DXF group
+   * code **3**.
+   */
+  getUserType(): string {
+    return this._userType
+  }
+
+  /**
+   * Sets the user-visible OLE type description.
+   */
+  setUserType(value: string) {
+    this._userType = value
+  }
+
+  /**
+   * Gets the user-visible OLE type description.
+   *
+   * Prefer {@link getUserType} when matching ObjectARX naming.
+   */
+  get userType() {
+    return this._userType
+  }
+
+  set userType(value: string) {
+    this._userType = value
+  }
+
+  /**
+   * Gets the linked OLE object name.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getLinkName`.
+   */
+  getLinkName(): string {
+    return this._linkName
+  }
+
+  /**
+   * Sets the linked OLE object name.
+   */
+  setLinkName(value: string) {
+    this._linkName = value
+  }
+
+  /**
+   * Gets the linked OLE object path.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getLinkPath`.
+   */
+  getLinkPath(): string {
+    return this._linkPath
+  }
+
+  /**
+   * Sets the linked OLE object path.
+   */
+  setLinkPath(value: string) {
+    this._linkPath = value
+  }
+
+  /**
+   * Returns the opaque host OLE client item associated with this frame.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::getOleClientItem`. There is no MFC
+   * `COleClientItem` in the browser runtime; the value is application-defined.
+   */
+  getOleClientItem(): unknown {
+    return this._oleClientItem
+  }
+
+  /**
+   * Associates an opaque host OLE client item with this frame.
+   *
+   * Mirrors ObjectARX `AcDbOle2Frame::setOleClientItem`.
+   */
+  setOleClientItem(value: unknown) {
+    this._oleClientItem = value ?? null
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get geometricExtents(): AcGeBox3d {
+    return new AcGeBox3d().setFromPoints(this.boundaryPath())
+  }
+
+  /**
+   * @inheritdoc
+   */
+  subGetGripPoints() {
+    return this.boundaryPath().slice(0, 4)
+  }
+
+  /** @inheritdoc */
+  subMoveGripPointsAt(indices: number[], offset: AcGeVector3dLike) {
+    const corners = this.boundaryPath().slice(0, 4)
+    acdbMovePointArrayGripAt(indices, offset, corners)
+    acdbForEachGripIndex(indices, index => {
+      if (index === 0) {
+        this._upperLeft.copy(corners[0])
+      } else if (index === 2) {
+        this._lowerRight.copy(corners[2])
+      } else if (index === 1) {
+        this._upperLeft.y = corners[1].y
+        this._lowerRight.x = corners[1].x
+        this._upperLeft.z = corners[1].z
+        this._lowerRight.z = corners[1].z
+      } else if (index === 3) {
+        this._upperLeft.x = corners[3].x
+        this._lowerRight.y = corners[3].y
+        this._upperLeft.z = corners[3].z
+        this._lowerRight.z = corners[3].z
+      }
+    })
+    return this
+  }
+
+  /**
+   * Gets object snap points for this OLE frame.
+   */
+  subGetOsnapPoints(
+    osnapMode: AcDbOsnapMode,
+    pickPoint: AcGePoint3dLike,
+    _lastPoint: AcGePoint3dLike,
+    snapPoints: AcGePoint3dLike[]
+  ) {
+    if (osnapMode === AcDbOsnapMode.Insertion) {
+      snapPoints.push(this._upperLeft.clone())
+      return
+    }
+
+    const vertices = this.boundaryPath().slice(0, 4)
+    if (osnapMode === AcDbOsnapMode.EndPoint) {
+      snapPoints.push(...vertices)
+      return
+    }
+
+    acdbCollectVertexPathOsnapPoints(
+      vertices,
+      true,
+      osnapMode,
+      pickPoint,
+      snapPoints
+    )
+  }
+
+  /**
+   * Transforms this OLE frame by the specified matrix.
+   */
+  transformBy(matrix: AcGeMatrix3d) {
+    const signedWidth = this._lowerRight.x - this._upperLeft.x
+    const signedHeight = this._upperLeft.y - this._lowerRight.y
+    const cos = Math.cos(this._rotation)
+    const sin = Math.sin(this._rotation)
+    const origin = this._upperLeft.clone()
+    const uPoint = origin
+      .clone()
+      .add(new AcGeVector3d(signedWidth * cos, signedWidth * sin, 0))
+    const vPoint = origin
+      .clone()
+      .add(new AcGeVector3d(signedHeight * sin, -signedHeight * cos, 0))
+
+    origin.applyMatrix4(matrix)
+    uPoint.applyMatrix4(matrix)
+    vPoint.applyMatrix4(matrix)
+
+    const transformedU = new AcGeVector3d().subVectors(uPoint, origin)
+    const transformedV = new AcGeVector3d().subVectors(vPoint, origin)
+
+    this._upperLeft.copy(origin)
+    this._rotation = Math.atan2(transformedU.y, transformedU.x)
+    this._lowerRight.set(
+      origin.x + transformedU.length(),
+      origin.y - transformedV.length(),
+      origin.z
+    )
+    return this
+  }
+
+  /**
+   * Gets the image blob extracted from the embedded OLE object, when the
+   * payload contains a recognizable bitmap / PNG / JPEG presentation.
+   *
+   * Extraction is performed lazily on first access and cached until the OLE
+   * binary payload changes.
+   */
+  get image(): Blob | undefined {
+    return this.resolveImage()
+  }
+
+  /**
+   * Draws the embedded OLE picture when an image can be extracted from the
+   * OLE binary payload; otherwise draws the rectangular frame outline.
+   */
+  subWorldDraw(renderer: AcGiRenderer) {
+    const image = this.resolveImage()
+    const points = this.imageBoundaryPath()
+    if (image) {
+      return renderer.image(image, {
+        boundary: points,
+        roation: this._rotation
+      })
+    }
+    return renderer.lines(this.boundaryPath())
+  }
+
+  /** @inheritdoc */
+  protected override onOleObjectChanged() {
+    this._image = undefined
+    this._imageResolved = false
+  }
+
+  private resolveImage(): Blob | undefined {
+    if (this._imageResolved) {
+      return this._image
+    }
+    this._imageResolved = true
+    this._image = acdbExtractOleImageBlob(this.oleObjectData)
+    return this._image
+  }
+
+  /**
+   * Image quad in the same corner order as {@link AcDbRasterImage}:
+   * lower-left, lower-right, upper-right, upper-left, then close.
+   */
+  private imageBoundaryPath(): AcGePoint3d[] {
+    const frame = this.boundaryPath()
+    const points = [frame[3], frame[2], frame[1], frame[0]]
+
+    points.push(points[0].clone())
+    return points
+  }
+
+  /**
+   * Writes DXF fields for this OLE 2 frame.
+   *
+   * Emits the `AcDbOle2Frame` subclass marker and Autodesk OLE2FRAME group
+   * codes. Entity-level fields come from {@link AcDbEntity.dxfOutFields};
+   * {@link AcDbOleFrame} fields are skipped because OLE2FRAME uses its own
+   * layout.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   * @see https://help.autodesk.com/cloudhelp/2018/ENU/AutoCAD-DXF/files/GUID-77747CE6-82C6-4452-97ED-4CEEB38BE960.htm
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    AcDbEntity.prototype.dxfOutFields.call(this, filer)
+    filer.writeSubclassMarker('AcDbOle2Frame')
+    filer.writeInt16(70, this.oleVersion)
+    if (this._userType) {
+      filer.writeString(3, this._userType)
+    }
+    filer.writePoint3d(10, this._upperLeft)
+    filer.writePoint3d(11, this._lowerRight)
+    filer.writeInt16(71, this._oleObjectType)
+    filer.writeInt16(72, this._tileMode)
+    if (this._outputQuality) {
+      filer.writeInt16(73, this._outputQuality)
+    }
+    const oleObject = this.getOleObject()
+    if (oleObject?.length) {
+      filer.writeInt32(90, oleObject.length)
+      let index = 0
+      while (index < oleObject.length) {
+        const chunk = oleObject.subarray(index, index + 127)
+        filer.writeString(310, bytesToHexString(chunk))
+        index += 127
+      }
+    }
+    filer.writeString(1, 'OLE')
+    return this
+  }
+
+  private cornerUpperRight(): AcGePoint3d {
+    return new AcGePoint3d(
+      this._lowerRight.x,
+      this._upperLeft.y,
+      this._upperLeft.z
+    )
+  }
+
+  private cornerLowerLeft(): AcGePoint3d {
+    return new AcGePoint3d(
+      this._upperLeft.x,
+      this._lowerRight.y,
+      this._lowerRight.z
+    )
+  }
+
+  private boundaryPath(): AcGePoint3d[] {
+    const points = [
+      this._upperLeft.clone(),
+      this.cornerUpperRight(),
+      this._lowerRight.clone(),
+      this.cornerLowerLeft()
+    ]
+
+    if (this._rotation !== 0) {
+      const origin = this._upperLeft
+      for (let index = 1; index < points.length; index++) {
+        points[index]
+          .sub(origin)
+          .applyMatrix4(new AcGeMatrix3d().makeRotationZ(this._rotation))
+        points[index].add(origin)
+      }
+    }
+
+    // Closed path for line rendering
+    points.push(points[0].clone())
+    return points
+  }
+
+  private syncHeightFromAspect() {
+    const width = this.wcsWidth()
+    if (width === 0 || this._scaleWidth === 0) return
+    const aspect = this._scaleHeight / this._scaleWidth
+    const height = width * aspect
+    const sign = this._upperLeft.y >= this._lowerRight.y ? 1 : -1
+    this._lowerRight.y = this._upperLeft.y - sign * Math.abs(height)
+  }
+
+  private syncWidthFromAspect() {
+    const height = this.wcsHeight()
+    if (height === 0 || this._scaleHeight === 0) return
+    const aspect = this._scaleWidth / this._scaleHeight
+    const width = height * aspect
+    const sign = this._lowerRight.x >= this._upperLeft.x ? 1 : -1
+    this._lowerRight.x = this._upperLeft.x + sign * Math.abs(width)
+  }
+}

--- a/packages/data-model/src/entity/AcDbOleFrame.ts
+++ b/packages/data-model/src/entity/AcDbOleFrame.ts
@@ -1,0 +1,177 @@
+import { AcGeBox3d } from '@mlightcad/geometry-engine'
+import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
+
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { bytesToHexString } from '../misc/proxyGraphic'
+import { AcDbFrame } from './AcDbFrame'
+
+/**
+ * Represents a legacy OLE 1 frame entity in AutoCAD.
+ *
+ * {@link AcDbOleFrame} stores the raw OLE binary payload for an embedded OLE
+ * object. Prefer {@link AcDbOle2Frame} for OLE 2 objects, which also expose
+ * frame geometry and display attributes.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbOleFrame
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-__MEMBERTYPE_Methods_AcDbOleFrame
+ *
+ * @example
+ * ```typescript
+ * const oleFrame = new AcDbOleFrame()
+ * oleFrame.oleVersion = 1
+ * oleFrame.setOleObject(binaryPayload)
+ * ```
+ */
+export class AcDbOleFrame extends AcDbFrame {
+  /** The entity type name */
+  static override typeName: string = 'OleFrame'
+
+  override get dxfTypeName() {
+    return 'OLEFRAME'
+  }
+
+  /** OLE version number (DXF group code 70). */
+  private _oleVersion = 0
+  /** Raw OLE binary payload. */
+  private _oleObject?: Uint8Array
+
+  /**
+   * Creates a new OLE 1 frame entity.
+   *
+   * Objects created with this constructor must receive a valid OLE payload
+   * through {@link setOleObject} before they represent a complete OLE entity.
+   */
+  constructor() {
+    super()
+  }
+
+  /**
+   * Gets the OLE version number stored with this frame.
+   *
+   * Corresponds to DXF group code **70**.
+   */
+  get oleVersion() {
+    return this._oleVersion
+  }
+
+  /**
+   * Sets the OLE version number stored with this frame.
+   *
+   * @param value - OLE version number (DXF group code **70**).
+   */
+  set oleVersion(value: number) {
+    this._oleVersion = value
+  }
+
+  /**
+   * Returns the raw OLE object data associated with this frame.
+   *
+   * Mirrors ObjectARX `AcDbOleFrame::getOleObject`. In this TypeScript port the
+   * payload is exposed as a byte array rather than an opaque MFC pointer.
+   *
+   * @returns A copy of the stored OLE bytes, or `undefined` when unset.
+   */
+  getOleObject(): Uint8Array | undefined {
+    return this._oleObject ? new Uint8Array(this._oleObject) : undefined
+  }
+
+  /**
+   * Sets the raw OLE object data associated with this frame.
+   *
+   * Mirrors ObjectARX `AcDbOleFrame::setOleObject`. The supplied buffer is
+   * copied so later mutations of the caller's array do not affect this entity.
+   *
+   * @param value - OLE binary payload, or `null`/`undefined` to clear.
+   */
+  setOleObject(value?: Uint8Array | ArrayBuffer | null) {
+    if (value == null) {
+      this._oleObject = undefined
+    } else {
+      this._oleObject =
+        value instanceof ArrayBuffer
+          ? new Uint8Array(value.slice(0))
+          : new Uint8Array(value)
+    }
+    this.onOleObjectChanged()
+  }
+
+  /**
+   * Loads OLE binary data from DXF group codes **90** / **310**.
+   *
+   * @param length - Expected byte length from group code **90**.
+   * @param data - Decoded binary payload (already converted from hex chunks).
+   */
+  loadOleObjectFromDxf(length: number | undefined, data?: Uint8Array | null) {
+    if (!data?.length) {
+      this._oleObject = undefined
+    } else if (length != null && length > 0 && length < data.length) {
+      this._oleObject = data.subarray(0, length)
+    } else {
+      this._oleObject = new Uint8Array(data)
+    }
+    this.onOleObjectChanged()
+  }
+
+  /**
+   * Raw OLE payload retained by this frame (no copy).
+   *
+   * Subclasses use this for decoding presentation data without cloning the
+   * buffer on every draw.
+   */
+  protected get oleObjectData(): Uint8Array | undefined {
+    return this._oleObject
+  }
+
+  /**
+   * Hook invoked when the OLE binary payload changes.
+   *
+   * Subclasses override this to invalidate cached presentation images.
+   */
+  protected onOleObjectChanged() {}
+
+  /**
+   * Gets the geometric extents of this OLE frame.
+   *
+   * Legacy OLEFRAME entities do not store independent corner geometry in DXF;
+   * an empty box is returned unless a subclass overrides this property.
+   */
+  get geometricExtents(): AcGeBox3d {
+    return new AcGeBox3d()
+  }
+
+  /**
+   * Draws this OLE frame.
+   *
+   * Legacy OLE 1 frames have no drawable geometry outside the embedded OLE
+   * payload, which is not rendered here.
+   *
+   * @param _renderer - Target graphics renderer.
+   */
+  subWorldDraw(_renderer: AcGiRenderer): AcGiEntity | undefined {
+    return undefined
+  }
+
+  /**
+   * Writes DXF fields for this OLE frame.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   * @see https://help.autodesk.com/cloudhelp/2018/ENU/AutoCAD-DXF/files/GUID-4A10EF68-35A3-4961-8B15-1222ECE5E8C6.htm
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbOleFrame')
+    filer.writeInt16(70, this._oleVersion)
+    if (this._oleObject?.length) {
+      filer.writeInt32(90, this._oleObject.length)
+      let index = 0
+      while (index < this._oleObject.length) {
+        const chunk = this._oleObject.subarray(index, index + 127)
+        filer.writeString(310, bytesToHexString(chunk))
+        index += 127
+      }
+    }
+    filer.writeString(1, 'OLE')
+    return this
+  }
+}

--- a/packages/data-model/src/entity/index.ts
+++ b/packages/data-model/src/entity/index.ts
@@ -66,6 +66,14 @@ export type {
   AcDbMLeaderMTextContentLike
 } from './AcDbMLeader'
 export { AcDbMText } from './AcDbMText'
+export { AcDbFrame } from './AcDbFrame'
+export { AcDbOleFrame } from './AcDbOleFrame'
+export {
+  AcDbOle2Frame,
+  AcDbOleObjectType,
+  AcDbOleTileMode
+} from './AcDbOle2Frame'
+export type { AcDbOleRectangle3d } from './AcDbOle2Frame'
 export { AcDbSpline } from './AcDbSpline'
 export { AcDbTable } from './AcDbTable'
 export type {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -153,6 +153,7 @@ export {
   AcDbEntity,
   AcDbFace,
   AcDbFcf,
+  AcDbFrame,
   AcDbGradientPatternType,
   AcDbHatch,
   AcDbHatchObjectType,
@@ -171,6 +172,10 @@ export {
   AcDbMLineFlags,
   AcDbMLineJustification,
   AcDbMText,
+  AcDbOle2Frame,
+  AcDbOleFrame,
+  AcDbOleObjectType,
+  AcDbOleTileMode,
   AcDbOrdinateDimension,
   AcDbPoint,
   AcDbPoly2dType,
@@ -225,6 +230,7 @@ export type {
   AcDbMLineElementLike,
   AcDbMLineSegment,
   AcDbMLineSegmentLike,
+  AcDbOleRectangle3d,
   AcDbPropertyAccessor,
   AcDbTableBorderColors,
   AcDbTableCell,
@@ -293,6 +299,7 @@ export {
   VPORT_FALLBACK_VIEW_TARGET,
   acdbDisableOsnapMode,
   bytesToHexString,
+  acdbExtractOleImageBlob,
   hexStringsToBytes,
   loadAcDbProxyGraphicFromDxf,
   acdbEnableOsnapMode,
@@ -322,6 +329,10 @@ export type {
 export {
   AcDbDictionary,
   AcDbDuplicateRecordCloning,
+  AcDbFilter,
+  AcDbIndex,
+  AcDbLayerFilter,
+  AcDbLayerIndex,
   AcDbLayout,
   AcDbLayoutDictionary,
   AcDbLayoutManager,
@@ -338,12 +349,41 @@ export {
   AcDbXrecord
 } from './object'
 export type {
+  AcDbBlockChangeIterator,
+  AcDbFilteredBlockIterator,
+  AcDbIndexUpdateData,
+  AcDbLayerIndexEntry,
   AcDbLayoutEventArgs,
   AcDbLayoutRenamedEventArgs,
   AcDbMlineStyleElement,
   AcDbPlotPaperMargins,
   AcDbPlotScale
 } from './object'
+export {
+  AcLyBoolExpr,
+  ACAD_LAYERFILTERS_NAME,
+  ACLY_DICTIONARY_NAME,
+  AcLyLayerFilter,
+  AcLyLayerFilterDialogResult,
+  AcLyLayerFilterTree,
+  AcLyLayerGroup,
+  acdbLayerGroupsToResultBuffer,
+  acdbParseFilterXRecordData,
+  acdbReadLayerFilterTree,
+  acdbResultBufferToLayerGroups,
+  acdbSerializeLayerFilterTree,
+  acdbWriteFilterXRecordData
+} from './ly'
+export type {
+  AcDbLayerFilterGroup,
+  AcDbLayerFilterPersistSource,
+  AcDbParsedFilterXRecord,
+  AcDbPersistDictionary,
+  AcDbPersistXRecord,
+  AcDbSerializedFilterNode,
+  AcDbSerializedFilterTree,
+  AcLyLayerId
+} from './ly'
 export {
   AcCmColor,
   AcCmColorMethod,

--- a/packages/data-model/src/ly/AcLyBoolExpr.ts
+++ b/packages/data-model/src/ly/AcLyBoolExpr.ts
@@ -1,0 +1,33 @@
+/**
+ * Opaque placeholder for a parsed layer-filter boolean expression tree.
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcLyBoolExpr`. A full expression-AST implementation is
+ * not required to support the {@link AcLyLayerFilter} nesting API; property
+ * filters currently evaluate {@link AcLyLayerFilter.filterExpression} as a
+ * string.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcLy_Classes
+ */
+export class AcLyBoolExpr {
+  /** Original filter expression text. */
+  private readonly _expression: string
+
+  /**
+   * Creates a new {@link AcLyBoolExpr} instance.
+   *
+   * @param expression - Source filter expression string.
+   */
+  constructor(expression: string) {
+    this._expression = expression
+  }
+
+  /**
+   * Gets the original filter expression text.
+   *
+   * @returns The filter expression string.
+   */
+  get expression(): string {
+    return this._expression
+  }
+}

--- a/packages/data-model/src/ly/AcLyLayerFilter.ts
+++ b/packages/data-model/src/ly/AcLyLayerFilter.ts
@@ -1,0 +1,571 @@
+import type { AcDbObjectId } from '../base/AcDbObject'
+import type { AcDbLayerTableRecord } from '../database/AcDbLayerTableRecord'
+import { AcLyBoolExpr } from './AcLyBoolExpr'
+
+/**
+ * Result returned by {@link AcLyLayerFilter.showEditor}.
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcLyLayerFilter::DialogResult`.
+ */
+export enum AcLyLayerFilterDialogResult {
+  /** The editor was cancelled. */
+  Cancel = 0,
+  /** The editor completed successfully. */
+  Ok = 1
+}
+
+/**
+ * Main Layer Manager filter class (property filter).
+ *
+ * An {@link AcLyLayerFilter} allows clients to specify a filter expression and
+ * nest other filters into a tree. This is the AutoCAD Layer Properties Manager
+ * filter model (`AcLy*` classes), not the block-index {@link AcDbLayerFilter}.
+ *
+ * Nesting rules (AutoCAD Layer Manager behavior):
+ * - The tree root may contain both group filters and property filters.
+ * - A non-root property filter ({@link isIdFilter} = `false`) may contain
+ *   other property filters, but may **not** contain a group filter.
+ * - A group filter may contain both group filters and property filters.
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcLyLayerFilter` from `acly.h`.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcLy_Classes
+ * @see https://help.autodesk.com/cloudhelp/2019/ENU/OARX-RefGuide/files/OREF-AcLyLayerFilter.html
+ *
+ * @example
+ * ```typescript
+ * const unlocked = new AcLyLayerFilter();
+ * unlocked.name = 'Unlocked Layers';
+ * unlocked.setFilterExpression('LOCKED=="False"');
+ *
+ * const root = new AcLyLayerFilter();
+ * root.name = 'All';
+ * root.addNested(unlocked);
+ * ```
+ */
+export class AcLyLayerFilter {
+  /** Display name of this filter. */
+  private _name: string
+  /** Property-filter expression string (unused by group filters). */
+  private _filterExpression: string
+  /** Nested child filters. */
+  private readonly _nestedFilters: AcLyLayerFilter[]
+  /** Parent filter in the tree, if any. */
+  private _parent: AcLyLayerFilter | null
+  /** Whether this filter may be deleted from the UI. */
+  private _allowDelete: boolean
+  /** Whether this filter may be renamed from the UI. */
+  private _allowRename: boolean
+  /** Whether this filter was generated dynamically by AutoCAD. */
+  private _dynamicallyGenerated: boolean
+  /** Whether this filter is a proxy for an unknown custom filter type. */
+  private _isProxy: boolean
+
+  /**
+   * Creates a new {@link AcLyLayerFilter} instance (property filter).
+   */
+  constructor() {
+    this._name = ''
+    this._filterExpression = ''
+    this._nestedFilters = []
+    this._parent = null
+    this._allowDelete = true
+    this._allowRename = true
+    this._dynamicallyGenerated = false
+    this._isProxy = false
+  }
+
+  /**
+   * Gets the filter name.
+   *
+   * @returns The filter name.
+   */
+  get name(): string {
+    return this._name
+  }
+
+  /**
+   * Sets the filter name.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::setName`.
+   *
+   * @param value - New filter name.
+   * @returns `true` if the name was set.
+   */
+  setName(value: string): boolean {
+    if (!this.allowRename() && this._name.length > 0) {
+      return false
+    }
+    this._name = value
+    return true
+  }
+
+  /**
+   * Sets the filter name via property assignment.
+   *
+   * @param value - New filter name.
+   */
+  set name(value: string) {
+    this.setName(value)
+  }
+
+  /**
+   * Gets the property-filter expression string.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::filterExpression`. Group filters do
+   * not use expression strings and return an empty string.
+   *
+   * @returns The filter expression, or an empty string.
+   */
+  get filterExpression(): string {
+    return this._filterExpression
+  }
+
+  /**
+   * Sets the property-filter expression string.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::setFilterExpression`.
+   *
+   * @param expression - Filter expression (for example `LOCKED=="False"`).
+   * @returns `true` if the expression was accepted.
+   */
+  setFilterExpression(expression: string): boolean {
+    if (this.isIdFilter()) {
+      return false
+    }
+    this._filterExpression = expression ?? ''
+    return true
+  }
+
+  /**
+   * Sets the filter expression via property assignment.
+   *
+   * @param value - Filter expression string.
+   */
+  set filterExpression(value: string) {
+    this.setFilterExpression(value)
+  }
+
+  /**
+   * Returns a parsed expression-tree representation of the filter expression.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::filterExpressionTree`. Returns `null`
+   * when no expression is set, or for ID/group filters.
+   *
+   * @returns An {@link AcLyBoolExpr}, or `null`.
+   */
+  filterExpressionTree(): AcLyBoolExpr | null {
+    if (this.isIdFilter() || !this._filterExpression) {
+      return null
+    }
+    return new AcLyBoolExpr(this._filterExpression)
+  }
+
+  /**
+   * Gets the nested child filters of this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::getNestedFilters`.
+   *
+   * @returns A read-only array of nested filters.
+   */
+  getNestedFilters(): readonly AcLyLayerFilter[] {
+    return this._nestedFilters
+  }
+
+  /**
+   * Convenience accessor for nested filters (mirrors .NET `NestedFilters`).
+   *
+   * @returns A read-only array of nested filters.
+   */
+  get nestedFilters(): readonly AcLyLayerFilter[] {
+    return this._nestedFilters
+  }
+
+  /**
+   * Gets the parent filter in the tree.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::parent`.
+   *
+   * @returns The parent filter, or `null` for the root.
+   */
+  parent(): AcLyLayerFilter | null {
+    return this._parent
+  }
+
+  /**
+   * Returns whether this filter is an ID/group filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::isIdFilter`. Property filters return
+   * `false`; {@link AcLyLayerGroup} overrides this to return `true`.
+   *
+   * @returns `true` for group filters; otherwise `false`.
+   */
+  isIdFilter(): boolean {
+    return false
+  }
+
+  /**
+   * Returns whether nested filters are allowed under this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::allowNested`. Both property and group
+   * filters allow nesting by default.
+   *
+   * @returns `true` if nested filters are allowed.
+   */
+  allowNested(): boolean {
+    return true
+  }
+
+  /**
+   * Returns whether this filter may be deleted.
+   *
+   * @returns `true` if deletion is allowed.
+   */
+  allowDelete(): boolean {
+    return this._allowDelete
+  }
+
+  /**
+   * Sets whether this filter may be deleted.
+   *
+   * @param value - `true` to allow deletion.
+   */
+  setAllowDelete(value: boolean): void {
+    this._allowDelete = value
+  }
+
+  /**
+   * Returns whether this filter may be renamed.
+   *
+   * @returns `true` if renaming is allowed.
+   */
+  allowRename(): boolean {
+    return this._allowRename
+  }
+
+  /**
+   * Sets whether this filter may be renamed.
+   *
+   * @param value - `true` to allow renaming.
+   */
+  setAllowRename(value: boolean): void {
+    this._allowRename = value
+  }
+
+  /**
+   * Returns whether this filter was generated dynamically.
+   *
+   * @returns `true` if dynamically generated.
+   */
+  dynamicallyGenerated(): boolean {
+    return this._dynamicallyGenerated
+  }
+
+  /**
+   * Sets whether this filter was generated dynamically.
+   *
+   * @param value - `true` if dynamically generated.
+   */
+  setDynamicallyGenerated(value: boolean): void {
+    this._dynamicallyGenerated = value
+  }
+
+  /**
+   * Returns whether this filter is a proxy for an unknown custom type.
+   *
+   * @returns `true` if this is a proxy filter.
+   */
+  isProxy(): boolean {
+    return this._isProxy
+  }
+
+  /**
+   * Sets whether this filter is a proxy.
+   *
+   * @param value - `true` if this is a proxy filter.
+   */
+  setIsProxy(value: boolean): void {
+    this._isProxy = value
+  }
+
+  /**
+   * Adds a nested child filter under this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::addNested`.
+   *
+   * Nesting rules:
+   * - This filter must {@link allowNested}.
+   * - The tree root may contain both group and property filters.
+   * - A non-root property filter may not contain a group filter.
+   * - A group filter may contain both group and property filters.
+   *
+   * @param filter - Child filter to add.
+   * @returns `true` if the child was added.
+   */
+  addNested(filter: AcLyLayerFilter): boolean {
+    if (!filter || filter === this) {
+      return false
+    }
+    if (!this.allowNested()) {
+      return false
+    }
+    // Non-root Property Filter cannot contain Group Filter.
+    // The root "All" filter is allowed to host both kinds (AutoCAD behavior).
+    const isRoot = this._parent == null
+    if (!isRoot && !this.isIdFilter() && filter.isIdFilter()) {
+      return false
+    }
+    if (this._nestedFilters.includes(filter)) {
+      return false
+    }
+    if (filter._parent) {
+      filter._parent.removeNested(filter)
+    }
+    filter._parent = this
+    this._nestedFilters.push(filter)
+    return true
+  }
+
+  /**
+   * Removes a nested child filter from this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::removeNested`.
+   *
+   * @param filter - Child filter to remove.
+   * @returns `true` if the child was removed.
+   */
+  removeNested(filter: AcLyLayerFilter): boolean {
+    const index = this._nestedFilters.indexOf(filter)
+    if (index < 0) {
+      return false
+    }
+    this._nestedFilters.splice(index, 1)
+    if (filter._parent === this) {
+      filter._parent = null
+    }
+    return true
+  }
+
+  /**
+   * Generates nested filters from this filter's expression, when supported.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::generateNested`. Not implemented beyond
+   * API parity; returns `false`.
+   *
+   * @returns `true` if nested filters were generated.
+   */
+  generateNested(): boolean {
+    return false
+  }
+
+  /**
+   * Compares this filter to another filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::compareTo`.
+   *
+   * @param other - Filter to compare against.
+   * @returns `true` if the filters are considered equal.
+   */
+  compareTo(other: AcLyLayerFilter | null | undefined): boolean {
+    if (!other) {
+      return false
+    }
+    return (
+      this.isIdFilter() === other.isIdFilter() &&
+      this._name === other._name &&
+      this._filterExpression === other._filterExpression
+    )
+  }
+
+  /**
+   * Tests whether the given layer table record passes this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::filter`. Property filters evaluate
+   * {@link filterExpression}; group filters override this method.
+   *
+   * @param layer - Layer table record to test.
+   * @returns `true` if the layer is accepted by this filter.
+   */
+  filter(layer: AcDbLayerTableRecord): boolean {
+    if (!layer) {
+      return false
+    }
+    if (!this._filterExpression) {
+      return true
+    }
+    return evaluateLayerFilterExpression(this._filterExpression, layer)
+  }
+
+  /**
+   * Shows the filter editor UI.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::showEditor`. No UI is available in
+   * this port; always returns {@link AcLyLayerFilterDialogResult.Cancel}.
+   *
+   * @returns Dialog result.
+   */
+  showEditor(): AcLyLayerFilterDialogResult {
+    return AcLyLayerFilterDialogResult.Cancel
+  }
+}
+
+/**
+ * Evaluates a simple AutoCAD-style layer filter expression against a layer.
+ *
+ * Supports `AND` / `OR` combinations of relational clauses such as:
+ * `LOCKED=="False"`, `FROZEN=="True"`, `OFF=="False"`, `NAME=="0"`,
+ * `COLOR=="7"`, `PLOT=="True"`.
+ *
+ * @param expression - Filter expression string.
+ * @param layer - Layer to evaluate.
+ * @returns `true` if the layer matches the expression.
+ */
+function evaluateLayerFilterExpression(
+  expression: string,
+  layer: AcDbLayerTableRecord
+): boolean {
+  const trimmed = expression.trim()
+  if (!trimmed) {
+    return true
+  }
+
+  // Split on top-level OR first, then AND within each branch.
+  const orParts = splitBooleanExpression(trimmed, 'OR')
+  return orParts.some(orPart => {
+    const andParts = splitBooleanExpression(orPart, 'AND')
+    return andParts.every(clause => evaluateRelationalClause(clause, layer))
+  })
+}
+
+/**
+ * Splits an expression on a top-level boolean operator.
+ *
+ * @param expression - Expression text.
+ * @param operator - `AND` or `OR`.
+ * @returns Clause segments.
+ */
+function splitBooleanExpression(
+  expression: string,
+  operator: 'AND' | 'OR'
+): string[] {
+  const pattern = new RegExp(`\\s+${operator}\\s+`, 'i')
+  return expression
+    .split(pattern)
+    .map(part => part.trim())
+    .filter(part => part.length > 0)
+}
+
+/**
+ * Evaluates a single relational clause such as `LOCKED=="False"`.
+ *
+ * @param clause - Relational clause.
+ * @param layer - Layer to evaluate.
+ * @returns `true` if the clause matches.
+ */
+function evaluateRelationalClause(
+  clause: string,
+  layer: AcDbLayerTableRecord
+): boolean {
+  const match = clause
+    .trim()
+    .match(/^([A-Za-z_]+)\s*(==|=)\s*"?(.*?)"?\s*$/)
+  if (!match) {
+    return false
+  }
+
+  const property = match[1].toUpperCase()
+  const expected = match[3]
+  const expectedBool = parseBooleanLiteral(expected)
+
+  switch (property) {
+    case 'NAME':
+      return matchLayerNamePattern(layer.name, expected)
+    case 'LOCKED':
+      return expectedBool != null ? layer.isLocked === expectedBool : false
+    case 'FROZEN':
+      return expectedBool != null ? layer.isFrozen === expectedBool : false
+    case 'OFF':
+      return expectedBool != null ? layer.isOff === expectedBool : false
+    case 'PLOT':
+      return expectedBool != null ? layer.isPlottable === expectedBool : false
+    case 'COLOR': {
+      const colorIndex = layer.color?.colorIndex
+      return colorIndex != null && String(colorIndex) === expected
+    }
+    case 'LINETYPE':
+      return (
+        layer.linetype.localeCompare(expected, undefined, {
+          sensitivity: 'accent'
+        }) === 0
+      )
+    default:
+      return false
+  }
+}
+
+/**
+ * Matches a layer name against an AutoCAD-style filter pattern.
+ *
+ * Supports `*` (any sequence) and `?` (any single character). Matching is
+ * case-insensitive to mirror AutoCAD layer name comparisons.
+ *
+ * @param layerName - Layer table record name.
+ * @param pattern - Filter pattern from a `NAME=="..."` clause.
+ * @returns `true` if the layer name matches the pattern.
+ */
+function matchLayerNamePattern(layerName: string, pattern: string): boolean {
+  if (!/[*?]/.test(pattern)) {
+    return (
+      layerName.localeCompare(pattern, undefined, {
+        sensitivity: 'accent'
+      }) === 0
+    )
+  }
+
+  const regex = new RegExp(
+    `^${pattern
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '.*')
+      .replace(/\?/g, '.')}$`,
+    'i'
+  )
+  return regex.test(layerName)
+}
+
+/**
+ * Parses AutoCAD boolean literals used in filter expressions.
+ *
+ * @param value - Literal text such as `True` / `False`.
+ * @returns Parsed boolean, or `null` if not recognized.
+ */
+function parseBooleanLiteral(value: string): boolean | null {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'true' || normalized === '1') {
+    return true
+  }
+  if (normalized === 'false' || normalized === '0') {
+    return false
+  }
+  return null
+}
+
+/**
+ * Type alias used by group filters for layer object IDs.
+ */
+export type AcLyLayerId = AcDbObjectId

--- a/packages/data-model/src/ly/AcLyLayerFilterIO.ts
+++ b/packages/data-model/src/ly/AcLyLayerFilterIO.ts
@@ -1,0 +1,482 @@
+import { AcDbResultBuffer } from '../base/AcDbResultBuffer'
+import type { AcDbTypedValue } from '../base/AcDbTypedValue'
+import { AcLyLayerFilter } from './AcLyLayerFilter'
+import { AcLyLayerFilterTree } from './AcLyLayerFilterTree'
+import { AcLyLayerGroup } from './AcLyLayerGroup'
+
+/**
+ * Dictionary name for the legacy (pre-2005) layer-filter store.
+ *
+ * @remarks
+ * Lives in the Layer Table extension dictionary. Typically holds only
+ * top-level filter heads; nested filters are stored under
+ * {@link ACLY_DICTIONARY_NAME}.
+ *
+ * @see https://blog.autodesk.io/delete-layer-filters-using-objectarx/
+ */
+export const ACAD_LAYERFILTERS_NAME = 'ACAD_LAYERFILTERS'
+
+/**
+ * Dictionary name for the modern nested layer-filter store (AutoCAD 2005+).
+ *
+ * @remarks
+ * Lives in the Layer Table extension dictionary. Nested filters are reached
+ * through child `ACLYDICTIONARY` dictionaries owned by parent filter
+ * XRecords (via each XRecord's extension dictionary).
+ *
+ * @see https://forums.autodesk.com/t5/vba-forum/lost-in-acad-layerfilters-dictionnary/td-p/1841031
+ */
+export const ACLY_DICTIONARY_NAME = 'ACLYDICTIONARY'
+
+/**
+ * A DXF/DWG group-code pair used when reading or writing filter XRecords.
+ */
+export interface AcDbLayerFilterGroup {
+  /** DXF group code. */
+  code: number
+  /** Group value. */
+  value: unknown
+}
+
+/**
+ * Minimal dictionary shape used when reconstructing the filter tree.
+ */
+export interface AcDbPersistDictionary {
+  /** Object handle. */
+  handle: string
+  /** Owner object handle, when known. */
+  ownerObjectId?: string
+  /** Extension dictionary handle, when known. */
+  extensionDictionaryId?: string
+  /** Named entries mapping to soft/hard-owned object handles. */
+  entries: Record<string, string>
+}
+
+/**
+ * Minimal XRecord shape used when reconstructing the filter tree.
+ */
+export interface AcDbPersistXRecord {
+  /** Object handle. */
+  handle: string
+  /** Owner object handle, when known. */
+  ownerObjectId?: string
+  /** Extension dictionary handle, when known. */
+  extensionDictionaryId?: string
+  /** XRecord payload as DXF group pairs. */
+  data: AcDbLayerFilterGroup[]
+}
+
+/**
+ * Lookup tables used to rebuild an {@link AcLyLayerFilterTree} from drawing
+ * objects.
+ */
+export interface AcDbLayerFilterPersistSource {
+  /** Dictionaries keyed by handle. */
+  dictionaries: Map<string, AcDbPersistDictionary>
+  /** XRecords keyed by handle. */
+  xrecords: Map<string, AcDbPersistXRecord>
+}
+
+/**
+ * One serialized filter node produced by {@link acdbSerializeLayerFilterTree}.
+ */
+export interface AcDbSerializedFilterNode {
+  /** Dictionary entry key / filter identity. */
+  key: string
+  /** Whether this node is a group (ID) filter. */
+  isIdFilter: boolean
+  /** XRecord payload groups. */
+  data: AcDbLayerFilterGroup[]
+  /** Nested child nodes. */
+  children: AcDbSerializedFilterNode[]
+}
+
+/**
+ * Serialized Layer Manager filter tree ready to be written as dictionaries
+ * and XRecords under the Layer Table extension dictionary.
+ */
+export interface AcDbSerializedFilterTree {
+  /** Root nested filters (excluding the synthetic `All` root itself). */
+  nodes: AcDbSerializedFilterNode[]
+}
+
+/**
+ * Reads an {@link AcLyLayerFilterTree} from Layer Table extension-dictionary
+ * objects (`ACAD_LAYERFILTERS` / `ACLYDICTIONARY` + XRecords).
+ *
+ * @remarks
+ * Prefer {@link ACLY_DICTIONARY_NAME} when present (supports nesting). Fall
+ * back to the legacy flat {@link ACAD_LAYERFILTERS_NAME} dictionary.
+ *
+ * Legacy property-filter XRecord layout (documented VBA samples):
+ * `(1 name) (1 expression) (1 colorPat) (1 linetypePat) (70 flags) (1 ...) (1 ...)`
+ * Group filters additionally store layer object IDs as soft/hard pointers
+ * (group codes 330 / 340 / 350 / 360).
+ *
+ * @param source - Dictionaries and XRecords from the drawing.
+ * @returns The reconstructed filter tree.
+ */
+export function acdbReadLayerFilterTree(
+  source: AcDbLayerFilterPersistSource
+): AcLyLayerFilterTree {
+  const root = AcLyLayerFilterTree.createDefaultRoot()
+  const tree = new AcLyLayerFilterTree(root, root)
+
+  const aclyDict = findNamedDictionary(source, ACLY_DICTIONARY_NAME)
+  const legacyDict = findNamedDictionary(source, ACAD_LAYERFILTERS_NAME)
+
+  if (aclyDict) {
+    for (const [key, handle] of Object.entries(aclyDict.entries)) {
+      const child = readFilterNode(source, handle, key)
+      if (child) {
+        root.addNested(child)
+      }
+    }
+    return tree
+  }
+
+  if (legacyDict) {
+    for (const [key, handle] of Object.entries(legacyDict.entries)) {
+      const child = readFilterNode(source, handle, key)
+      if (child) {
+        root.addNested(child)
+      }
+    }
+  }
+
+  return tree
+}
+
+/**
+ * Serializes an {@link AcLyLayerFilterTree} into dictionary/XRecord payloads.
+ *
+ * @param tree - Filter tree to serialize.
+ * @returns Serialized nodes for `ACAD_LAYERFILTERS` / `ACLYDICTIONARY`.
+ */
+export function acdbSerializeLayerFilterTree(
+  tree: AcLyLayerFilterTree
+): AcDbSerializedFilterTree {
+  const nodes: AcDbSerializedFilterNode[] = []
+  for (const child of tree.root.getNestedFilters()) {
+    nodes.push(serializeFilterNode(child))
+  }
+  return { nodes }
+}
+
+/**
+ * Converts typed XRecord groups into an {@link AcDbResultBuffer}.
+ *
+ * @param groups - DXF group pairs.
+ * @returns Result buffer suitable for {@link AcDbXrecord.data}.
+ */
+export function acdbLayerGroupsToResultBuffer(
+  groups: readonly AcDbLayerFilterGroup[]
+): AcDbResultBuffer {
+  const buffer = new AcDbResultBuffer()
+  for (const group of groups) {
+    buffer.add({
+      code: group.code,
+      value: group.value
+    } as AcDbTypedValue)
+  }
+  return buffer
+}
+
+/**
+ * Converts an {@link AcDbResultBuffer} into DXF group pairs.
+ *
+ * @param buffer - Source result buffer.
+ * @returns DXF group pairs.
+ */
+export function acdbResultBufferToLayerGroups(
+  buffer: AcDbResultBuffer | null | undefined
+): AcDbLayerFilterGroup[] {
+  if (!buffer) return []
+  return buffer.toArray().map(item => ({
+    code: Number(item.code),
+    value: item.value
+  }))
+}
+
+/**
+ * Finds a dictionary that appears as a named entry (`ACAD_LAYERFILTERS` or
+ * `ACLYDICTIONARY`) in any parent dictionary.
+ *
+ * Prefers the Layer Table extension-dictionary entry (parent not owned by an
+ * XRecord) over nested per-filter `ACLYDICTIONARY` instances.
+ *
+ * @param source - Persist source.
+ * @param name - Dictionary entry name to find.
+ * @returns The named dictionary, or `undefined`.
+ */
+function findNamedDictionary(
+  source: AcDbLayerFilterPersistSource,
+  name: string
+): AcDbPersistDictionary | undefined {
+  let nestedFallback: AcDbPersistDictionary | undefined
+  for (const dict of source.dictionaries.values()) {
+    const handle = dict.entries[name]
+    if (!handle) continue
+    const nested = source.dictionaries.get(normalizeHandle(handle))
+    if (!nested) continue
+    const ownerIsXRecord = dict.ownerObjectId
+      ? source.xrecords.has(normalizeHandle(dict.ownerObjectId))
+      : false
+    if (!ownerIsXRecord) {
+      return nested
+    }
+    nestedFallback = nested
+  }
+  return nestedFallback
+}
+
+/**
+ * Reads one filter node (and its nested children) from an XRecord handle.
+ *
+ * @param source - Persist source.
+ * @param handle - XRecord handle.
+ * @param fallbackName - Dictionary entry key used when the XRecord omits name.
+ * @returns The filter instance, or `undefined` if the handle is missing.
+ */
+function readFilterNode(
+  source: AcDbLayerFilterPersistSource,
+  handle: string,
+  fallbackName: string
+): AcLyLayerFilter | undefined {
+  const xrecord = source.xrecords.get(normalizeHandle(handle))
+  if (!xrecord) {
+    return undefined
+  }
+
+  const parsed = acdbParseFilterXRecordData(xrecord.data, fallbackName)
+  const filter: AcLyLayerFilter = parsed.isIdFilter
+    ? new AcLyLayerGroup()
+    : new AcLyLayerFilter()
+
+  filter.setAllowRename(true)
+  filter.setName(parsed.name || fallbackName)
+  if (!parsed.isIdFilter) {
+    filter.setFilterExpression(parsed.filterExpression)
+  } else {
+    const group = filter as AcLyLayerGroup
+    for (const layerId of parsed.layerIds) {
+      group.addLayerId(layerId)
+    }
+  }
+
+  for (const childHandle of findNestedFilterHandles(source, xrecord)) {
+    const child = readFilterNode(source, childHandle.handle, childHandle.key)
+    if (child) {
+      filter.addNested(child)
+    }
+  }
+
+  return filter
+}
+
+/**
+ * Locates nested filter XRecord handles under a parent filter XRecord.
+ *
+ * Nesting is represented as:
+ * parent XRecord → extension dictionary → `ACLYDICTIONARY` → child XRecords
+ * or any dictionary owned by the parent XRecord / its extension dictionary.
+ *
+ * @param source - Persist source.
+ * @param parent - Parent XRecord.
+ * @returns Child dictionary entries.
+ */
+function findNestedFilterHandles(
+  source: AcDbLayerFilterPersistSource,
+  parent: AcDbPersistXRecord
+): { key: string; handle: string }[] {
+  const result: { key: string; handle: string }[] = []
+  const parentHandle = normalizeHandle(parent.handle)
+  const extensionId = parent.extensionDictionaryId
+    ? normalizeHandle(parent.extensionDictionaryId)
+    : undefined
+
+  for (const dict of source.dictionaries.values()) {
+    const owner = dict.ownerObjectId
+      ? normalizeHandle(dict.ownerObjectId)
+      : undefined
+    const ownedByParent = owner === parentHandle || owner === extensionId
+    if (!ownedByParent) {
+      continue
+    }
+
+    const nestedAcly = dict.entries[ACLY_DICTIONARY_NAME]
+    if (nestedAcly) {
+      const nestedDict = source.dictionaries.get(normalizeHandle(nestedAcly))
+      if (nestedDict) {
+        for (const [key, handle] of Object.entries(nestedDict.entries)) {
+          result.push({ key, handle })
+        }
+        continue
+      }
+    }
+
+    // Direct children listed on a dictionary owned by the parent.
+    for (const [key, handle] of Object.entries(dict.entries)) {
+      if (key === ACLY_DICTIONARY_NAME || key === ACAD_LAYERFILTERS_NAME) {
+        continue
+      }
+      result.push({ key, handle })
+    }
+  }
+
+  return result
+}
+
+/**
+ * Parsed fields from one filter XRecord payload.
+ */
+export interface AcDbParsedFilterXRecord {
+  name: string
+  filterExpression: string
+  flags: number
+  layerIds: string[]
+  isIdFilter: boolean
+}
+
+/**
+ * Parses legacy / modern filter XRecord group codes into structured fields.
+ *
+ * @param data - XRecord groups.
+ * @param fallbackName - Name used when group code 1 is missing.
+ * @returns Parsed filter fields.
+ */
+export function acdbParseFilterXRecordData(
+  data: readonly AcDbLayerFilterGroup[],
+  fallbackName = ''
+): AcDbParsedFilterXRecord {
+  const strings: string[] = []
+  const layerIds: string[] = []
+  let flags = 0
+  let explicitIdFilter: boolean | undefined
+  /** Modern ACLYDICTIONARY layout: name in group 300, expression in 301. */
+  let nameFrom300: string | undefined
+  let expressionFrom301: string | undefined
+
+  for (const group of data) {
+    const code = Number(group.code)
+    const value = group.value
+    if (code === 1 && typeof value === 'string') {
+      strings.push(value)
+    } else if (code === 300 && typeof value === 'string') {
+      nameFrom300 = value
+    } else if (code === 301 && typeof value === 'string') {
+      expressionFrom301 = value
+    } else if (code === 70 || code === 90) {
+      flags = Number(value) || 0
+    } else if (code === 290 || code === 280) {
+      // 290/280 used by some writers as boolean "is group/id filter".
+      // Prefer expression / layer-id heuristics when modern 301 is present,
+      // because some drawings set 290 even on property filters.
+      explicitIdFilter = Number(value) === 1
+    } else if (
+      (code === 330 || code === 340 || code === 350 || code === 360) &&
+      value != null &&
+      String(value).length > 0
+    ) {
+      layerIds.push(normalizeHandle(String(value)))
+    }
+  }
+
+  const className = strings[0]
+  const isClassMarker =
+    className === 'AcLyLayerFilter' || className === 'AcLyLayerGroup'
+  const name =
+    nameFrom300 ||
+    (!isClassMarker ? className : undefined) ||
+    fallbackName
+
+  const legacySecond = strings[1] ?? ''
+  let filterExpression = expressionFrom301 ?? legacySecond
+  // Legacy ACAD_LAYERFILTERS often stores a bare name pattern in the second
+  // string (for example `圆` or `多*`) instead of a full `NAME=="..."` clause.
+  if (
+    !expressionFrom301 &&
+    filterExpression &&
+    filterExpression !== '*' &&
+    !/==/.test(filterExpression)
+  ) {
+    filterExpression = `NAME=="${filterExpression}"`
+  }
+
+  const isIdFilter =
+    expressionFrom301 != null && expressionFrom301.length > 0
+      ? false
+      : explicitIdFilter === true && layerIds.length > 0
+        ? true
+        : layerIds.length > 0 &&
+          (filterExpression.length === 0 || filterExpression === '*')
+
+  return {
+    name,
+    filterExpression: isIdFilter ? '' : filterExpression,
+    flags,
+    layerIds,
+    isIdFilter
+  }
+}
+
+/**
+ * Serializes one filter (and nested children) to XRecord payloads.
+ *
+ * @param filter - Filter to serialize.
+ * @returns Serialized node.
+ */
+function serializeFilterNode(filter: AcLyLayerFilter): AcDbSerializedFilterNode {
+  const isIdFilter = filter.isIdFilter()
+  const data = acdbWriteFilterXRecordData(filter)
+  const children = filter
+    .getNestedFilters()
+    .map(child => serializeFilterNode(child))
+  const key = filter.name || (isIdFilter ? 'Group' : 'Filter')
+  return { key, isIdFilter, data, children }
+}
+
+/**
+ * Writes filter fields to the legacy-compatible XRecord group layout.
+ *
+ * @param filter - Filter to write.
+ * @returns DXF group pairs.
+ */
+export function acdbWriteFilterXRecordData(
+  filter: AcLyLayerFilter
+): AcDbLayerFilterGroup[] {
+  const groups: AcDbLayerFilterGroup[] = []
+  groups.push({ code: 1, value: filter.name })
+  if (filter.isIdFilter()) {
+    groups.push({ code: 1, value: '' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 70, value: 0 })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 290, value: 1 })
+    const group = filter as AcLyLayerGroup
+    for (const layerId of group.layerIds()) {
+      groups.push({ code: 330, value: layerId })
+    }
+  } else {
+    groups.push({ code: 1, value: filter.filterExpression || '*' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 70, value: 0 })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 1, value: '*' })
+    groups.push({ code: 290, value: 0 })
+  }
+  return groups
+}
+
+/**
+ * Normalizes a DXF/DWG handle to uppercase hexadecimal text.
+ *
+ * @param handle - Raw handle.
+ * @returns Normalized handle.
+ */
+function normalizeHandle(handle: string): string {
+  return handle.trim().toUpperCase()
+}

--- a/packages/data-model/src/ly/AcLyLayerFilterTree.ts
+++ b/packages/data-model/src/ly/AcLyLayerFilterTree.ts
@@ -1,0 +1,95 @@
+import { AcLyLayerFilter } from './AcLyLayerFilter'
+
+/**
+ * In-memory tree of Layer Manager filters for a drawing database.
+ *
+ * Mirrors the AutoCAD .NET `LayerFilterTree` wrapper around the ObjectARX
+ * `AcLy*` filter hierarchy. The tree is typically accessed through
+ * {@link AcDbDatabase.layerFilters}.
+ *
+ * @remarks
+ * AutoCAD exposes the tree **by value**: callers should get the tree, mutate
+ * {@link root} / nested filters, then assign it back to the database.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcLy_Classes
+ *
+ * @example
+ * ```typescript
+ * const tree = db.layerFilters;
+ * const unlocked = new AcLyLayerFilter();
+ * unlocked.name = 'Unlocked Layers';
+ * unlocked.setFilterExpression('LOCKED=="False"');
+ * tree.root.addNested(unlocked);
+ * db.layerFilters = tree;
+ * ```
+ */
+export class AcLyLayerFilterTree {
+  /** Root filter of the tree. */
+  private _root: AcLyLayerFilter
+  /** Currently active filter, if any. */
+  private _current: AcLyLayerFilter | null
+
+  /**
+   * Creates a new {@link AcLyLayerFilterTree}.
+   *
+   * @param root - Root filter. When omitted, a default `"All"` root is created.
+   * @param current - Currently active filter (defaults to `root`).
+   */
+  constructor(root?: AcLyLayerFilter, current?: AcLyLayerFilter | null) {
+    this._root = root ?? AcLyLayerFilterTree.createDefaultRoot()
+    this._current = current === undefined ? this._root : current
+  }
+
+  /**
+   * Creates the default root property filter used by AutoCAD (`All`).
+   *
+   * @returns A root {@link AcLyLayerFilter}.
+   */
+  static createDefaultRoot(): AcLyLayerFilter {
+    const root = new AcLyLayerFilter()
+    root.setName('All')
+    root.setAllowDelete(false)
+    root.setAllowRename(false)
+    root.setFilterExpression('')
+    return root
+  }
+
+  /**
+   * Gets the root filter of this tree.
+   *
+   * @returns The root {@link AcLyLayerFilter}.
+   */
+  get root(): AcLyLayerFilter {
+    return this._root
+  }
+
+  /**
+   * Gets the currently active filter.
+   *
+   * @returns The current filter, or `null`.
+   */
+  get current(): AcLyLayerFilter | null {
+    return this._current
+  }
+
+  /**
+   * Sets the currently active filter.
+   *
+   * @param value - Filter to make current, or `null`.
+   */
+  set current(value: AcLyLayerFilter | null) {
+    this._current = value
+  }
+
+  /**
+   * Creates a shallow copy of this tree that shares the same filter instances.
+   *
+   * @remarks
+   * Useful when following AutoCAD's by-value `Database.LayerFilters` pattern.
+   *
+   * @returns A new {@link AcLyLayerFilterTree}.
+   */
+  clone(): AcLyLayerFilterTree {
+    return new AcLyLayerFilterTree(this._root, this._current)
+  }
+}

--- a/packages/data-model/src/ly/AcLyLayerGroup.ts
+++ b/packages/data-model/src/ly/AcLyLayerGroup.ts
@@ -1,0 +1,147 @@
+import type { AcDbObjectId } from '../base/AcDbObject'
+import type { AcDbLayerTableRecord } from '../database/AcDbLayerTableRecord'
+import { AcLyLayerFilter } from './AcLyLayerFilter'
+
+/**
+ * Layer group filter (ID filter) used by the Layer Properties Manager.
+ *
+ * An {@link AcLyLayerGroup} selects layers by object ID rather than by a
+ * property expression. Use {@link isIdFilter} (always `true`) to distinguish
+ * group filters from property filters.
+ *
+ * Nesting rules (AutoCAD Layer Manager behavior):
+ * - A group filter may contain other group filters.
+ * - A group filter may contain property filters.
+ * - A property filter may **not** contain a group filter (enforced by
+ *   {@link AcLyLayerFilter.addNested}).
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcLyLayerGroup`. Filter expression APIs are unused and
+ * return empty / `null` values.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcLy_Classes
+ *
+ * @example
+ * ```typescript
+ * const group = new AcLyLayerGroup();
+ * group.name = 'My Layer Group';
+ * group.addLayerId(layer.objectId);
+ *
+ * const tree = db.layerFilters;
+ * tree.root.addNested(group); // root may contain groups
+ *
+ * const nested = new AcLyLayerGroup();
+ * nested.name = 'Nested Group';
+ * group.addNested(nested); // group may contain groups
+ * ```
+ */
+export class AcLyLayerGroup extends AcLyLayerFilter {
+  /** Layer object IDs included in this group. */
+  private readonly _layerIds: AcDbObjectId[]
+
+  /**
+   * Creates a new {@link AcLyLayerGroup} instance.
+   */
+  constructor() {
+    super()
+    this._layerIds = []
+  }
+
+  /**
+   * Returns whether this filter is an ID/group filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerFilter::isIdFilter` for group filters.
+   *
+   * @returns Always `true`.
+   */
+  override isIdFilter(): boolean {
+    return true
+  }
+
+  /**
+   * Gets the layer object IDs included in this group.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerGroup::layerIds`.
+   *
+   * @returns A read-only array of layer object IDs.
+   */
+  layerIds(): readonly AcDbObjectId[] {
+    return this._layerIds
+  }
+
+  /**
+   * Convenience accessor for layer IDs (mirrors .NET `LayerIds`).
+   *
+   * @returns A read-only array of layer object IDs.
+   */
+  get layerIdList(): readonly AcDbObjectId[] {
+    return this._layerIds
+  }
+
+  /**
+   * Adds a layer object ID to this group.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerGroup::addLayerId`.
+   *
+   * @param layerId - Layer table record object ID to include.
+   * @returns `true` if the ID was added; `false` if empty or already present.
+   */
+  addLayerId(layerId: AcDbObjectId): boolean {
+    if (!layerId) {
+      return false
+    }
+    if (this._layerIds.includes(layerId)) {
+      return false
+    }
+    this._layerIds.push(layerId)
+    return true
+  }
+
+  /**
+   * Removes a layer object ID from this group.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerGroup::removeLayerId`.
+   *
+   * @param layerId - Layer table record object ID to remove.
+   * @returns `true` if the ID was removed.
+   */
+  removeLayerId(layerId: AcDbObjectId): boolean {
+    const index = this._layerIds.indexOf(layerId)
+    if (index < 0) {
+      return false
+    }
+    this._layerIds.splice(index, 1)
+    return true
+  }
+
+  /**
+   * Tests whether the given layer is a member of this group.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcLyLayerGroup` filter behavior: returns `true` when
+   * the layer's object ID is contained in {@link layerIds}.
+   *
+   * @param layer - Layer table record to test.
+   * @returns `true` if the layer ID is in this group.
+   */
+  override filter(layer: AcDbLayerTableRecord): boolean {
+    if (!layer) {
+      return false
+    }
+    return this._layerIds.includes(layer.objectId)
+  }
+
+  /**
+   * Group filters do not use filter expression strings.
+   *
+   * @param _expression - Ignored.
+   * @returns Always `false`.
+   */
+  override setFilterExpression(_expression: string): boolean {
+    return false
+  }
+}

--- a/packages/data-model/src/ly/index.ts
+++ b/packages/data-model/src/ly/index.ts
@@ -1,0 +1,27 @@
+export { AcLyBoolExpr } from './AcLyBoolExpr'
+export {
+  AcLyLayerFilter,
+  AcLyLayerFilterDialogResult
+} from './AcLyLayerFilter'
+export type { AcLyLayerId } from './AcLyLayerFilter'
+export {
+  ACAD_LAYERFILTERS_NAME,
+  ACLY_DICTIONARY_NAME,
+  acdbLayerGroupsToResultBuffer,
+  acdbParseFilterXRecordData,
+  acdbReadLayerFilterTree,
+  acdbResultBufferToLayerGroups,
+  acdbSerializeLayerFilterTree,
+  acdbWriteFilterXRecordData
+} from './AcLyLayerFilterIO'
+export type {
+  AcDbLayerFilterGroup,
+  AcDbLayerFilterPersistSource,
+  AcDbParsedFilterXRecord,
+  AcDbPersistDictionary,
+  AcDbPersistXRecord,
+  AcDbSerializedFilterNode,
+  AcDbSerializedFilterTree
+} from './AcLyLayerFilterIO'
+export { AcLyLayerFilterTree } from './AcLyLayerFilterTree'
+export { AcLyLayerGroup } from './AcLyLayerGroup'

--- a/packages/data-model/src/misc/AcDbOleImageExtractor.ts
+++ b/packages/data-model/src/misc/AcDbOleImageExtractor.ts
@@ -1,0 +1,660 @@
+/**
+ * Extracts a renderable image {@link Blob} from AutoCAD OLE frame binary
+ * payloads (OLE2FRAME / OLEFRAME).
+ *
+ * AutoCAD stores OLE 2 items as a short geometry header followed by an OLE
+ * Compound File Binary (CFB) document. Embedded pictures (for example
+ * "Paintbrush Picture") typically expose either:
+ * - a `CONTENTS` stream containing a full BMP / PNG / JPEG file, or
+ * - a `\2OlePres###` presentation stream with a CF_DIB / CF_BITMAP payload
+ *
+ * This extractor prefers CFB streams when present, then falls back to scanning
+ * the raw buffer for common image signatures and packed DIBs.
+ */
+
+const CFB_SIGNATURE = [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1] as const
+
+/** Standard clipboard format identifiers used in OLE presentation streams. */
+const CF_BITMAP = 2
+const CF_DIB = 8
+
+const DIRECTORY_ENTRY_SIZE = 128
+const MAX_STREAM_BYTES = 64 * 1024 * 1024
+
+/**
+ * Attempts to extract an image blob from OLE binary data.
+ *
+ * @param data - Raw OLE payload from {@link AcDbOleFrame.getOleObject}.
+ * @returns A browser-decodable image blob, or `undefined` when no image is found.
+ */
+export function acdbExtractOleImageBlob(
+  data?: Uint8Array | null
+): Blob | undefined {
+  if (!data?.length) {
+    return undefined
+  }
+
+  const fromCfb = extractImageFromCfb(data)
+  if (fromCfb) {
+    return fromCfb
+  }
+
+  return extractImageFromRawBytes(data)
+}
+
+/**
+ * Locates an embedded CFB document inside `data` and tries to pull an image
+ * from preferred streams (`CONTENTS`, `Ole10Native`, OlePres, …), then from
+ * every remaining stream as a last resort.
+ *
+ * @param data - Full OLE payload that may contain a CFB compound file.
+ * @returns An image blob when one is found, otherwise `undefined`.
+ */
+function extractImageFromCfb(data: Uint8Array): Blob | undefined {
+  const cfbOffset = findSignature(data, CFB_SIGNATURE)
+  if (cfbOffset < 0) {
+    return undefined
+  }
+
+  const cfb = data.subarray(cfbOffset)
+  let file: CfbFile
+  try {
+    file = openCfb(cfb)
+  } catch {
+    return undefined
+  }
+
+  const preferredNames = [
+    'CONTENTS',
+    'Package',
+    'Ole10Native',
+    '\x01Ole10Native'
+  ]
+
+  for (const name of preferredNames) {
+    const stream = file.readStream(name)
+    if (!stream?.length) continue
+    const blob = extractImageFromRawBytes(stream)
+    if (blob) return blob
+  }
+
+  for (const entry of file.entries()) {
+    if (entry.type !== 'stream') continue
+    if (!/olepres/i.test(entry.name) && !entry.name.includes('OlePres')) {
+      continue
+    }
+    const stream = file.readStream(entry.name)
+    if (!stream?.length) continue
+    const fromPres = extractImageFromOlePresentation(stream)
+    if (fromPres) return fromPres
+    const fromRaw = extractImageFromRawBytes(stream)
+    if (fromRaw) return fromRaw
+  }
+
+  // Last resort: scan every stream for embedded image bytes.
+  for (const entry of file.entries()) {
+    if (entry.type !== 'stream') continue
+    const stream = file.readStream(entry.name)
+    if (!stream?.length) continue
+    const blob = extractImageFromRawBytes(stream)
+    if (blob) return blob
+  }
+
+  return undefined
+}
+
+/**
+ * Parses an OLE presentation stream (`\2OlePres000`, …) and extracts a DIB /
+ * bitmap when the clipboard format is CF_DIB or CF_BITMAP.
+ *
+ * @param stream - Bytes of a `\2OlePres###` (or similarly named) stream.
+ * @returns A BMP image blob for CF_DIB / CF_BITMAP payloads, or `undefined`.
+ *
+ * @see https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleds/78ab0f5c-ad1b-41b4-bb5e-1eea2cd13a6c
+ */
+function extractImageFromOlePresentation(stream: Uint8Array): Blob | undefined {
+  if (stream.length < 28) {
+    return undefined
+  }
+
+  const view = new DataView(stream.buffer, stream.byteOffset, stream.byteLength)
+  let offset = 0
+  const markerOrLength = view.getUint32(offset, true)
+  offset += 4
+
+  let clipboardFormat = 0
+  if (markerOrLength === 0xffffffff) {
+    clipboardFormat = view.getUint32(offset, true)
+    offset += 4
+  } else if (markerOrLength === 0xfffffffe) {
+    // Unicode clipboard format name — skip string and try raw scan later.
+    return undefined
+  } else if (markerOrLength > 0 && markerOrLength < 0xffff) {
+    // ANSI clipboard format name
+    offset += markerOrLength
+  } else {
+    return undefined
+  }
+
+  // TargetDevice.Size
+  if (offset + 4 > stream.length) return undefined
+  const targetDeviceSize = view.getUint32(offset, true)
+  offset += 4
+  if (targetDeviceSize > 4) {
+    offset += targetDeviceSize - 4
+  }
+
+  // Aspect, lindex, advf, reserved1, width, height
+  offset += 4 * 6
+  if (offset + 4 > stream.length) return undefined
+  const dataSize = view.getUint32(offset, true)
+  offset += 4
+  if (dataSize <= 0 || offset + dataSize > stream.length) {
+    return undefined
+  }
+
+  const presentationData = stream.subarray(offset, offset + dataSize)
+  if (clipboardFormat === CF_DIB) {
+    return dibToBmpBlob(presentationData)
+  }
+  if (clipboardFormat === CF_BITMAP) {
+    return extractImageFromRawBytes(presentationData)
+  }
+  return extractImageFromRawBytes(presentationData)
+}
+
+/**
+ * Scans a byte buffer for common image file signatures (BMP, PNG, JPEG, GIF)
+ * and packed DIB structures.
+ *
+ * @param data - Arbitrary bytes that may contain an embedded image.
+ * @returns The first recognized image blob, or `undefined` if none is found.
+ */
+function extractImageFromRawBytes(data: Uint8Array): Blob | undefined {
+  const bmp = findBmpBlob(data)
+  if (bmp) return bmp
+
+  const png = findPngBlob(data)
+  if (png) return png
+
+  const jpeg = findJpegBlob(data)
+  if (jpeg) return jpeg
+
+  const gif = findGifBlob(data)
+  if (gif) return gif
+
+  const dib = findPackedDibBlob(data)
+  if (dib) return dib
+
+  return undefined
+}
+
+/**
+ * Finds a Windows BMP file (`BM` magic) inside `data` and returns it as a blob.
+ *
+ * @param data - Buffer to search for a BITMAPFILEHEADER.
+ * @returns An `image/bmp` blob when a valid BMP is found, otherwise `undefined`.
+ */
+function findBmpBlob(data: Uint8Array): Blob | undefined {
+  for (let i = 0; i < data.length - 14; i++) {
+    if (data[i] !== 0x42 || data[i + 1] !== 0x4d) continue
+    const view = new DataView(data.buffer, data.byteOffset + i, data.length - i)
+    const fileSize = view.getUint32(2, true)
+    if (fileSize < 14 || fileSize > data.length - i) continue
+    const dibOffset = view.getUint32(10, true)
+    if (dibOffset < 14 || dibOffset >= fileSize) continue
+    return new Blob([data.subarray(i, i + fileSize)], { type: 'image/bmp' })
+  }
+  return undefined
+}
+
+/**
+ * Finds a PNG file inside `data`, preferably bounded by an `IEND` chunk.
+ *
+ * @param data - Buffer to search for a PNG signature.
+ * @returns An `image/png` blob when found, otherwise `undefined`.
+ */
+function findPngBlob(data: Uint8Array): Blob | undefined {
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  const start = findSignature(data, sig)
+  if (start < 0) return undefined
+
+  // Scan for IEND chunk to bound the PNG.
+  for (let i = start + 8; i + 12 <= data.length; i++) {
+    if (
+      data[i + 4] === 0x49 &&
+      data[i + 5] === 0x45 &&
+      data[i + 6] === 0x4e &&
+      data[i + 7] === 0x44
+    ) {
+      const end = i + 12
+      return new Blob([data.subarray(start, end)], { type: 'image/png' })
+    }
+  }
+  return new Blob([data.subarray(start)], { type: 'image/png' })
+}
+
+/**
+ * Finds a JPEG file inside `data` by locating SOI (`FF D8 FF`) and EOI
+ * (`FF D9`) markers.
+ *
+ * @param data - Buffer to search for JPEG markers.
+ * @returns An `image/jpeg` blob when a complete JPEG is found, otherwise
+ *   `undefined`.
+ */
+function findJpegBlob(data: Uint8Array): Blob | undefined {
+  const start = findSignature(data, [0xff, 0xd8, 0xff])
+  if (start < 0) return undefined
+  for (let i = start + 3; i + 1 < data.length; i++) {
+    if (data[i] === 0xff && data[i + 1] === 0xd9) {
+      return new Blob([data.subarray(start, i + 2)], { type: 'image/jpeg' })
+    }
+  }
+  return undefined
+}
+
+/**
+ * Finds a GIF87a / GIF89a file inside `data`, preferably bounded by a trailer
+ * byte (`0x3B`).
+ *
+ * @param data - Buffer to search for a GIF signature.
+ * @returns An `image/gif` blob when found, otherwise `undefined`.
+ */
+function findGifBlob(data: Uint8Array): Blob | undefined {
+  const start87 = findSignature(data, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61])
+  const start89 = findSignature(data, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+  const start = start87 >= 0 ? start87 : start89
+  if (start < 0) return undefined
+  for (let i = start + 6; i < data.length; i++) {
+    if (data[i] === 0x3b) {
+      return new Blob([data.subarray(start, i + 1)], { type: 'image/gif' })
+    }
+  }
+  return new Blob([data.subarray(start)], { type: 'image/gif' })
+}
+
+/**
+ * Locates a packed DIB (BITMAPINFOHEADER with `biSize === 40`) and wraps it as
+ * a BMP file by prepending a BITMAPFILEHEADER.
+ *
+ * @param data - Buffer that may contain a packed device-independent bitmap.
+ * @returns An `image/bmp` blob when a plausible DIB is found, otherwise
+ *   `undefined`.
+ */
+function findPackedDibBlob(data: Uint8Array): Blob | undefined {
+  for (let i = 0; i + 40 <= data.length; i++) {
+    const view = new DataView(data.buffer, data.byteOffset + i, data.length - i)
+    const biSize = view.getUint32(0, true)
+    if (biSize !== 40) continue
+
+    const width = view.getInt32(4, true)
+    const height = view.getInt32(8, true)
+    const planes = view.getUint16(12, true)
+    const bitCount = view.getUint16(14, true)
+    const compression = view.getUint32(16, true)
+    const sizeImage = view.getUint32(20, true)
+    const clrUsed = view.getUint32(32, true)
+
+    if (width <= 0 || width > 65536) continue
+    if (height === 0 || Math.abs(height) > 65536) continue
+    if (planes !== 1) continue
+    if (![1, 4, 8, 16, 24, 32].includes(bitCount)) continue
+    // BI_RGB / BI_BITFIELDS only
+    if (compression !== 0 && compression !== 3) continue
+
+    const pixelOffset = getPackedDibPixelOffset(
+      biSize,
+      bitCount,
+      compression,
+      clrUsed
+    )
+    const absHeight = Math.abs(height)
+    const rowSize = ((width * bitCount + 31) >> 5) << 2
+    const expectedPixels = sizeImage > 0 ? sizeImage : rowSize * absHeight
+    const totalSize = pixelOffset + expectedPixels
+    if (totalSize <= 40 || i + totalSize > data.length) continue
+
+    return dibToBmpBlob(data.subarray(i, i + totalSize))
+  }
+  return undefined
+}
+
+/**
+ * Computes the byte offset from the start of a packed BITMAPINFOHEADER DIB to
+ * the first pixel byte, accounting for color tables and BI_BITFIELDS masks.
+ *
+ * @param biSize - Size of the bitmap info header (typically 40).
+ * @param bitCount - Bits per pixel.
+ * @param compression - Compression type (`0` = BI_RGB, `3` = BI_BITFIELDS).
+ * @param clrUsed - Number of color-table entries, or `0` for the default.
+ * @returns Offset in bytes from the DIB start to pixel data.
+ */
+function getPackedDibPixelOffset(
+  biSize: number,
+  bitCount: number,
+  compression: number,
+  clrUsed: number
+): number {
+  let extra = 0
+  if (bitCount > 8 && compression === 3) {
+    extra += 12
+  }
+  if (clrUsed > 0) {
+    extra += clrUsed * 4
+  } else if (bitCount <= 8) {
+    extra += (1 << bitCount) * 4
+  }
+  return biSize + extra
+}
+
+/**
+ * Wraps packed DIB bytes as a Windows BMP by prepending a 14-byte
+ * BITMAPFILEHEADER.
+ *
+ * @param dib - Packed DIB starting with BITMAPINFOHEADER / BITMAPCOREHEADER.
+ * @returns An `image/bmp` blob, or `undefined` when the header is invalid.
+ */
+function dibToBmpBlob(dib: Uint8Array): Blob | undefined {
+  if (dib.length < 40) return undefined
+  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength)
+  const biSize = view.getUint32(0, true)
+  if (biSize !== 40 && biSize !== 12) return undefined
+
+  const fileSize = 14 + dib.length
+  const header = new Uint8Array(14)
+  const headerView = new DataView(header.buffer)
+  header[0] = 0x42 // 'B'
+  header[1] = 0x4d // 'M'
+  headerView.setUint32(2, fileSize, true)
+  headerView.setUint32(10, 14 + getPixelDataOffsetFromDib(dib), true)
+
+  const combined = new Uint8Array(fileSize)
+  combined.set(header, 0)
+  combined.set(dib, 14)
+  return new Blob([combined], { type: 'image/bmp' })
+}
+
+/**
+ * Returns the offset from the start of a DIB to its pixel array, for use as
+ * `bfOffBits` after a 14-byte BITMAPFILEHEADER is prepended.
+ *
+ * @param dib - Packed DIB starting with BITMAPINFOHEADER or BITMAPCOREHEADER.
+ * @returns Pixel-data offset relative to the DIB start (not including the
+ *   file header).
+ */
+function getPixelDataOffsetFromDib(dib: Uint8Array): number {
+  const view = new DataView(dib.buffer, dib.byteOffset, dib.byteLength)
+  const biSize = view.getUint32(0, true)
+  if (biSize === 12) {
+    const bitCount = view.getUint16(10, true)
+    const colors = bitCount <= 8 ? 1 << bitCount : 0
+    return biSize + colors * 3
+  }
+  const bitCount = view.getUint16(14, true)
+  const compression = view.getUint32(16, true)
+  const clrUsed = view.getUint32(32, true)
+  return getPackedDibPixelOffset(biSize, bitCount, compression, clrUsed)
+}
+
+/**
+ * Searches `data` for the first occurrence of `signature`.
+ *
+ * @param data - Buffer to search.
+ * @param signature - Byte sequence to locate.
+ * @returns Index of the first match, or `-1` if not found.
+ */
+function findSignature(data: Uint8Array, signature: readonly number[]): number {
+  outer: for (let i = 0; i <= data.length - signature.length; i++) {
+    for (let j = 0; j < signature.length; j++) {
+      if (data[i + j] !== signature[j]) continue outer
+    }
+    return i
+  }
+  return -1
+}
+
+/* -------------------------------------------------------------------------- */
+/* Minimal CFB (Compound File Binary) reader                                  */
+/* -------------------------------------------------------------------------- */
+
+interface CfbEntry {
+  name: string
+  type: 'root' | 'storage' | 'stream' | 'unknown'
+  size: number
+  startSector: number
+}
+
+interface CfbFile {
+  entries(): CfbEntry[]
+  readStream(name: string): Uint8Array | undefined
+}
+
+/**
+ * Opens a Compound File Binary (OLE2) document and exposes directory entries
+ * plus named stream reads.
+ *
+ * @param data - Bytes starting at a valid CFB signature.
+ * @returns A lightweight CFB reader for stream extraction.
+ * @throws If the buffer is too small, not a CFB, or has an unsupported sector
+ *   size.
+ */
+function openCfb(data: Uint8Array): CfbFile {
+  if (data.length < 512) {
+    throw new Error('CFB too small')
+  }
+  for (let i = 0; i < CFB_SIGNATURE.length; i++) {
+    if (data[i] !== CFB_SIGNATURE[i]) {
+      throw new Error('Not a CFB document')
+    }
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+  const sectorShift = view.getUint16(30, true)
+  const sectorSize = 1 << sectorShift
+  if (sectorSize !== 512 && sectorSize !== 4096) {
+    throw new Error('Unsupported CFB sector size')
+  }
+
+  const fatCount = view.getUint32(44, true)
+  const firstDirSector = view.getUint32(48, true)
+  const miniStreamCutoff = view.getUint32(56, true)
+  const firstMiniFatSector = view.getUint32(60, true)
+  const miniFatCount = view.getUint32(64, true)
+  const firstDifatSector = view.getUint32(68, true)
+  const difatCount = view.getUint32(72, true)
+
+  const difat: number[] = []
+  for (let i = 0; i < 109; i++) {
+    const sector = view.getUint32(76 + i * 4, true)
+    if (sector <= 0xfffffffa) {
+      difat.push(sector)
+    }
+  }
+
+  let difatSector = firstDifatSector
+  for (let n = 0; n < difatCount && difatSector <= 0xfffffffa; n++) {
+    const offset = (difatSector + 1) * sectorSize
+    if (offset + sectorSize > data.length) break
+    const entriesPerSector = sectorSize / 4 - 1
+    for (let i = 0; i < entriesPerSector; i++) {
+      const sector = view.getUint32(offset + i * 4, true)
+      if (sector <= 0xfffffffa) {
+        difat.push(sector)
+      }
+    }
+    difatSector = view.getUint32(offset + entriesPerSector * 4, true)
+  }
+
+  const fat: number[] = []
+  for (let i = 0; i < Math.min(fatCount, difat.length); i++) {
+    const fatSector = difat[i]
+    const offset = (fatSector + 1) * sectorSize
+    if (offset + sectorSize > data.length) break
+    const entries = sectorSize / 4
+    for (let j = 0; j < entries; j++) {
+      fat.push(view.getUint32(offset + j * 4, true))
+    }
+  }
+
+  const directorySectors = followFatChain(fat, firstDirSector, 4096)
+  const directoryBytes = readSectorChain(data, directorySectors, sectorSize)
+  const entries: CfbEntry[] = []
+  const entryCount = Math.floor(directoryBytes.length / DIRECTORY_ENTRY_SIZE)
+  for (let i = 0; i < entryCount; i++) {
+    const entryOffset = i * DIRECTORY_ENTRY_SIZE
+    const entryView = new DataView(
+      directoryBytes.buffer,
+      directoryBytes.byteOffset + entryOffset,
+      DIRECTORY_ENTRY_SIZE
+    )
+    const nameLength = entryView.getUint16(64, true)
+    if (nameLength < 2 || nameLength > 64) continue
+    const charCount = Math.floor((nameLength - 2) / 2)
+    let name = ''
+    for (let c = 0; c < charCount; c++) {
+      name += String.fromCharCode(entryView.getUint16(c * 2, true))
+    }
+    const objectType = entryView.getUint8(66)
+    const startSector = entryView.getUint32(116, true)
+    const sizeLow = entryView.getUint32(120, true)
+    const sizeHigh = entryView.getUint32(124, true)
+    const size = sizeHigh === 0 ? sizeLow : sizeLow + sizeHigh * 0x100000000
+    let type: CfbEntry['type'] = 'unknown'
+    if (objectType === 5) type = 'root'
+    else if (objectType === 1) type = 'storage'
+    else if (objectType === 2) type = 'stream'
+    entries.push({ name, type, size, startSector })
+  }
+
+  const root = entries.find(e => e.type === 'root')
+  const miniFat: number[] = []
+  if (miniFatCount > 0 && firstMiniFatSector <= 0xfffffffa) {
+    const miniFatSectors = followFatChain(fat, firstMiniFatSector, miniFatCount)
+    const miniFatBytes = readSectorChain(data, miniFatSectors, sectorSize)
+    const miniView = new DataView(
+      miniFatBytes.buffer,
+      miniFatBytes.byteOffset,
+      miniFatBytes.byteLength
+    )
+    for (let i = 0; i + 4 <= miniFatBytes.length; i += 4) {
+      miniFat.push(miniView.getUint32(i, true))
+    }
+  }
+
+  let miniStream: Uint8Array | undefined
+  if (root && root.size > 0) {
+    const miniStreamSectors = followFatChain(fat, root.startSector, 65536)
+    miniStream = readSectorChain(data, miniStreamSectors, sectorSize).subarray(
+      0,
+      root.size
+    )
+  }
+
+  const readStream = (name: string): Uint8Array | undefined => {
+    const entry = entries.find(
+      e =>
+        e.type === 'stream' &&
+        (e.name === name || e.name.toLowerCase() === name.toLowerCase())
+    )
+    if (!entry || entry.size <= 0 || entry.size > MAX_STREAM_BYTES) {
+      return undefined
+    }
+
+    if (entry.size < miniStreamCutoff && miniStream && miniFat.length > 0) {
+      const miniSectorSize = 64
+      const sectors = followChain(miniFat, entry.startSector, 65536)
+      const out = new Uint8Array(entry.size)
+      let written = 0
+      for (const sector of sectors) {
+        if (written >= entry.size) break
+        const start = sector * miniSectorSize
+        const end = Math.min(start + miniSectorSize, miniStream.length)
+        if (start >= miniStream.length) break
+        const chunk = miniStream.subarray(start, end)
+        out.set(
+          chunk.subarray(0, Math.min(chunk.length, entry.size - written)),
+          written
+        )
+        written += chunk.length
+      }
+      return out.subarray(0, Math.min(written, entry.size))
+    }
+
+    const sectors = followFatChain(fat, entry.startSector, 65536)
+    return readSectorChain(data, sectors, sectorSize).subarray(0, entry.size)
+  }
+
+  return {
+    entries: () => entries,
+    readStream
+  }
+}
+
+/**
+ * Walks the CFB File Allocation Table starting at `start` and returns the
+ * sector chain.
+ *
+ * @param fat - FAT sector index table.
+ * @param start - First sector index in the chain.
+ * @param maxSectors - Safety cap on chain length.
+ * @returns Ordered list of sector indices.
+ */
+function followFatChain(
+  fat: number[],
+  start: number,
+  maxSectors: number
+): number[] {
+  return followChain(fat, start, maxSectors)
+}
+
+/**
+ * Walks a sector-chain table (FAT or MiniFAT) until an end-of-chain marker,
+ * a cycle, or `maxSectors` is reached.
+ *
+ * @param table - Sector chain table (FAT or MiniFAT).
+ * @param start - First sector index.
+ * @param maxSectors - Maximum number of sectors to follow.
+ * @returns Ordered list of sector indices visited.
+ */
+function followChain(
+  table: number[],
+  start: number,
+  maxSectors: number
+): number[] {
+  const sectors: number[] = []
+  let sector = start
+  const seen = new Set<number>()
+  while (sector <= 0xfffffffa && sectors.length < maxSectors) {
+    if (seen.has(sector)) break
+    seen.add(sector)
+    sectors.push(sector)
+    if (sector >= table.length) break
+    sector = table[sector]
+  }
+  return sectors
+}
+
+/**
+ * Reads and concatenates CFB sectors into a single contiguous buffer.
+ *
+ * @param data - Full CFB document bytes.
+ * @param sectors - Sector indices to read (0-based within the file body).
+ * @param sectorSize - Bytes per sector (512 or 4096).
+ * @returns Concatenated sector data (may be truncated if past EOF).
+ */
+function readSectorChain(
+  data: Uint8Array,
+  sectors: number[],
+  sectorSize: number
+): Uint8Array {
+  const out = new Uint8Array(sectors.length * sectorSize)
+  let offset = 0
+  for (const sector of sectors) {
+    const start = (sector + 1) * sectorSize
+    const end = Math.min(start + sectorSize, data.length)
+    if (start >= data.length) break
+    out.set(data.subarray(start, end), offset)
+    offset += sectorSize
+  }
+  return out
+}

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -93,6 +93,7 @@ export {
   bytesToHexString,
   hexStringsToBytes
 } from './proxyGraphic'
+export { acdbExtractOleImageBlob } from './AcDbOleImageExtractor'
 export type {
   AcDbPatDocument,
   AcDbPatGradientColor,

--- a/packages/data-model/src/object/AcDbFilter.ts
+++ b/packages/data-model/src/object/AcDbFilter.ts
@@ -1,0 +1,59 @@
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbObject } from '../base/AcDbObject'
+
+/**
+ * Abstract base class for filter objects used with the AutoCAD index/filter
+ * scheme.
+ *
+ * An {@link AcDbFilter} defines a query used when iterating block data through
+ * filtered block iterators. The corresponding index class is obtained through
+ * {@link AcDbFilter.indexClass}.
+ *
+ * @remarks
+ * Mirrors the ObjectARX `AcDbFilter` class. Applications that provide a custom
+ * indexing scheme typically also implement matching
+ * {@link AcDbIndex} and filtered-block-iterator types.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbFilter
+ *
+ * @example
+ * ```typescript
+ * class MyFilter extends AcDbFilter {
+ *   indexClass(): string {
+ *     return 'MyIndex';
+ *   }
+ * }
+ * ```
+ */
+export abstract class AcDbFilter extends AcDbObject {
+  /**
+   * Creates a new {@link AcDbFilter} instance.
+   */
+  constructor() {
+    super()
+  }
+
+  /**
+   * Returns the class name of the {@link AcDbIndex}-derived type required to
+   * process this filter.
+   *
+   * @remarks
+   * In ObjectARX this method returns an `AcRxClass*`. This TypeScript port
+   * returns the class name string instead.
+   *
+   * @returns The index class name associated with this filter.
+   */
+  abstract indexClass(): string
+
+  /**
+   * Writes DXF fields for this filter object.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbFilter')
+    return this
+  }
+}

--- a/packages/data-model/src/object/AcDbIndex.ts
+++ b/packages/data-model/src/object/AcDbIndex.ts
@@ -1,0 +1,191 @@
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbObject, AcDbObjectId } from '../base/AcDbObject'
+import type { AcDbFilter } from './AcDbFilter'
+
+/**
+ * Opaque handle for filtered-block iteration results.
+ *
+ * @remarks
+ * ObjectARX returns an `AcDbFilteredBlockIterator*`. A full iterator
+ * implementation is not yet available in this port; methods that would create
+ * one currently return `null`.
+ */
+export type AcDbFilteredBlockIterator = object
+
+/**
+ * Opaque handle for index rebuild update data.
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcDbIndexUpdateData`. Passed to
+ * {@link AcDbIndex.rebuildFull}.
+ */
+export type AcDbIndexUpdateData = object
+
+/**
+ * Opaque handle for block-change iteration during incremental rebuilds.
+ *
+ * @remarks
+ * Mirrors ObjectARX `AcDbBlockChangeIterator`. Passed to
+ * {@link AcDbIndex.rebuildModified}.
+ */
+export type AcDbBlockChangeIterator = object
+
+/**
+ * Abstract base class for index objects used with the AutoCAD index/filter
+ * scheme.
+ *
+ * An {@link AcDbIndex} accelerates queries defined by an {@link AcDbFilter}.
+ * Keeping the index up to date is typically done through index-filter manager
+ * update calls (or during save).
+ *
+ * @remarks
+ * Mirrors the ObjectARX `AcDbIndex` class. {@link AcDbLayerIndex} and spatial
+ * indexes derive from this type.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbIndex
+ *
+ * @example
+ * ```typescript
+ * const index = new AcDbLayerIndex();
+ * index.lastUpdatedAt = Date.now();
+ * ```
+ */
+export abstract class AcDbIndex extends AcDbObject {
+  /** Julian / local last-updated timestamp (DXF group code 40). */
+  private _lastUpdatedAt: number
+  /** UTC last-updated timestamp. */
+  private _lastUpdatedAtU: number
+  /** Whether this index is considered current. */
+  private _isUptoDate: boolean
+  /** Object ID of the block table record being indexed. */
+  private _objectBeingIndexedId: AcDbObjectId
+
+  /**
+   * Creates a new {@link AcDbIndex} instance.
+   */
+  constructor() {
+    super()
+    this._lastUpdatedAt = 0
+    this._lastUpdatedAtU = 0
+    this._isUptoDate = false
+    this._objectBeingIndexedId = ''
+  }
+
+  /**
+   * Gets the local last-updated timestamp for this index.
+   *
+   * @remarks
+   * In ObjectARX this returns an `AcDbDate`. This port stores a numeric
+   * timestamp (Julian date when read from DXF group code 40).
+   *
+   * @returns The last-updated timestamp.
+   */
+  get lastUpdatedAt(): number {
+    return this._lastUpdatedAt
+  }
+
+  /**
+   * Sets the local last-updated timestamp for this index.
+   *
+   * @param value - The new timestamp value.
+   */
+  set lastUpdatedAt(value: number) {
+    this._lastUpdatedAt = value
+  }
+
+  /**
+   * Gets the UTC last-updated timestamp for this index.
+   *
+   * @returns The UTC last-updated timestamp.
+   */
+  get lastUpdatedAtU(): number {
+    return this._lastUpdatedAtU
+  }
+
+  /**
+   * Sets the UTC last-updated timestamp for this index.
+   *
+   * @param value - The new UTC timestamp value.
+   */
+  set lastUpdatedAtU(value: number) {
+    this._lastUpdatedAtU = value
+  }
+
+  /**
+   * Returns whether this index is considered up to date.
+   *
+   * @returns `true` if the index is current; otherwise `false`.
+   */
+  get isUptoDate(): boolean {
+    return this._isUptoDate
+  }
+
+  /**
+   * Sets whether this index is considered up to date.
+   *
+   * @param value - `true` if the index is current.
+   */
+  set isUptoDate(value: boolean) {
+    this._isUptoDate = value
+  }
+
+  /**
+   * Gets the object ID of the object (typically a block table record) being
+   * indexed.
+   *
+   * @returns The object ID being indexed.
+   */
+  objectBeingIndexedId(): AcDbObjectId {
+    return this._objectBeingIndexedId
+  }
+
+  /**
+   * Sets the object ID of the object being indexed.
+   *
+   * @param value - The object ID to associate with this index.
+   */
+  setObjectBeingIndexedId(value: AcDbObjectId): void {
+    this._objectBeingIndexedId = value
+  }
+
+  /**
+   * Creates a filtered block iterator for the given filter query.
+   *
+   * @param filter - The filter defining the query.
+   * @returns A filtered block iterator, or `null` if not available.
+   */
+  abstract newIterator(
+    filter: AcDbFilter
+  ): AcDbFilteredBlockIterator | null
+
+  /**
+   * Fully rebuilds this index from the given update data.
+   *
+   * @param updateData - Index update mapping data.
+   * @returns `true` if the rebuild succeeded.
+   */
+  abstract rebuildFull(updateData?: AcDbIndexUpdateData): boolean
+
+  /**
+   * Incrementally rebuilds this index for modified block contents.
+   *
+   * @param changeIterator - Iterator over changed block entities.
+   * @returns `true` if the rebuild succeeded.
+   */
+  protected abstract rebuildModified(
+    changeIterator?: AcDbBlockChangeIterator
+  ): boolean
+
+  /**
+   * Writes DXF fields for this index object.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbIndex')
+    filer.writeDouble(40, this.lastUpdatedAt)
+    return this
+  }
+}

--- a/packages/data-model/src/object/AcDbLayerFilter.ts
+++ b/packages/data-model/src/object/AcDbLayerFilter.ts
@@ -1,0 +1,190 @@
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbFilter } from './AcDbFilter'
+
+/**
+ * Layer filter object used with the AutoCAD **index/filter** scheme
+ * (`INDEXCTL` / block regeneration), not the Layer Properties Manager tree.
+ *
+ * An {@link AcDbLayerFilter} stores a flat list of layer names that participate
+ * in a layer-based query against a block. It is the counterpart to
+ * {@link AcDbLayerIndex}; {@link AcDbLayerFilter.indexClass} returns the layer
+ * index class name.
+ *
+ * @remarks
+ * Mirrors the ObjectARX `AcDbLayerFilter` class. For the Layer Manager
+ * property/group filter **tree**, see {@link AcLyLayerFilter} /
+ * {@link AcLyLayerGroup} under the ObjectARX `AcLy*` classes.
+ *
+ * In DXF this object is written as type `LAYER_FILTER` with subclass markers
+ * `AcDbFilter` and `AcDbLayerFilter`, and repeated group code 8 entries for
+ * layer names.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbLayerFilter
+ *
+ * @example
+ * ```typescript
+ * const filter = new AcDbLayerFilter();
+ * filter.add('Walls');
+ * filter.add('Doors');
+ * console.log(filter.layerCount()); // 2
+ * console.log(filter.getAt(0)); // 'Walls'
+ * ```
+ */
+export class AcDbLayerFilter extends AcDbFilter {
+  /** Layer names included in this filter (DXF group code 8, repeated). */
+  private _layerNames: string[]
+
+  /**
+   * Creates a new {@link AcDbLayerFilter} instance.
+   *
+   * @example
+   * ```typescript
+   * const filter = new AcDbLayerFilter();
+   * ```
+   */
+  constructor() {
+    super()
+    this._layerNames = []
+  }
+
+  /**
+   * Gets a copy of the layer names stored in this filter.
+   *
+   * @returns An array of layer names.
+   */
+  get layerNames(): readonly string[] {
+    return this._layerNames
+  }
+
+  /**
+   * Replaces the layer names stored in this filter.
+   *
+   * @param value - The new list of layer names.
+   */
+  set layerNames(value: readonly string[]) {
+    this._layerNames = [...value]
+  }
+
+  /**
+   * Adds a layer name to this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::add`. Duplicate names are ignored.
+   *
+   * @param layerName - Layer name to include in the filter.
+   * @returns `true` if the name was added; `false` if it was empty or already present.
+   *
+   * @example
+   * ```typescript
+   * filter.add('0');
+   * ```
+   */
+  add(layerName: string): boolean {
+    const name = layerName?.trim()
+    if (!name) return false
+    if (this._layerNames.includes(name)) return false
+    this._layerNames.push(name)
+    return true
+  }
+
+  /**
+   * Gets the layer name at the specified index.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::getAt`.
+   *
+   * @param index - Zero-based index into the layer name list.
+   * @returns The layer name at `index`.
+   * @throws {Error} If `index` is out of range.
+   *
+   * @example
+   * ```typescript
+   * const name = filter.getAt(0);
+   * ```
+   */
+  getAt(index: number): string {
+    if (index < 0 || index >= this._layerNames.length) {
+      throw new Error('The layer index is out of range!')
+    }
+    return this._layerNames[index]
+  }
+
+  /**
+   * Removes a layer name from this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::remove`.
+   *
+   * @param layerName - Layer name to remove.
+   * @returns `true` if the name was removed; otherwise `false`.
+   *
+   * @example
+   * ```typescript
+   * filter.remove('Walls');
+   * ```
+   */
+  remove(layerName: string): boolean {
+    const index = this._layerNames.indexOf(layerName)
+    if (index < 0) return false
+    this._layerNames.splice(index, 1)
+    return true
+  }
+
+  /**
+   * Returns the number of layer names in this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::layerCount`.
+   *
+   * @returns The number of layer names.
+   *
+   * @example
+   * ```typescript
+   * const count = filter.layerCount();
+   * ```
+   */
+  layerCount(): number {
+    return this._layerNames.length
+  }
+
+  /**
+   * Returns the index class name associated with this filter.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::indexClass`, which returns
+   * `AcDbLayerIndex::desc()`. This port returns the class name string.
+   *
+   * @returns Always `'AcDbLayerIndex'`.
+   */
+  override indexClass(): string {
+    return 'AcDbLayerIndex'
+  }
+
+  /**
+   * Returns whether this filter is considered valid.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerFilter::isValid`. A filter is valid when it
+   * contains at least one non-empty layer name.
+   *
+   * @returns `true` if the filter is valid; otherwise `false`.
+   */
+  isValid(): boolean {
+    return this._layerNames.some(name => name.length > 0)
+  }
+
+  /**
+   * Writes DXF fields for this layer filter object.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbLayerFilter')
+    for (const layerName of this._layerNames) {
+      filer.writeString(8, layerName)
+    }
+    return this
+  }
+}

--- a/packages/data-model/src/object/AcDbLayerIndex.ts
+++ b/packages/data-model/src/object/AcDbLayerIndex.ts
@@ -1,0 +1,272 @@
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import type { AcDbObjectId } from '../base/AcDbObject'
+import type { AcDbBlockTableRecord } from '../database/AcDbBlockTableRecord'
+import type { AcDbLayerTable } from '../database/AcDbLayerTable'
+import type { AcDbFilter } from './AcDbFilter'
+import {
+  AcDbBlockChangeIterator,
+  AcDbFilteredBlockIterator,
+  AcDbIndex,
+  AcDbIndexUpdateData
+} from './AcDbIndex'
+
+/**
+ * Describes one layer entry stored in an {@link AcDbLayerIndex}.
+ *
+ * @remarks
+ * LAYER_INDEX DXF objects store parallel arrays of layer names (group 8),
+ * hard-owner IDBUFFER handles (group 360), and IDBUFFER entry counts
+ * (group 90). This type groups those related values for convenience.
+ */
+export interface AcDbLayerIndexEntry {
+  /** Layer name (DXF group code 8). */
+  layerName: string
+  /** Hard-owner handle of the associated IDBUFFER object (DXF group code 360). */
+  idBufferId: AcDbObjectId
+  /** Number of entries in the associated IDBUFFER (DXF group code 90). */
+  idBufferEntryCount: number
+}
+
+/**
+ * Layer index object used with the AutoCAD index/filter scheme.
+ *
+ * An {@link AcDbLayerIndex} is an index implementation specialized for layers.
+ * It is typically associated with a block table record and used together with
+ * {@link AcDbLayerFilter} when regenerating xrefs and blocks under the
+ * `INDEXCTL` system variable.
+ *
+ * @remarks
+ * Mirrors the ObjectARX `AcDbLayerIndex` class. In DXF this object is written
+ * as type `LAYER_INDEX` with subclass markers `AcDbIndex` and
+ * `AcDbLayerIndex`.
+ *
+ * @see https://help.autodesk.com/view/OARX/2024/ENU/?guid=OARX-RefGuide-AcDbLayerIndex
+ *
+ * @example
+ * ```typescript
+ * const index = new AcDbLayerIndex();
+ * index.lastUpdatedAt = 2451545.0;
+ * index.layerNames = ['0', 'Walls'];
+ * index.idBufferIds = ['1A', '1B'];
+ * index.idBufferEntryCounts = [10, 4];
+ * ```
+ */
+export class AcDbLayerIndex extends AcDbIndex {
+  /** Layer names included in this index (DXF group code 8, repeated). */
+  private _layerNames: string[]
+  /** Hard-owner handles to IDBUFFER objects (DXF group code 360, repeated). */
+  private _idBufferIds: AcDbObjectId[]
+  /** Entry counts for each IDBUFFER (DXF group code 90, repeated). */
+  private _idBufferEntryCounts: number[]
+
+  /**
+   * Creates a new {@link AcDbLayerIndex} instance.
+   *
+   * @example
+   * ```typescript
+   * const index = new AcDbLayerIndex();
+   * ```
+   */
+  constructor() {
+    super()
+    this._layerNames = []
+    this._idBufferIds = []
+    this._idBufferEntryCounts = []
+  }
+
+  /**
+   * Gets a copy of the layer names stored in this index.
+   *
+   * @returns An array of layer names.
+   */
+  get layerNames(): readonly string[] {
+    return this._layerNames
+  }
+
+  /**
+   * Replaces the layer names stored in this index.
+   *
+   * @param value - The new list of layer names.
+   */
+  set layerNames(value: readonly string[]) {
+    this._layerNames = [...value]
+  }
+
+  /**
+   * Gets a copy of the IDBUFFER object IDs referenced by this index.
+   *
+   * @returns An array of hard-owner IDBUFFER handles.
+   */
+  get idBufferIds(): readonly AcDbObjectId[] {
+    return this._idBufferIds
+  }
+
+  /**
+   * Replaces the IDBUFFER object IDs referenced by this index.
+   *
+   * @param value - The new list of IDBUFFER handles.
+   */
+  set idBufferIds(value: readonly AcDbObjectId[]) {
+    this._idBufferIds = [...value]
+  }
+
+  /**
+   * Gets a copy of the IDBUFFER entry counts stored in this index.
+   *
+   * @returns An array of IDBUFFER entry counts.
+   */
+  get idBufferEntryCounts(): readonly number[] {
+    return this._idBufferEntryCounts
+  }
+
+  /**
+   * Replaces the IDBUFFER entry counts stored in this index.
+   *
+   * @param value - The new list of entry counts.
+   */
+  set idBufferEntryCounts(value: readonly number[]) {
+    this._idBufferEntryCounts = [...value]
+  }
+
+  /**
+   * Returns grouped layer-index entries derived from the parallel DXF arrays.
+   *
+   * @returns An array of {@link AcDbLayerIndexEntry} values.
+   */
+  get entries(): AcDbLayerIndexEntry[] {
+    const count = Math.max(
+      this._layerNames.length,
+      this._idBufferIds.length,
+      this._idBufferEntryCounts.length
+    )
+    const result: AcDbLayerIndexEntry[] = []
+    for (let i = 0; i < count; i++) {
+      result.push({
+        layerName: this._layerNames[i] ?? '',
+        idBufferId: this._idBufferIds[i] ?? '',
+        idBufferEntryCount: this._idBufferEntryCounts[i] ?? 0
+      })
+    }
+    return result
+  }
+
+  /**
+   * Replaces this index from grouped layer-index entries.
+   *
+   * @param value - The entries to store.
+   */
+  set entries(value: readonly AcDbLayerIndexEntry[]) {
+    this._layerNames = value.map(entry => entry.layerName)
+    this._idBufferIds = value.map(entry => entry.idBufferId)
+    this._idBufferEntryCounts = value.map(entry => entry.idBufferEntryCount)
+  }
+
+  /**
+   * Computes (rebuilds) this layer index from a layer table and block table
+   * record.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerIndex::compute`. This port records layer names
+   * present in `layerTable` and associates the index with `blockTableRecord`;
+   * IDBUFFER population is not performed here.
+   *
+   * @param layerTable - Layer table used as the index source.
+   * @param blockTableRecord - Block table record being indexed.
+   * @returns `true` if the compute succeeded.
+   */
+  compute(
+    layerTable?: AcDbLayerTable,
+    blockTableRecord?: AcDbBlockTableRecord
+  ): boolean {
+    if (blockTableRecord) {
+      this.setObjectBeingIndexedId(blockTableRecord.objectId)
+    }
+    if (layerTable) {
+      this._layerNames = []
+      for (const layer of layerTable.newIterator()) {
+        this._layerNames.push(layer.name)
+      }
+    }
+    this.lastUpdatedAt = Date.now()
+    this.lastUpdatedAtU = Date.now()
+    this.isUptoDate = true
+    return true
+  }
+
+  /**
+   * Creates a filtered block iterator for the given layer filter query.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerIndex::newIterator`. A full filtered iterator
+   * is not yet implemented in this port.
+   *
+   * @param _filter - The filter defining the query (typically an
+   *   {@link AcDbLayerFilter}).
+   * @returns Always `null` until filtered iteration is implemented.
+   */
+  override newIterator(_filter: AcDbFilter): AcDbFilteredBlockIterator | null {
+    return null
+  }
+
+  /**
+   * Fully rebuilds this layer index.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerIndex::rebuildFull`.
+   *
+   * @param _updateData - Optional index update mapping data.
+   * @returns `true` if the rebuild succeeded.
+   */
+  override rebuildFull(_updateData?: AcDbIndexUpdateData): boolean {
+    this.lastUpdatedAt = Date.now()
+    this.lastUpdatedAtU = Date.now()
+    this.isUptoDate = true
+    return true
+  }
+
+  /**
+   * Incrementally rebuilds this layer index for modified block contents.
+   *
+   * @remarks
+   * Mirrors ObjectARX `AcDbLayerIndex::rebuildModified`.
+   *
+   * @param _changeIterator - Optional iterator over changed block entities.
+   * @returns `true` if the rebuild succeeded.
+   */
+  protected override rebuildModified(
+    _changeIterator?: AcDbBlockChangeIterator
+  ): boolean {
+    this.lastUpdatedAt = Date.now()
+    this.lastUpdatedAtU = Date.now()
+    this.isUptoDate = true
+    return true
+  }
+
+  /**
+   * Writes DXF fields for this layer index object.
+   *
+   * @param filer - DXF output writer.
+   * @returns The instance (for chaining).
+   */
+  override dxfOutFields(filer: AcDbDxfFiler) {
+    super.dxfOutFields(filer)
+    filer.writeSubclassMarker('AcDbLayerIndex')
+    const count = Math.max(
+      this._layerNames.length,
+      this._idBufferIds.length,
+      this._idBufferEntryCounts.length
+    )
+    for (let i = 0; i < count; i++) {
+      if (this._layerNames[i] != null) {
+        filer.writeString(8, this._layerNames[i])
+      }
+      if (this._idBufferIds[i]) {
+        filer.writeHandle(360, this._idBufferIds[i])
+      }
+      if (this._idBufferEntryCounts[i] != null) {
+        filer.writeInt32(90, this._idBufferEntryCounts[i])
+      }
+    }
+    return this
+  }
+}

--- a/packages/data-model/src/object/index.ts
+++ b/packages/data-model/src/object/index.ts
@@ -17,6 +17,16 @@ export type {
   AcDbPlotScale
 } from './layout'
 export { AcDbDictionary } from './AcDbDictionary'
+export { AcDbFilter } from './AcDbFilter'
+export { AcDbIndex } from './AcDbIndex'
+export type {
+  AcDbBlockChangeIterator,
+  AcDbFilteredBlockIterator,
+  AcDbIndexUpdateData
+} from './AcDbIndex'
+export { AcDbLayerFilter } from './AcDbLayerFilter'
+export { AcDbLayerIndex } from './AcDbLayerIndex'
+export type { AcDbLayerIndexEntry } from './AcDbLayerIndex'
 export { AcDbMLeaderStyle } from './AcDbMLeaderStyle'
 export { AcDbMlineStyle } from './AcDbMlineStyle'
 export type { AcDbMlineStyleElement } from './AcDbMlineStyle'

--- a/packages/dxf-json-converter/package.json
+++ b/packages/dxf-json-converter/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/dxf-json": "^1.2.6"
+    "@mlightcad/dxf-json": "^1.2.7"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -19,10 +19,12 @@ import {
   AcDbDimZeroSuppressionAngular,
   AcDbEntity,
   AcDbFontNameCollector,
+  AcDbLayerFilterPersistSource,
   AcDbLayerTableRecord,
   AcDbLinetypeTableRecord,
   AcDbObjectId,
   AcDbOpenDatabaseError,
+  acdbReadLayerFilterTree,
   AcDbSymbolTable,
   AcDbSymbolTableRecord,
   AcDbSystemVariables,
@@ -47,10 +49,13 @@ import {
   BlockRecordTableEntry,
   CommonDxfEntity,
   CommonDxfTableEntry,
+  DictionaryDXFObject,
   DimStylesTableEntry,
   DxfTable,
   ImageDefDXFObject,
   InsertEntity,
+  LayerFilterDXFObject,
+  LayerIndexDXFObject,
   LayerTableEntry,
   LayoutDXFObject,
   LTypeTableEntry,
@@ -62,7 +67,8 @@ import {
   StyleTableEntry,
   TextEntity,
   ToleranceEntity,
-  VPortTableEntry
+  VPortTableEntry,
+  XRecordDXFObject
 } from '@mlightcad/dxf-json/types'
 
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
@@ -145,7 +151,8 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       dimStyleTextStyles.set(entry.name, entry.DIMTXSTY || DEFAULT_TEXT_STYLE)
     }
     const rootEntities: CommonDxfEntity[] = [...(dxf.entities ?? [])]
-    for (const block of Object.values(blocks)) {
+    for (const name in blocks) {
+      const block = blocks[name]
       if (block.entities?.length) {
         rootEntities.push(...block.entities)
       }
@@ -418,7 +425,8 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
    */
   protected processBlocks(model: ParsedDxf, db: AcDbDatabase) {
     const blocks = model.blocks
-    for (const [name, block] of Object.entries(blocks)) {
+    for (const name in blocks) {
+      const block = blocks[name]
       let dbBlock = db.tables.blockTable.getAt(block.name)
       if (!dbBlock) {
         dbBlock = new AcDbBlockTableRecord()
@@ -639,6 +647,24 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         imageDefDict.setAt(dbImageDef.objectId, dbImageDef)
       })
     }
+    if ('LAYER_FILTER' in objects) {
+      const layerFilterDict = db.objects.layerFilter
+      objects['LAYER_FILTER'].forEach(filter => {
+        const dbFilter = objectConverter.convertLayerFilter(
+          filter as LayerFilterDXFObject
+        )
+        layerFilterDict.setAt(dbFilter.objectId, dbFilter)
+      })
+    }
+    if ('LAYER_INDEX' in objects) {
+      const layerIndexDict = db.objects.layerIndex
+      objects['LAYER_INDEX'].forEach(index => {
+        const dbIndex = objectConverter.convertLayerIndex(
+          index as LayerIndexDXFObject
+        )
+        layerIndexDict.setAt(dbIndex.objectId, dbIndex)
+      })
+    }
     if ('MLEADERSTYLE' in objects) {
       const mleaderStyleDict = db.objects.mleaderStyle
       objects['MLEADERSTYLE'].forEach(style => {
@@ -656,6 +682,77 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         )
         mlineStyleDict.setAt(dbStyle.styleName || dbStyle.objectId, dbStyle)
       })
+    }
+    this.processLayerFilterTree(model, db)
+  }
+
+  /**
+   * Reconstructs the Layer Manager filter tree (`AcLy*` classes) from the
+   * `ACAD_LAYERFILTERS` / `ACLYDICTIONARY` dictionaries and their XRecords
+   * stored in the Layer Table extension dictionary.
+   *
+   * @param model - Parsed DXF model containing objects section.
+   * @param db - Target database whose {@link AcDbDatabase.layerFilters} is set.
+   */
+  protected processLayerFilterTree(model: ParsedDxf, db: AcDbDatabase) {
+    const objects = model.objects.byName
+    const dictionaries: AcDbLayerFilterPersistSource['dictionaries'] = new Map()
+    const xrecords: AcDbLayerFilterPersistSource['xrecords'] = new Map()
+
+    const normalize = (handle?: string) =>
+      handle ? handle.trim().toUpperCase() : ''
+
+    const dictObjects = objects['DICTIONARY'] as
+      | DictionaryDXFObject[]
+      | undefined
+    if (dictObjects) {
+      dictObjects.forEach(dict => {
+        const entries: Record<string, string> = {}
+        ;(dict.entries ?? []).forEach(entry => {
+          const target = entry.objectHardId ?? entry.objectSoftId
+          if (entry.name && target) {
+            entries[entry.name] = normalize(target)
+          }
+        })
+        dictionaries.set(normalize(dict.handle), {
+          handle: normalize(dict.handle),
+          ownerObjectId: normalize(dict.ownerObjectId),
+          entries
+        })
+      })
+    }
+
+    const xrecordObjects = objects['XRECORD'] as XRecordDXFObject[] | undefined
+    if (xrecordObjects) {
+      xrecordObjects.forEach(xrecord => {
+        const source = xrecord as XRecordDXFObject & {
+          extensionDictionary?: string
+          extensionDictionaryId?: string
+          extensionDictionaryHandle?: string
+        }
+        xrecords.set(normalize(xrecord.handle), {
+          handle: normalize(xrecord.handle),
+          ownerObjectId: normalize(xrecord.ownerObjectId),
+          extensionDictionaryId: normalize(
+            source.extensionDictionary ??
+              source.extensionDictionaryId ??
+              source.extensionDictionaryHandle
+          ),
+          data: (xrecord.data ?? []).map(group => ({
+            code: Number(group.code),
+            value: group.value
+          }))
+        })
+      })
+    }
+
+    if (dictionaries.size === 0 && xrecords.size === 0) {
+      return
+    }
+
+    const tree = acdbReadLayerFilterTree({ dictionaries, xrecords })
+    if (tree.root.getNestedFilters().length > 0) {
+      db.layerFilters = tree
     }
   }
 
@@ -1092,7 +1189,11 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       groups[entity.type].push(entity)
     }
 
-    return order.flatMap(type => groups[type])
+    const result: CommonDxfEntity[] = []
+    for (const type of order) {
+      result.push(...groups[type])
+    }
+    return result
   }
 
   private normalizeHeaderStringValue(value: unknown) {

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -34,6 +34,10 @@ import {
   AcDbMLine,
   AcDbMLineJustification,
   AcDbMText,
+  AcDbOle2Frame,
+  AcDbOleFrame,
+  AcDbOleObjectType,
+  AcDbOleTileMode,
   AcDbOrdinateDimension,
   AcDbPoint,
   AcDbPoly2dType,
@@ -109,6 +113,8 @@ import {
   MLineEntity,
   MTextEntity,
   MultiLeaderEntity,
+  Ole2FrameEntity,
+  OleFrameEntity,
   PointEntity,
   PolylineEntity,
   RayEntity,
@@ -339,6 +345,10 @@ export class AcDbEntityConverter {
       return this.convertBlockReference(entity as InsertEntity)
     } else if (entity.type == 'ACAD_PROXY_ENTITY') {
       return this.convertProxyEntity(entity as AcadProxyEntity)
+    } else if (entity.type == 'OLE2FRAME') {
+      return this.convertOle2Frame(entity as Ole2FrameEntity)
+    } else if (entity.type == 'OLEFRAME') {
+      return this.convertOleFrame(entity as OleFrameEntity)
     }
     return null
   }
@@ -1479,6 +1489,38 @@ export class AcDbEntityConverter {
     const dbWipeout = new AcDbWipeout()
     this.processWipeout(wipeout, dbWipeout)
     return dbWipeout
+  }
+
+  private convertOleFrame(entity: OleFrameEntity) {
+    const dbEntity = new AcDbOleFrame()
+    dbEntity.oleVersion = entity.version ?? 0
+    if (entity.data) {
+      const bytes = hexStringsToBytes([entity.data])
+      dbEntity.loadOleObjectFromDxf(entity.dataSize, bytes)
+    }
+    return dbEntity
+  }
+
+  private convertOle2Frame(entity: Ole2FrameEntity) {
+    const dbEntity = new AcDbOle2Frame()
+    dbEntity.oleVersion = entity.version ?? 0
+    dbEntity.userType = entity.name ?? ''
+    dbEntity.upperLeftCorner.copy(entity.upperLeftCorner)
+    dbEntity.lowerRightCorner.copy(entity.lowerRightCorner)
+    dbEntity.oleObjectType =
+      (entity.oleObjectType as unknown as AcDbOleObjectType) ??
+      AcDbOleObjectType.Embedded
+    dbEntity.tileMode =
+      (entity.tileMode as unknown as AcDbOleTileMode) ??
+      AcDbOleTileMode.ModelSpace
+    if (entity.quality != null) {
+      dbEntity.setOutputQuality(entity.quality)
+    }
+    if (entity.data) {
+      const bytes = hexStringsToBytes([entity.data])
+      dbEntity.loadOleObjectFromDxf(entity.dataSize, bytes)
+    }
+    return dbEntity
   }
 
   private convertViewport(viewport: ViewportEntity) {

--- a/packages/dxf-json-converter/src/AcDbObjectConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbObjectConverter.ts
@@ -1,6 +1,8 @@
 import { AcCmColor } from '@mlightcad/data-model'
 import {
   AcDbBlockTableRecord,
+  AcDbLayerFilter,
+  AcDbLayerIndex,
   AcDbLayout,
   AcDbMLeaderStyle,
   AcDbMlineStyle,
@@ -17,6 +19,8 @@ import {
 import {
   CommonDXFObject,
   ImageDefDXFObject,
+  LayerFilterDXFObject,
+  LayerIndexDXFObject,
   LayoutDXFObject,
   MLeaderStyleDXFObject,
   MLineStyleDXFObject,
@@ -202,6 +206,47 @@ export class AcDbObjectConverter {
     const dbObject = new AcDbRasterImageDef()
     dbObject.sourceFileName = image.fileName
     this.processCommonAttrs(image, dbObject)
+    return dbObject
+  }
+
+  /**
+   * Converts a DXF LAYER_FILTER object to an AcDbLayerFilter.
+   *
+   * @param filter - The DXF layer filter object to convert
+   * @returns The converted AcDbLayerFilter instance
+   */
+  convertLayerFilter(filter: LayerFilterDXFObject) {
+    const dbObject = new AcDbLayerFilter()
+    if (filter.layerNames?.length) {
+      dbObject.layerNames = filter.layerNames
+    }
+    this.processCommonAttrs(filter, dbObject)
+    return dbObject
+  }
+
+  /**
+   * Converts a DXF LAYER_INDEX object to an AcDbLayerIndex.
+   *
+   * @param index - The DXF layer index object to convert
+   * @returns The converted AcDbLayerIndex instance
+   */
+  convertLayerIndex(index: LayerIndexDXFObject) {
+    const dbObject = new AcDbLayerIndex()
+    if (index.timeStamp != null) {
+      dbObject.lastUpdatedAt = index.timeStamp
+      dbObject.lastUpdatedAtU = index.timeStamp
+    }
+    if (index.layerNames?.length) {
+      dbObject.layerNames = index.layerNames
+    }
+    if (index.idBufferIds?.length) {
+      dbObject.idBufferIds = index.idBufferIds
+    }
+    if (index.idBufferEntryCounts?.length) {
+      dbObject.idBufferEntryCounts = index.idBufferEntryCounts
+    }
+    dbObject.isUptoDate = true
+    this.processCommonAttrs(index, dbObject)
     return dbObject
   }
 

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -33,6 +33,10 @@ import {
   AcDbMLine,
   AcDbMLineJustification,
   AcDbMText,
+  AcDbOle2Frame,
+  AcDbOleFrame,
+  AcDbOleObjectType,
+  AcDbOleTileMode,
   AcDbOrdinateDimension,
   AcDbPoint,
   AcDbPoly2dType,
@@ -101,6 +105,8 @@ import type {
   DwgMLineEntity,
   DwgMTextEntity,
   DwgMultiLeaderEntity,
+  DwgOle2FrameEntity,
+  DwgOleFrameEntity,
   DwgOrdinateDimensionEntity,
   DwgPointEntity,
   DwgPolyline2dEntity,
@@ -220,6 +226,10 @@ export class AcDbEntityConverter {
       return this.convertBlockReference(entity as DwgInsertEntity)
     } else if (entity.type == 'ACAD_PROXY_ENTITY') {
       return this.convertProxyEntity(entity as DwgProxyEntity)
+    } else if (entity.type == 'OLE2FRAME') {
+      return this.convertOle2Frame(entity as DwgOle2FrameEntity)
+    } else if (entity.type == 'OLEFRAME') {
+      return this.convertOleFrame(entity as DwgOleFrameEntity)
     }
     return null
   }
@@ -1246,6 +1256,39 @@ export class AcDbEntityConverter {
     const dbWipeout = new AcDbWipeout()
     this.processImage(wipeout, dbWipeout)
     return dbWipeout
+  }
+
+  private convertOleFrame(entity: DwgOleFrameEntity) {
+    const dbEntity = new AcDbOleFrame()
+    dbEntity.oleVersion = entity.flag ?? 0
+    if (entity.binaryData) {
+      const bytes = hexStringsToBytes([entity.binaryData])
+      dbEntity.loadOleObjectFromDxf(entity.dataSize, bytes)
+    }
+    return dbEntity
+  }
+
+  private convertOle2Frame(entity: DwgOle2FrameEntity) {
+    const dbEntity = new AcDbOle2Frame()
+    dbEntity.oleVersion = entity.oleVersion ?? 0
+    dbEntity.userType = entity.oleClient ?? ''
+    if (entity.leftUpPoint) {
+      dbEntity.upperLeftCorner.copy(entity.leftUpPoint)
+    }
+    if (entity.rightDownPoint) {
+      dbEntity.lowerRightCorner.copy(entity.rightDownPoint)
+    }
+    dbEntity.setLockAspect(entity.lockAspect ?? 0)
+    dbEntity.oleObjectType =
+      (entity.oleObjectType as AcDbOleObjectType) ?? AcDbOleObjectType.Embedded
+    dbEntity.tileMode =
+      (entity.tileModeDescriptor as AcDbOleTileMode) ??
+      AcDbOleTileMode.ModelSpace
+    if (entity.binaryData) {
+      const bytes = hexStringsToBytes([entity.binaryData])
+      dbEntity.loadOleObjectFromDxf(entity.dataSize, bytes)
+    }
+    return dbEntity
   }
 
   private convertViewport(viewport: DwgViewportEntity) {

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -16,6 +16,7 @@ import {
   AcDbDimZeroSuppressionAngular,
   AcDbEntity,
   AcDbFontNameCollector,
+  AcDbLayerFilterPersistSource,
   AcDbLayerTableRecord,
   AcDbLayout,
   AcDbLinetypeTableRecord,
@@ -24,6 +25,7 @@ import {
   AcDbOpenDatabaseError,
   AcDbParsingTaskResult,
   AcDbRasterImageDef,
+  acdbReadLayerFilterTree,
   AcDbSymbolTableRecord,
   AcDbTextStyleTableRecord,
   AcDbTextStyleTableRecordAttrs,
@@ -54,6 +56,10 @@ import {
 } from '@mlightcad/libredwg-web'
 
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
+import type {
+  DwgLayerFilterObject,
+  DwgLayerIndexObject
+} from './AcDbObjectConverter'
 import { AcDbObjectConverter } from './AcDbObjectConverter'
 
 const MODEL_SPACE = '*MODEL_SPACE'
@@ -641,7 +647,90 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   protected processObjects(model: DwgDatabase, db: AcDbDatabase) {
     this.processLayouts(model, db)
     this.processImageDefs(model, db)
+    this.processLayerFilters(model, db)
+    this.processLayerIndexes(model, db)
+    this.processLayerFilterTree(model, db)
     this.processMLeaderStyles(model, db)
+  }
+
+  /**
+   * Reconstructs the Layer Manager filter tree (`AcLy*` classes) from the
+   * `ACAD_LAYERFILTERS` / `ACLYDICTIONARY` dictionaries and their XRecords.
+   *
+   * @remarks
+   * Requires the DWG parser to expose `DICTIONARY` and `XRECORD` objects. When
+   * the current `libredwg-web` build does not surface `XRECORD` objects, the
+   * nested filter payloads are unavailable and this method is a no-op.
+   *
+   * @param model - Parsed DWG database.
+   * @param db - Target database whose {@link AcDbDatabase.layerFilters} is set.
+   */
+  private processLayerFilterTree(model: DwgDatabase, db: AcDbDatabase) {
+    const objects = model.objects as DwgDatabase['objects'] & {
+      DICTIONARY?: {
+        handle: string
+        ownerHandle?: string
+        entries?: Record<string, string>
+      }[]
+      XRECORD?: {
+        handle: string
+        ownerHandle?: string
+        extensionDictionary?: string
+        extensionDictionaryHandle?: string
+        extensionDictionaryId?: string
+        entries?: { code: number; value: unknown }[]
+        data?: { code: number; value: unknown }[]
+      }[]
+    }
+
+    const dictObjects = objects.DICTIONARY
+    const xrecordObjects = objects.XRECORD
+    if (!dictObjects?.length || !xrecordObjects?.length) {
+      return
+    }
+
+    const normalize = (handle?: string) =>
+      handle ? String(handle).trim().toUpperCase() : ''
+
+    const dictionaries: AcDbLayerFilterPersistSource['dictionaries'] = new Map()
+    dictObjects.forEach(dict => {
+      const entries: Record<string, string> = {}
+      const src = dict.entries ?? {}
+      for (const name in src) {
+        const target = src[name]
+        if (name && target) {
+          entries[name] = normalize(String(target))
+        }
+      }
+      dictionaries.set(normalize(dict.handle), {
+        handle: normalize(dict.handle),
+        ownerObjectId: normalize(dict.ownerHandle),
+        entries
+      })
+    })
+
+    const xrecords: AcDbLayerFilterPersistSource['xrecords'] = new Map()
+    xrecordObjects.forEach(xrecord => {
+      const groups = xrecord.data ?? xrecord.entries ?? []
+      xrecords.set(normalize(xrecord.handle), {
+        handle: normalize(xrecord.handle),
+        ownerObjectId: normalize(xrecord.ownerHandle),
+        extensionDictionaryId: normalize(
+          xrecord.extensionDictionary ??
+            xrecord.extensionDictionaryHandle ??
+            xrecord.extensionDictionaryId
+        ),
+        data: groups.map(group => ({
+          code: Number(group.code),
+          value: group.value
+        }))
+      })
+    })
+
+    const tree = acdbReadLayerFilterTree({ dictionaries, xrecords })
+    if (tree.root.getNestedFilters().length > 0) {
+      db.layerFilters = tree
+    }
   }
 
   private processLayouts(model: DwgDatabase, db: AcDbDatabase) {
@@ -695,6 +784,38 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     })
   }
 
+  private processLayerFilters(model: DwgDatabase, db: AcDbDatabase) {
+    const layerFilters = (
+      model.objects as DwgDatabase['objects'] & {
+        LAYER_FILTER?: DwgLayerFilterObject[]
+      }
+    ).LAYER_FILTER
+    if (!layerFilters?.length) return
+
+    const layerFilterDict = db.objects.layerFilter
+    const objectConverter = new AcDbObjectConverter()
+    layerFilters.forEach(filter => {
+      const dbFilter = objectConverter.convertLayerFilter(filter)
+      layerFilterDict.setAt(dbFilter.objectId, dbFilter)
+    })
+  }
+
+  private processLayerIndexes(model: DwgDatabase, db: AcDbDatabase) {
+    const layerIndexes = (
+      model.objects as DwgDatabase['objects'] & {
+        LAYER_INDEX?: DwgLayerIndexObject[]
+      }
+    ).LAYER_INDEX
+    if (!layerIndexes?.length) return
+
+    const layerIndexDict = db.objects.layerIndex
+    const objectConverter = new AcDbObjectConverter()
+    layerIndexes.forEach(index => {
+      const dbIndex = objectConverter.convertLayerIndex(index)
+      layerIndexDict.setAt(dbIndex.objectId, dbIndex)
+    })
+  }
+
   private processMLeaderStyles(model: DwgDatabase, db: AcDbDatabase) {
     const mleaderStyles = model.objects.MLEADERSTYLE
     if (!mleaderStyles?.length) return
@@ -742,7 +863,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       groups[entity.type].push(entity)
     }
 
-    return order.flatMap(type => groups[type])
+    const result: DwgEntity[] = []
+    for (const type of order) {
+      result.push(...groups[type])
+    }
+    return result
   }
 
   private isModelSpace(name: string) {

--- a/packages/libredwg-converter/src/AcDbObjectConverter.ts
+++ b/packages/libredwg-converter/src/AcDbObjectConverter.ts
@@ -1,9 +1,43 @@
 import {
+  AcDbLayerFilter,
+  AcDbLayerIndex,
   AcDbMLeaderStyle,
   AcDbObject,
   decodeMLeaderStyleRawColor
 } from '@mlightcad/data-model'
 import { DwgCommonObject, DwgMLeaderStyleObject } from '@mlightcad/libredwg-web'
+
+/**
+ * DWG LAYER_FILTER object fields.
+ *
+ * @remarks
+ * `@mlightcad/libredwg-web` currently exposes the DWG type enum for layer
+ * filters but does not yet publish a dedicated TypeScript interface. This
+ * shape mirrors the DXF LAYER_FILTER mapping used by ObjectARX / dxf-json.
+ */
+export interface DwgLayerFilterObject extends DwgCommonObject {
+  /** Layer names included in this filter. */
+  layerNames?: string[]
+}
+
+/**
+ * DWG LAYER_INDEX object fields.
+ *
+ * @remarks
+ * `@mlightcad/libredwg-web` currently exposes the DWG type enum for layer
+ * indexes but does not yet publish a dedicated TypeScript interface. This
+ * shape mirrors the DXF LAYER_INDEX mapping used by ObjectARX / dxf-json.
+ */
+export interface DwgLayerIndexObject extends DwgCommonObject {
+  /** Julian / last-updated timestamp. */
+  timeStamp?: number
+  /** Layer names included in this layer index. */
+  layerNames?: string[]
+  /** Hard-owner handles to IDBUFFER objects. */
+  idBufferIds?: string[]
+  /** Number of entries in each referenced IDBUFFER. */
+  idBufferEntryCounts?: number[]
+}
 
 /**
  * Converts libredwg object records to AcDbObject instances.
@@ -123,6 +157,47 @@ export class AcDbObjectConverter {
     }
     dbObject.unknown2 = style.unknown2
     this.processCommonAttrs(style, dbObject)
+    return dbObject
+  }
+
+  /**
+   * Converts a DWG LAYER_FILTER object to an AcDbLayerFilter.
+   *
+   * @param filter - The DWG layer filter object to convert
+   * @returns The converted AcDbLayerFilter instance
+   */
+  convertLayerFilter(filter: DwgLayerFilterObject) {
+    const dbObject = new AcDbLayerFilter()
+    if (filter.layerNames?.length) {
+      dbObject.layerNames = filter.layerNames
+    }
+    this.processCommonAttrs(filter, dbObject)
+    return dbObject
+  }
+
+  /**
+   * Converts a DWG LAYER_INDEX object to an AcDbLayerIndex.
+   *
+   * @param index - The DWG layer index object to convert
+   * @returns The converted AcDbLayerIndex instance
+   */
+  convertLayerIndex(index: DwgLayerIndexObject) {
+    const dbObject = new AcDbLayerIndex()
+    if (index.timeStamp != null) {
+      dbObject.lastUpdatedAt = index.timeStamp
+      dbObject.lastUpdatedAtU = index.timeStamp
+    }
+    if (index.layerNames?.length) {
+      dbObject.layerNames = index.layerNames
+    }
+    if (index.idBufferIds?.length) {
+      dbObject.idBufferIds = index.idBufferIds
+    }
+    if (index.idBufferEntryCounts?.length) {
+      dbObject.idBufferEntryCounts = index.idBufferEntryCounts
+    }
+    dbObject.isUptoDate = true
+    this.processCommonAttrs(index, dbObject)
     return dbObject
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/dxf-json-converter:
     dependencies:
       '@mlightcad/dxf-json':
-        specifier: ^1.2.6
-        version: 1.2.6
+        specifier: ^1.2.7
+        version: 1.2.7
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1403,8 +1403,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mlightcad/dxf-json@1.2.6':
-    resolution: {integrity: sha512-7iQFRrXOr7TAT/5ELYncifV4bQgdA0KCGyu7P/2xWJH0+U5LZgxWdXJRBiAepcJPRJihNqdlweDwwJk7XGUOvA==}
+  '@mlightcad/dxf-json@1.2.7':
+    resolution: {integrity: sha512-bQwZa+vDNvGzMNhmyrRYvrPv/gfKVTS7FCditDy9fzw81e799YcvUeJLG6lvw2yhW65toQ+7MCvl6xdQ+i+D7Q==}
 
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
@@ -6353,7 +6353,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mlightcad/dxf-json@1.2.6':
+  '@mlightcad/dxf-json@1.2.7':
     dependencies:
       '@fxts/core': 1.26.0
 


### PR DESCRIPTION
## Summary
- Add OLE/OLE2 frame entities with embedded image extraction and renderer integration.
- Add layer filter/index and AcLy layer filter tree persistence for data-model.
- Wire DXF JSON and LibreDWG converters to import/export OLE and layer filter objects safely.

## Test plan
- pnpm jest packages/data-model/__tests__/AcDbOle2Frame.spec.ts --runInBand
- pnpm --filter @mlightcad/data-model lint
- pnpm --filter @mlightcad/dxf-json-converter lint
- pnpm --filter @mlightcad/libredwg-converter lint
- pnpm --filter @mlightcad/data-model exec tsc --noEmit
- pnpm --filter @mlightcad/dxf-json-converter exec tsc --noEmit
- pnpm --filter @mlightcad/libredwg-converter exec tsc --noEmit