### PR TITLE
fix(data-model): draw ATTDEF per AutoCAD semantics and fix DXF flags

### DIFF
--- a/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
+++ b/packages/data-model/__tests__/AcDbAttributeDefinition.spec.ts
@@ -1,6 +1,6 @@
 import { AcGePoint3d } from '@mlightcad/geometry-engine'
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
-import { AcDbDatabase } from '../src/database'
+import { AcDbBlockTableRecord, AcDbDatabase } from '../src/database'
 import {
   AcDbAttributeDefinition,
   AcDbMText,
@@ -99,11 +99,84 @@ describe('AcDbAttributeDefinition', () => {
     expect(attDef.isMTextAttribute).toBe(false)
   })
 
-  it('returns undefined in subWorldDraw', () => {
+  it('draws the tag for loose ATTDEFs and skips invisible ones', () => {
+    const db = setWorkingDb()
     const attDef = new AcDbAttributeDefinition()
-    expect(attDef.subWorldDraw({} as never)).toBeUndefined()
+    db.tables.blockTable.modelSpace.appendEntity(attDef)
+    attDef.tag = 'TAG_01'
+    attDef.textString = 'default value'
+    attDef.height = 2.5
+
+    const giEntity = { objectId: 'ATTDEF' }
+    const renderer = {
+      mtext: jest.fn(() => giEntity)
+    } as unknown as {
+      mtext: jest.Mock
+    }
+
+    expect(attDef.subWorldDraw(renderer as never, true)).toBe(giEntity)
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    expect(renderer.mtext.mock.calls[0][0]).toMatchObject({ text: 'TAG_01' })
+    expect(attDef.textString).toBe('default value')
+
+    attDef.isInvisible = true
+    expect(attDef.subWorldDraw(renderer as never)).toBeUndefined()
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
   })
 
+  it('draws the default value for ATTDEFs inside a block definition', () => {
+    const db = setWorkingDb()
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'ATTDEF_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+
+    const attDef = new AcDbAttributeDefinition()
+    attDef.tag = 'TAG_01'
+    attDef.textString = 'default value'
+    attDef.height = 2.5
+    blockRecord.appendEntity(attDef)
+
+    const giEntity = { objectId: 'ATTDEF' }
+    const renderer = {
+      mtext: jest.fn(() => giEntity)
+    } as unknown as {
+      mtext: jest.Mock
+    }
+
+    expect(attDef.subWorldDraw(renderer as never)).toBe(giEntity)
+    expect(renderer.mtext.mock.calls[0][0]).toMatchObject({
+      text: 'default value'
+    })
+  })
+
+  it('draws constant default values inside a block and still hides invisible ones', () => {
+    const db = setWorkingDb()
+    const blockRecord = new AcDbBlockTableRecord()
+    blockRecord.name = 'CONST_BLOCK'
+    db.tables.blockTable.add(blockRecord)
+
+    const attDef = new AcDbAttributeDefinition()
+    attDef.tag = 'TAG_01'
+    attDef.textString = 'fixed value'
+    attDef.isConst = true
+    attDef.height = 2.5
+    blockRecord.appendEntity(attDef)
+
+    const renderer = {
+      mtext: jest.fn(() => ({ objectId: 'ATTDEF' }))
+    } as unknown as {
+      mtext: jest.Mock
+    }
+
+    expect(attDef.subWorldDraw(renderer as never)).toBeDefined()
+    expect(renderer.mtext.mock.calls[0][0]).toMatchObject({
+      text: 'fixed value'
+    })
+
+    attDef.isInvisible = true
+    expect(attDef.subWorldDraw(renderer as never)).toBeUndefined()
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+  })
   it('writes expected ATTDEF-specific fields in dxfOutFields', () => {
     const db = setWorkingDb()
     const attDef = new AcDbAttributeDefinition()
@@ -116,8 +189,12 @@ describe('AcDbAttributeDefinition', () => {
     attDef.prompt = 'Prompt text'
     attDef.tag = 'A_TAG'
     attDef.isInvisible = true
+    attDef.isConst = true
+    attDef.isVerifiable = true
+    attDef.isPreset = true
     attDef.fieldLength = 42
-    attDef.isReallyLocked = true
+    attDef.lockPositionInBlock = true
+    attDef.isReallyLocked = false
 
     const result = attDef.dxfOutFields(filer)
     const out = filer.toString()
@@ -126,7 +203,8 @@ describe('AcDbAttributeDefinition', () => {
     expect(out).toContain('AcDbAttributeDefinition')
     expect(out).toContain('\n3\nPrompt text\n')
     expect(out).toContain('\n2\nA_TAG\n')
-    expect(out).toContain('\n70\n1\n')
+    // Invisible(1) | Const(2) | Verifiable(4) | Preset(8) = 15
+    expect(out).toContain('\n70\n15\n')
     expect(out).toContain('\n73\n42\n')
     expect(out).toContain('\n74\n1\n')
   })

--- a/packages/data-model/src/entity/AcDbAttributeDefinition.ts
+++ b/packages/data-model/src/entity/AcDbAttributeDefinition.ts
@@ -1,9 +1,8 @@
-import { AcGiRenderer } from '@mlightcad/graphic-interface'
+import { AcGiEntity, AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbMText } from './AcDbMText'
 import { AcDbText } from './AcDbText'
-
 /**
  * Attribute definition flags.
  *
@@ -322,15 +321,69 @@ export class AcDbAttributeDefinition extends AcDbText {
   }
 
   /**
-   * Draws nothing for attribute definition.
-   *
-   * @param renderer - The renderer to use for drawing
-   * @returns Always return undefined because of drawing nothing for attribute definition.
+   * Returns true when this ATTDEF is loose in model/paper space rather than
+   * stored inside a named block definition.
    */
-  subWorldDraw(_renderer: AcGiRenderer): undefined {
-    return undefined
+  private isLooseInDrawingSpace(): boolean {
+    const db = this.database
+    if (!db || !this.ownerId) {
+      return true
+    }
+    const owner = db.tables.blockTable.getIdAt(this.ownerId)
+    if (!owner) {
+      return true
+    }
+    return owner.isModelSapce || owner.isPaperSapce
   }
 
+  /**
+   * Resolves the on-screen glyph for this ATTDEF.
+   *
+   * - Loose in model/paper space: tag (placeholder while editing)
+   * - Inside a block definition: default attribute value
+   * - Invisible: not drawn
+   */
+  private resolveDisplayText(): string | undefined {
+    if (this.isInvisible) {
+      return undefined
+    }
+    if (this.isLooseInDrawingSpace()) {
+      return this.tag || this.textString
+    }
+    return this.textString
+  }
+
+  /**
+   * Draws an attribute definition following AutoCAD ATTDEF semantics.
+   *
+   * Loose definitions in model/paper space show the tag; definitions inside a
+   * block show the default value. Invisible definitions are not drawn.
+   *
+   * @param renderer - The renderer to use for drawing
+   * @param delay - When true, the renderer may defer heavy work
+   * @returns The rendered text entity, or undefined when not drawn
+   */
+  override subWorldDraw(
+    renderer: AcGiRenderer,
+    delay?: boolean
+  ): AcGiEntity | undefined {
+    const display = this.resolveDisplayText()
+    if (display === undefined) {
+      return undefined
+    }
+
+    if (display === this.textString) {
+      return super.subWorldDraw(renderer, delay)
+    }
+
+    const saved = this.textString
+    this.textString = display
+    try {
+      return super.subWorldDraw(renderer, delay)
+    } finally {
+      this.textString = saved
+    }
+  }
   /**
    * Writes DXF fields for this object.
    *
@@ -342,9 +395,11 @@ export class AcDbAttributeDefinition extends AcDbText {
     filer.writeSubclassMarker('AcDbAttributeDefinition')
     filer.writeString(3, this.prompt)
     filer.writeString(2, this.tag)
-    filer.writeInt16(70, this.isInvisible ? 1 : 0)
+    // Group 70: Invisible | Constant | Verifiable | Preset bit flags
+    filer.writeInt16(70, this._flags)
     filer.writeInt16(73, this.fieldLength)
-    filer.writeInt16(74, this.isReallyLocked ? 1 : 0)
+    // Group 74: lock position within the block (not isReallyLocked)
+    filer.writeInt16(74, this.lockPositionInBlock ? 1 : 0)
     return this
   }
 }


### PR DESCRIPTION
## Summary
- Render `AcDbAttributeDefinition` following AutoCAD ATTDEF semantics: loose definitions in model/paper space show the tag, definitions inside a block show the default value, and invisible definitions are not drawn.
- Fix DXF output for group 70 (full Invisible/Const/Verifiable/Preset flags) and group 74 (`lockPositionInBlock` instead of `isReallyLocked`).
- Expand unit tests to cover drawing behavior and corrected DXF flag encoding.

## Test plan
- [ ] Run `packages/data-model` unit tests, especially `AcDbAttributeDefinition.spec.ts`
- [ ] Open a drawing with loose ATTDEFs in model space and confirm tags are shown
- [ ] Open a block definition containing ATTDEFs and confirm default values are shown
- [ ] Confirm invisible ATTDEFs are not drawn
- [ ] Round-trip DXF for ATTDEF and verify groups 70 and 74