### PR TITLE
feat(data-model): store block PreviewIcon as bytes

### DIFF
--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -82,8 +82,11 @@ export interface AcDbBlockTableRecordAttrs extends AcDbSymbolTableRecordAttrs {
    * (DXF group code 1 on BLOCK). Empty when not an xref or the path is unknown.
    */
   pathName: string
-  /** Binary data for bitmap preview (DXF group code 310, optional) */
-  bmpPreview?: string
+  /**
+   * PreviewIcon binary payload (DXF BLOCK_RECORD group 310), typically a DIB
+   * (BITMAPINFO + bits). Stored as raw bytes rather than hex to save memory.
+   */
+  previewIcon?: Uint8Array
 }
 
 export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRecordAttrs> {
@@ -161,7 +164,7 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
       blockInsertUnits: 0,
       explodability: 1,
       blockScaling: AcDbBlockScaling.Uniform,
-      bmpPreview: undefined
+      previewIcon: undefined
     })
     super(attrs, defaultAttrs)
     this._entities = []
@@ -347,17 +350,23 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
   }
 
   /**
-   * Gets or sets the bitmap preview data.
+   * Gets or sets the PreviewIcon binary payload for this block definition.
    *
-   * This corresponds to DXF group code 310 in BLOCK_RECORD entries.
+   * Corresponds to AutoCAD .NET `BlockTableRecord.PreviewIcon` and DXF
+   * BLOCK_RECORD group code 310. The payload is typically a DIB (BITMAPINFO +
+   * bits), not a full BMP file. Stored as raw bytes to avoid hex doubling.
    *
-   * @returns The bitmap preview data
+   * @returns Preview icon bytes, or `undefined` when none exist
    */
