### PR TITLE
chore(libredwg-converter): use libredwg-web 0.7.8 layer filter types

### DIFF
--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "^0.7.7"
+    "@mlightcad/libredwg-web": "^0.7.8"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -56,10 +56,6 @@ import {
 } from '@mlightcad/libredwg-web'
 
 import { AcDbEntityConverter } from './AcDbEntitiyConverter'
-import type {
-  DwgLayerFilterObject,
-  DwgLayerIndexObject
-} from './AcDbObjectConverter'
 import { AcDbObjectConverter } from './AcDbObjectConverter'
 
 const MODEL_SPACE = '*MODEL_SPACE'
@@ -658,33 +654,16 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
    * `ACAD_LAYERFILTERS` / `ACLYDICTIONARY` dictionaries and their XRecords.
    *
    * @remarks
-   * Requires the DWG parser to expose `DICTIONARY` and `XRECORD` objects. When
-   * the current `libredwg-web` build does not surface `XRECORD` objects, the
-   * nested filter payloads are unavailable and this method is a no-op.
+   * Reads `DICTIONARY` and `XRECORD` objects from the parsed DWG. When either
+   * collection is empty, nested filter payloads are unavailable and this
+   * method is a no-op.
    *
    * @param model - Parsed DWG database.
    * @param db - Target database whose {@link AcDbDatabase.layerFilters} is set.
    */
   private processLayerFilterTree(model: DwgDatabase, db: AcDbDatabase) {
-    const objects = model.objects as DwgDatabase['objects'] & {
-      DICTIONARY?: {
-        handle: string
-        ownerHandle?: string
-        entries?: Record<string, string>
-      }[]
-      XRECORD?: {
-        handle: string
-        ownerHandle?: string
-        extensionDictionary?: string
-        extensionDictionaryHandle?: string
-        extensionDictionaryId?: string
-        entries?: { code: number; value: unknown }[]
-        data?: { code: number; value: unknown }[]
-      }[]
-    }
-
-    const dictObjects = objects.DICTIONARY
-    const xrecordObjects = objects.XRECORD
+    const dictObjects = model.objects.DICTIONARY
+    const xrecordObjects = model.objects.XRECORD
     if (!dictObjects?.length || !xrecordObjects?.length) {
       return
     }
@@ -711,16 +690,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
 
     const xrecords: AcDbLayerFilterPersistSource['xrecords'] = new Map()
     xrecordObjects.forEach(xrecord => {
-      const groups = xrecord.data ?? xrecord.entries ?? []
       xrecords.set(normalize(xrecord.handle), {
         handle: normalize(xrecord.handle),
         ownerObjectId: normalize(xrecord.ownerHandle),
-        extensionDictionaryId: normalize(
-          xrecord.extensionDictionary ??
-            xrecord.extensionDictionaryHandle ??
-            xrecord.extensionDictionaryId
-        ),
-        data: groups.map(group => ({
+        extensionDictionaryId: normalize(xrecord.extensionDictionary),
+        data: (xrecord.data ?? []).map(group => ({
           code: Number(group.code),
           value: group.value
         }))
@@ -785,11 +759,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   }
 
   private processLayerFilters(model: DwgDatabase, db: AcDbDatabase) {
-    const layerFilters = (
-      model.objects as DwgDatabase['objects'] & {
-        LAYER_FILTER?: DwgLayerFilterObject[]
-      }
-    ).LAYER_FILTER
+    const layerFilters = model.objects.LAYER_FILTER
     if (!layerFilters?.length) return
 
     const layerFilterDict = db.objects.layerFilter
@@ -801,11 +771,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   }
 
   private processLayerIndexes(model: DwgDatabase, db: AcDbDatabase) {
-    const layerIndexes = (
-      model.objects as DwgDatabase['objects'] & {
-        LAYER_INDEX?: DwgLayerIndexObject[]
-      }
-    ).LAYER_INDEX
+    const layerIndexes = model.objects.LAYER_INDEX
     if (!layerIndexes?.length) return
 
     const layerIndexDict = db.objects.layerIndex

--- a/packages/libredwg-converter/src/AcDbObjectConverter.ts
+++ b/packages/libredwg-converter/src/AcDbObjectConverter.ts
@@ -5,39 +5,12 @@ import {
   AcDbObject,
   decodeMLeaderStyleRawColor
 } from '@mlightcad/data-model'
-import { DwgCommonObject, DwgMLeaderStyleObject } from '@mlightcad/libredwg-web'
-
-/**
- * DWG LAYER_FILTER object fields.
- *
- * @remarks
- * `@mlightcad/libredwg-web` currently exposes the DWG type enum for layer
- * filters but does not yet publish a dedicated TypeScript interface. This
- * shape mirrors the DXF LAYER_FILTER mapping used by ObjectARX / dxf-json.
- */
-export interface DwgLayerFilterObject extends DwgCommonObject {
-  /** Layer names included in this filter. */
-  layerNames?: string[]
-}
-
-/**
- * DWG LAYER_INDEX object fields.
- *
- * @remarks
- * `@mlightcad/libredwg-web` currently exposes the DWG type enum for layer
- * indexes but does not yet publish a dedicated TypeScript interface. This
- * shape mirrors the DXF LAYER_INDEX mapping used by ObjectARX / dxf-json.
- */
-export interface DwgLayerIndexObject extends DwgCommonObject {
-  /** Julian / last-updated timestamp. */
-  timeStamp?: number
-  /** Layer names included in this layer index. */
-  layerNames?: string[]
-  /** Hard-owner handles to IDBUFFER objects. */
-  idBufferIds?: string[]
-  /** Number of entries in each referenced IDBUFFER. */
-  idBufferEntryCounts?: number[]
-}
+import {
+  DwgCommonObject,
+  DwgLayerFilterObject,
+  DwgLayerIndexObject,
+  DwgMLeaderStyleObject
+} from '@mlightcad/libredwg-web'
 
 /**
  * Converts libredwg object records to AcDbObject instances.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/libredwg-converter:
     dependencies:
       '@mlightcad/libredwg-web':
-        specifier: ^0.7.7
-        version: 0.7.7
+        specifier: ^0.7.8
+        version: 0.7.8
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1409,8 +1409,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.7':
-    resolution: {integrity: sha512-JnEug2IVXafUecM9/WCQgH8mJRliaEq0Uxu3Mxt0Zk82n1MrSd25iA0Boo7e7t9qVwRPxQLGFxWoyPIrAeTy4w==}
+  '@mlightcad/libredwg-web@0.7.8':
+    resolution: {integrity: sha512-3ol9nxsCr5YJarcUs8Pv5WM8MvF45H3Gi8M3/GA4o8sahwG0Ehfz8Nh3OnxuX+pxQCt+pm9n8DFCeOf7kaU81A==}
     engines: {node: '>=20'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6359,7 +6359,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.7': {}
+  '@mlightcad/libredwg-web@0.7.8': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Bump `@mlightcad/libredwg-web` from `0.7.7` to `0.7.8`, which publishes first-class `LAYER_FILTER` / `LAYER_INDEX` / `DICTIONARY` / `XRECORD` types on `DwgDatabase`.
- Remove local workaround interfaces and cast-based access in the converter; read those collections and XRecord fields (`data`, `extensionDictionary`) directly from the package types.

## Test plan
- [ ] Confirm `pnpm --filter @mlightcad/libredwg-converter exec tsc --noEmit` passes
- [ ] Open a DWG that contains Layer Manager filters and verify nested filter tree still imports
- [ ] Open a DWG with `LAYER_FILTER` / `LAYER_INDEX` objects and verify they still convert into `db.objects.layerFilter` / `layerIndex`