-  get bmpPreview() {
-    return this.getAttrWithoutException('bmpPreview')
+  get previewIcon(): Uint8Array | undefined {
+    return this.getAttrWithoutException('previewIcon')
   }
-  set bmpPreview(value: string | undefined) {
-    this.setAttr('bmpPreview', value)
+  set previewIcon(value: Uint8Array | undefined) {
+    if (!value || value.length === 0) {
+      this.setAttr('previewIcon', undefined)
+      return
+    }
+    this.setAttr('previewIcon', value)
   }
 
   /**
@@ -605,8 +614,8 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
     filer.writeInt16(70, this.blockInsertUnits)
     filer.writeInt16(280, this.explodability)
     filer.writeInt16(281, this.blockScaling)
-    // TODO: Oupput preview bitmap with the correct format
-    // filer.writeString(310, this.bmpPreview)
+    // TODO: Output PreviewIcon (group 310) with the correct DIB/hex format
+    // if (this.previewIcon?.length) { ... }
     if (this.isModelSapce || this.isPaperSapce) {
       filer.writeObjectId(340, this.layoutId)
     }

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -297,6 +297,7 @@ export {
   VPORT_FALLBACK_VIEW_DIR,
   VPORT_FALLBACK_VIEW_TARGET,
   acdbHexStringsToBytes,
+  acdbPreviewIconToDataUrl,
   acdbHasOsnapMode,
   acdbMaskToOsnapModes,
   acdbOsnapModesToMask,

--- a/packages/data-model/src/ly/AcLyLayerFilterIO.ts
+++ b/packages/data-model/src/ly/AcLyLayerFilterIO.ts
@@ -290,10 +290,20 @@ function findNestedFilterHandles(
   parent: AcDbPersistXRecord
 ): { key: string; handle: string }[] {
   const result: { key: string; handle: string }[] = []
+  const seen = new Set<string>()
   const parentHandle = normalizeHandle(parent.handle)
   const extensionId = parent.extensionDictionaryId
     ? normalizeHandle(parent.extensionDictionaryId)
     : undefined
+
+  const pushEntry = (key: string, handle: string) => {
+    const normalized = normalizeHandle(handle)
+    if (seen.has(normalized)) {
+      return
+    }
+    seen.add(normalized)
+    result.push({ key, handle })
+  }
 
   for (const dict of source.dictionaries.values()) {
     const owner = dict.ownerObjectId
@@ -309,18 +319,20 @@ function findNestedFilterHandles(
       const nestedDict = source.dictionaries.get(normalizeHandle(nestedAcly))
       if (nestedDict) {
         for (const [key, handle] of Object.entries(nestedDict.entries)) {
-          result.push({ key, handle })
+          pushEntry(key, handle)
         }
         continue
       }
     }
 
     // Direct children listed on a dictionary owned by the parent.
+    // Skip ACLYDICTIONARY itself: its entries were already collected above when
+    // the parent/extension dictionary pointed at it (avoids duplicate children).
     for (const [key, handle] of Object.entries(dict.entries)) {
       if (key === ACLY_DICTIONARY_NAME || key === ACAD_LAYERFILTERS_NAME) {
         continue
       }
-      result.push({ key, handle })
+      pushEntry(key, handle)
     }
   }
 

--- a/packages/data-model/src/misc/AcDbPreviewIcon.ts
+++ b/packages/data-model/src/misc/AcDbPreviewIcon.ts
@@ -1,0 +1,74 @@
+/**
+ * Converts AutoCAD block PreviewIcon bytes to a browser-displayable BMP data URL.
+ *
+ * PreviewIcon data is typically a Device-Independent Bitmap (DIB): a memory copy
+ * of {@link https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo | BITMAPINFO}
+ * followed by pixel bits (DXF BLOCK_RECORD group 310). A full BMP file also has a
+ * 14-byte BITMAPFILEHEADER; this helper prepends that header when needed.
+ *
+ * @param data - Raw PreviewIcon bytes, or an empty buffer when none exist.
+ * @returns A `data:image/bmp;base64,...` URL, or `undefined` when the payload is empty/invalid.
+ */
+export function acdbPreviewIconToDataUrl(
+  data: Uint8Array | undefined | null
+): string | undefined {
+  if (!data || data.length === 0) return undefined
+
+  const bmpBytes = ensureBmpFileBytes(data)
+  if (!bmpBytes) return undefined
+
+  let binary = ''
+  for (let i = 0; i < bmpBytes.length; i++) {
+    binary += String.fromCharCode(bmpBytes[i])
+  }
+  return `data:image/bmp;base64,${btoa(binary)}`
+}
+
+/**
+ * Ensures PreviewIcon bytes are a complete BMP file (with BITMAPFILEHEADER).
+ *
+ * @param data - DIB or BMP bytes.
+ * @returns BMP file bytes, or `undefined` when the input cannot be interpreted.
+ */
+function ensureBmpFileBytes(data: Uint8Array): Uint8Array | undefined {
+  // Already a BMP file ("BM").
+  if (data.length >= 14 && data[0] === 0x42 && data[1] === 0x4d) {
+    return data
+  }
+
+  // Need at least a BITMAPINFOHEADER (biSize + width + height + …).
+  if (data.length < 40) return undefined
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+  const biSize = view.getUint32(0, true)
+  if (biSize < 12 || biSize > data.length) return undefined
+
+  const biBitCount = view.getUint16(14, true)
+  const biClrUsed = view.getUint32(32, true)
+  const paletteEntries =
+    biBitCount <= 8
+      ? biClrUsed > 0
+        ? biClrUsed
+        : 1 << biBitCount
+      : biClrUsed > 0
+        ? biClrUsed
+        : 0
+  // RGBQUAD is 4 bytes; BITMAPCOREHEADER (12) uses RGBTRIPLE (3 bytes) — rare for previews.
+  const paletteBytes = biSize === 12 ? paletteEntries * 3 : paletteEntries * 4
+  const pixelOffset = 14 + biSize + paletteBytes
+  if (pixelOffset > 14 + data.length) return undefined
+
+  const fileSize = 14 + data.length
+  const header = new Uint8Array(14)
+  const headerView = new DataView(header.buffer)
+  header[0] = 0x42 // 'B'
+  header[1] = 0x4d // 'M'
+  headerView.setUint32(2, fileSize, true)
+  headerView.setUint32(6, 0, true) // reserved
+  headerView.setUint32(10, pixelOffset, true)
+
+  const result = new Uint8Array(fileSize)
+  result.set(header, 0)
+  result.set(data, 14)
+  return result
+}

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -81,8 +81,10 @@ export {
   AcDbProxyGraphicBitStream,
   AcDbProxyGraphicByteStream,
   AcDbProxyGraphicEndOfBufferError,
+  acdbBytesToHexString,
   acdbHexStringsToBytes
 } from './proxyGraphic'
+export { acdbPreviewIconToDataUrl } from './AcDbPreviewIcon'
 export type {
   AcDbPatDocument,
   AcDbPatGradientColor,

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -20,6 +20,7 @@ import {
   AcDbDimZeroSuppressionAngular,
   AcDbEntity,
   AcDbFontNameCollector,
+  acdbHexStringsToBytes,
   AcDbLayerFilterPersistSource,
   AcDbLayerTableRecord,
   AcDbLinetypeTableRecord,
@@ -604,7 +605,7 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
         dbBlock.explodability = btr.explodability
         dbBlock.blockScaling = btr.scalability as AcDbBlockScaling
         if (btr.bmpPreview) {
-          dbBlock.bmpPreview = btr.bmpPreview
+          dbBlock.previewIcon = acdbHexStringsToBytes([btr.bmpPreview])
         }
         db.tables.blockTable.add(dbBlock)
       })

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -17,6 +17,7 @@ import {
   AcDbDimZeroSuppressionAngular,
   AcDbEntity,
   AcDbFontNameCollector,
+  acdbHexStringsToBytes,
   AcDbLayerFilterPersistSource,
   AcDbLayerTableRecord,
   AcDbLayout,
@@ -485,10 +486,12 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         dbBlock.blockInsertUnits = btr.insertionUnits
         dbBlock.explodability = btr.explodability
         dbBlock.blockScaling = btr.scalability as AcDbBlockScaling
-        if (btr.bmpPreview) {
-          dbBlock.bmpPreview = btr.bmpPreview
-        }
         db.tables.blockTable.add(dbBlock)
+      }
+      // Always sync PreviewIcon (DXF/DWG group 310) — including when the BTR
+      // already existed (e.g. lazily created model/paper space).
+      if (btr.bmpPreview) {
+        dbBlock.previewIcon = acdbHexStringsToBytes([btr.bmpPreview])
       }
       dbBlock.origin.copy(btr.basePoint)
 


### PR DESCRIPTION
## Summary
- Rename `BlockTableRecord.bmpPreview` (hex string) to `previewIcon` (`Uint8Array`) to match AutoCAD .NET and avoid hex doubling memory cost; converters decode DXF/DWG group 310 via `acdbHexStringsToBytes`.
- Add `acdbPreviewIconToDataUrl` to turn DIB/BMP PreviewIcon bytes into a browser-displayable BMP data URL.
- Fix nested layer-filter handle collection to dedupe children (and skip re-walking `ACLYDICTIONARY` entries).
- LibreDwg: always sync PreviewIcon even when the BTR already existed (e.g. lazy model/paper space).

## Test plan
- [ ] Open a DWG/DXF with block PreviewIcon (group 310) and confirm `blockTableRecord.previewIcon` is non-empty bytes
- [ ] Call `acdbPreviewIconToDataUrl(previewIcon)` and verify the data URL renders as an image in the browser
- [ ] Open a drawing with nested layer filters and confirm the filter tree has no duplicate children
- [ ] Regression: model/paper space blocks still receive PreviewIcon when present in LibreDwg conversion