### PR TITLE
feat: support drawing thumbnails and viewport DCS-to-WCS mapping

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -36,6 +36,22 @@ describe('AcDbDatabase', () => {
     )
   })
 
+  it('stores and clears thumbnailImage bytes', () => {
+    const db = new AcDbDatabase()
+    expect(db.thumbnailImage).toBeUndefined()
+
+    const bytes = new Uint8Array([0x42, 0x4d, 0x00, 0x01])
+    db.thumbnailImage = bytes
+    expect(db.thumbnailImage).toBe(bytes)
+
+    db.thumbnailImage = new Uint8Array()
+    expect(db.thumbnailImage).toBeUndefined()
+
+    db.thumbnailImage = bytes
+    db.thumbnailImage = undefined
+    expect(db.thumbnailImage).toBeUndefined()
+  })
+
   it('reassigns symbol-table handles that collide across tables', () => {
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db

--- a/packages/data-model/__tests__/AcDbThumbnailImage.spec.ts
+++ b/packages/data-model/__tests__/AcDbThumbnailImage.spec.ts
@@ -1,0 +1,32 @@
+import {
+  acdbPreviewIconToDataUrl,
+  acdbThumbnailImageToDataUrl
+} from '../src/misc/AcDbPreviewIcon'
+
+describe('acdbThumbnailImageToDataUrl', () => {
+  it('returns undefined for empty input', () => {
+    expect(acdbThumbnailImageToDataUrl(undefined)).toBeUndefined()
+    expect(acdbThumbnailImageToDataUrl(new Uint8Array())).toBeUndefined()
+  })
+
+  it('detects PNG thumbnails', () => {
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00
+    ])
+    expect(acdbThumbnailImageToDataUrl(png)?.startsWith('data:image/png;base64,')).toBe(
+      true
+    )
+  })
+
+  it('detects JPEG thumbnails', () => {
+    const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0x00])
+    expect(acdbThumbnailImageToDataUrl(jpeg)?.startsWith('data:image/jpeg;base64,')).toBe(
+      true
+    )
+  })
+
+  it('falls back to BMP/DIB handling', () => {
+    const bmp = new Uint8Array([0x42, 0x4d, 0x00, 0x01, 0x00, 0x00])
+    expect(acdbThumbnailImageToDataUrl(bmp)).toBe(acdbPreviewIconToDataUrl(bmp))
+  })
+})

--- a/packages/data-model/__tests__/AcDbViewport.spec.ts
+++ b/packages/data-model/__tests__/AcDbViewport.spec.ts
@@ -37,6 +37,8 @@ describe('AcDbViewport', () => {
     expect(viewport.viewHeight).toBe(0)
     expect(viewport.centerPoint).toMatchObject({ x: 0, y: 0, z: 0 })
     expect(viewport.viewCenter).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(viewport.viewTarget).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(viewport.viewTwistAngle).toBe(0)
 
     viewport.number = 2
     viewport.height = 8
@@ -44,6 +46,8 @@ describe('AcDbViewport', () => {
     viewport.viewHeight = 24
     viewport.centerPoint = new AcGePoint3d(10, 20, 0)
     viewport.viewCenter = new AcGePoint3d(5, 6, 0)
+    viewport.viewTarget = new AcGePoint3d(100, 200, 0)
+    viewport.viewTwistAngle = Math.PI / 4
 
     expect(viewport.number).toBe(2)
     expect(viewport.height).toBe(8)
@@ -51,6 +55,8 @@ describe('AcDbViewport', () => {
     expect(viewport.viewHeight).toBe(24)
     expect(viewport.centerPoint).toMatchObject({ x: 10, y: 20, z: 0 })
     expect(viewport.viewCenter).toMatchObject({ x: 5, y: 6, z: 0 })
+    expect(viewport.viewTarget).toMatchObject({ x: 100, y: 200, z: 0 })
+    expect(viewport.viewTwistAngle).toBeCloseTo(Math.PI / 4)
   })
 
   it('returns geometricExtents and maps itself to AcGiViewport', () => {
@@ -75,6 +81,37 @@ describe('AcDbViewport', () => {
     expect(giViewport.viewHeight).toBe(20)
     expect(giViewport.centerPoint).toMatchObject({ x: 2, y: 4, z: 0 })
     expect(giViewport.viewCenter).toMatchObject({ x: 1, y: 1, z: 0 })
+    expect(giViewport.viewTarget).toMatchObject({ x: 0, y: 0, z: 0 })
+    expect(giViewport.viewTwistAngle).toBe(0)
+  })
+
+  it('maps DCS view center through viewTarget into WCS viewBox', () => {
+    const db = createDb()
+    const viewport = new AcDbViewport()
+    viewport.width = 420
+    viewport.height = 296.6468489892975
+    viewport.viewHeight = 8899.405469678924
+    viewport.viewCenter = new AcGePoint3d(
+      -1108628.2173647524,
+      -354100.8830431862,
+      0
+    )
+    viewport.viewTarget = new AcGePoint3d(
+      1111867.66380098,
+      300645.9460363481,
+      -24329.16594455871
+    )
+    db.tables.blockTable.modelSpace.appendEntity(viewport)
+
+    const giViewport = viewport.toGiViewport()
+    const box = giViewport.viewBox
+    const centerX = (box.min.x + box.max.x) / 2
+    const centerY = (box.min.y + box.max.y) / 2
+
+    expect(centerX).toBeCloseTo(3239.446436227532, 3)
+    expect(centerY).toBeCloseTo(-53454.937006838096, 3)
+    expect(box.max.x - box.min.x).toBeCloseTo(giViewport.viewWidth, 3)
+    expect(box.max.y - box.min.y).toBeCloseTo(giViewport.viewHeight, 3)
   })
 
   it('returns geometricExtents and recomputes when centerPoint changes', () => {

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -451,6 +451,11 @@ export class AcDbDatabase extends AcDbObject {
   /** Current drawing file name (**DWGNAME**), including extension. */
   private _dwgname: string
   /**
+   * Drawing thumbnail preview image (DXF `THUMBNAILIMAGE` / DWG preview).
+   * Raw image bytes (typically BMP/DIB or PNG), or `undefined` when absent.
+   */
+  private _thumbnailImage?: Uint8Array
+  /**
    * Layer Properties Manager filter tree (`AcLy*` / .NET `LayerFilterTree`).
    * Distinct from {@link objects.layerFilter} (`AcDbLayerFilter` index objects).
    */
@@ -1556,6 +1561,26 @@ export class AcDbDatabase extends AcDbObject {
         this._dwgname = nextValue
       }
     )
+  }
+
+  /**
+   * Gets or sets the drawing thumbnail preview image.
+   *
+   * Corresponds to AutoCAD .NET `Database.ThumbnailBitmap`, DXF
+   * `THUMBNAILIMAGE` section (group codes 90/310), and the DWG file preview.
+   * Stored as raw image bytes (typically BMP/DIB or PNG).
+   *
+   * @returns Thumbnail image bytes, or `undefined` when none exist.
+   */
+  get thumbnailImage(): Uint8Array | undefined {
+    return this._thumbnailImage
+  }
+  set thumbnailImage(value: Uint8Array | undefined) {
+    if (!value || value.length === 0) {
+      this._thumbnailImage = undefined
+      return
+    }
+    this._thumbnailImage = value
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbViewport.ts
+++ b/packages/data-model/src/entity/AcDbViewport.ts
@@ -49,6 +49,8 @@ export class AcDbViewport extends AcDbEntity {
   private _height: number
   private _width: number
   private _viewCenter: AcGePoint3d
+  private _viewTarget: AcGePoint3d
+  private _viewTwistAngle: number
   private _viewHeight: number
   private _number: number
 
@@ -60,6 +62,8 @@ export class AcDbViewport extends AcDbEntity {
    * - height: 0
    * - width: 0
    * - viewCenter: origin (0,0,0)
+   * - viewTarget: origin (0,0,0)
+   * - viewTwistAngle: 0
    * - viewHeight: 0
    * - number: -1 (indicating inactive viewport)
    */
@@ -69,6 +73,8 @@ export class AcDbViewport extends AcDbEntity {
     this._height = 0
     this._width = 0
     this._viewCenter = new AcGePoint3d()
+    this._viewTarget = new AcGePoint3d()
+    this._viewTwistAngle = 0
     this._viewHeight = 0
     this._number = -1
   }
@@ -159,6 +165,30 @@ export class AcDbViewport extends AcDbEntity {
   }
   set viewCenter(value: AcGePoint3d) {
     this._viewCenter = value
+  }
+
+  /**
+   * Gets or sets the view target in WCS coordinates (DXF group 17).
+   *
+   * The model view center stored in {@link viewCenter} is in DCS; the WCS
+   * center shown through the viewport is `viewTarget + rotate(viewCenter,
+   * viewTwistAngle)`.
+   */
+  get viewTarget() {
+    return this._viewTarget
+  }
+  set viewTarget(value: AcGePoint3d) {
+    this._viewTarget = value
+  }
+
+  /**
+   * Gets or sets the view twist angle in radians (DXF group 51).
+   */
+  get viewTwistAngle() {
+    return this._viewTwistAngle
+  }
+  set viewTwistAngle(value: number) {
+    this._viewTwistAngle = value
   }
 
   /**
@@ -338,6 +368,8 @@ export class AcDbViewport extends AcDbEntity {
     viewport.height = this.height
     viewport.viewHeight = this.viewHeight
     viewport.viewCenter = this.viewCenter
+    viewport.viewTarget = this.viewTarget
+    viewport.viewTwistAngle = this.viewTwistAngle
     return viewport
   }
 
@@ -427,7 +459,9 @@ export class AcDbViewport extends AcDbEntity {
     filer.writeDouble(40, this.height)
     filer.writeDouble(41, this.width)
     filer.writePoint3d(12, this.viewCenter)
+    filer.writePoint3d(17, this.viewTarget)
     filer.writeDouble(45, this.viewHeight)
+    filer.writeAngle(51, this.viewTwistAngle)
     filer.writeInt32(69, this.number)
     return this
   }

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -298,6 +298,7 @@ export {
   VPORT_FALLBACK_VIEW_TARGET,
   acdbHexStringsToBytes,
   acdbPreviewIconToDataUrl,
+  acdbThumbnailImageToDataUrl,
   acdbHasOsnapMode,
   acdbMaskToOsnapModes,
   acdbOsnapModesToMask,

--- a/packages/data-model/src/misc/AcDbPreviewIcon.ts
+++ b/packages/data-model/src/misc/AcDbPreviewIcon.ts
@@ -17,11 +17,57 @@ export function acdbPreviewIconToDataUrl(
   const bmpBytes = ensureBmpFileBytes(data)
   if (!bmpBytes) return undefined
 
-  let binary = ''
-  for (let i = 0; i < bmpBytes.length; i++) {
-    binary += String.fromCharCode(bmpBytes[i])
+  return bytesToDataUrl(bmpBytes, 'image/bmp')
+}
+
+/**
+ * Converts drawing thumbnail bytes to a browser-displayable data URL.
+ *
+ * Accepts PNG, JPEG, full BMP files, and DIB payloads (same wrapping as
+ * {@link acdbPreviewIconToDataUrl}). Used for DXF `THUMBNAILIMAGE` and DWG
+ * preview bitmaps (`Database.ThumbnailBitmap`).
+ *
+ * @param data - Raw thumbnail bytes, or an empty buffer when none exist.
+ * @returns A data URL, or `undefined` when the payload is empty/unsupported.
+ */
+export function acdbThumbnailImageToDataUrl(
+  data: Uint8Array | undefined | null
+): string | undefined {
+  if (!data || data.length === 0) return undefined
+
+  // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    data.length >= 8 &&
+    data[0] === 0x89 &&
+    data[1] === 0x50 &&
+    data[2] === 0x4e &&
+    data[3] === 0x47
+  ) {
+    return bytesToDataUrl(data, 'image/png')
   }
-  return `data:image/bmp;base64,${btoa(binary)}`
+
+  // JPEG signature: FF D8 FF
+  if (
+    data.length >= 3 &&
+    data[0] === 0xff &&
+    data[1] === 0xd8 &&
+    data[2] === 0xff
+  ) {
+    return bytesToDataUrl(data, 'image/jpeg')
+  }
+
+  return acdbPreviewIconToDataUrl(data)
+}
+
+/**
+ * Encodes raw bytes as a `data:` URL for the given MIME type.
+ */
+function bytesToDataUrl(data: Uint8Array, mime: string): string {
+  let binary = ''
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i])
+  }
+  return `data:${mime};base64,${btoa(binary)}`
 }
 
 /**

--- a/packages/data-model/src/misc/index.ts
+++ b/packages/data-model/src/misc/index.ts
@@ -84,7 +84,7 @@ export {
   acdbBytesToHexString,
   acdbHexStringsToBytes
 } from './proxyGraphic'
-export { acdbPreviewIconToDataUrl } from './AcDbPreviewIcon'
+export { acdbPreviewIconToDataUrl, acdbThumbnailImageToDataUrl } from './AcDbPreviewIcon'
 export type {
   AcDbPatDocument,
   AcDbPatGradientColor,

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -45,6 +45,10 @@ class TestDxfConverter extends AcDbDxfConverter {
   processBlocksPublic(model: any, db: AcDbDatabase) {
     return this.processBlocks(model, db)
   }
+
+  processHeaderPublic(model: any, db: AcDbDatabase) {
+    return this.processHeader(model, db)
+  }
 }
 
 describe('AcDbDxfConverter', () => {
@@ -327,5 +331,30 @@ describe('AcDbDxfConverter', () => {
 
     expect(block.origin.x).toBeCloseTo(129.7483812685847)
     expect(block.origin.y).toBeCloseTo(191.3692592886388)
+  })
+
+  it('sets thumbnailImage from THUMBNAILIMAGE buffer or hex payload', () => {
+    const db = new AcDbDatabase()
+    const converter = new TestDxfConverter({ useWorker: false })
+    const bytes = new Uint8Array([0x42, 0x4d, 0x01, 0x02])
+
+    converter.processHeaderPublic(
+      {
+        header: {},
+        thumbnailImage: { size: bytes.length, data: bytes }
+      },
+      db
+    )
+    expect(db.thumbnailImage).toEqual(bytes)
+
+    const dbHex = new AcDbDatabase()
+    converter.processHeaderPublic(
+      {
+        header: {},
+        thumbnailImage: { size: 2, data: 'AABB' }
+      },
+      dbHex
+    )
+    expect(dbHex.thumbnailImage).toEqual(new Uint8Array([0xaa, 0xbb]))
   })
 })

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -511,6 +511,14 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
    * ```
    */
   protected processHeader(model: ParsedDxf, db: AcDbDatabase) {
+    const thumbnail = model.thumbnailImage?.data
+    if (thumbnail instanceof Uint8Array && thumbnail.length > 0) {
+      db.thumbnailImage = thumbnail
+    } else if (typeof thumbnail === 'string' && /^[0-9A-Fa-f]+$/.test(thumbnail)) {
+      // Fallback when thumbnailImageFormat is 'hex' (group 310).
+      db.thumbnailImage = acdbHexStringsToBytes([thumbnail])
+    }
+
     const header = model.header
     if (header['$ACADVER']) {
       db.version = header['$ACADVER']

--- a/packages/dxf-json-converter/src/AcDbDxfParser.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfParser.ts
@@ -1,7 +1,8 @@
 import {
   AcDbCodePage,
   acdbDwgCodePageToEncoding,
-  AcDbDwgVersion} from '@mlightcad/data-model'
+  AcDbDwgVersion
+} from '@mlightcad/data-model'
 import { DxfParser, isBinaryDxf, ParsedDxf } from '@mlightcad/dxf-json'
 
 /**
@@ -20,7 +21,7 @@ export interface AcDbDxfHeaderInfo {
 export class AcDbDxfParser {
   parse(data: ArrayBuffer): ParsedDxf {
     const bytes = new Uint8Array(data)
-    const parser = new DxfParser()
+    const parser = new DxfParser({ thumbnailImageFormat: 'buffer' })
 
     if (isBinaryDxf(bytes)) {
       return parser.parseBuffer(bytes)

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -1530,6 +1530,29 @@ export class AcDbEntityConverter {
     dbViewport.width = viewport.width
     dbViewport.viewCenter.copy(viewport.displayCenter)
     dbViewport.viewHeight = viewport.viewHeight
+    if (viewport.targetPoint) {
+      dbViewport.viewTarget.copy(viewport.targetPoint)
+    }
+    if (viewport.viewTwistAngle != null) {
+      dbViewport.viewTwistAngle = viewport.viewTwistAngle
+    }
+
+    // Mirror libredwg-converter: repair collapsed default paper centers.
+    const eps = 1e-6
+    const centerAtOrigin =
+      Math.abs(dbViewport.centerPoint.x) < eps &&
+      Math.abs(dbViewport.centerPoint.y) < eps
+    const target = dbViewport.viewTarget
+    const targetAtOrigin =
+      Math.abs(target.x) < eps && Math.abs(target.y) < eps
+    const oneToOne =
+      Number.isFinite(dbViewport.height) &&
+      Number.isFinite(dbViewport.viewHeight) &&
+      Math.abs(dbViewport.viewHeight - dbViewport.height) < eps
+    if (centerAtOrigin && targetAtOrigin && oneToOne) {
+      dbViewport.centerPoint.copy(dbViewport.viewCenter)
+    }
+
     return dbViewport
   }
 

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -20,7 +20,8 @@ import {
   AcDbPatParser,
   AcDbPatSvgRenderer,
   AcDbPredefinedAcadIsoPat,
-  AcDbPredefinedAcadPat
+  AcDbPredefinedAcadPat,
+  acdbThumbnailImageToDataUrl
 } from '@mlightcad/data-model'
 import { AcDbDxfConverter } from '@mlightcad/dxf-json-converter'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
@@ -30,6 +31,7 @@ const runButton = document.getElementById('runButton') as HTMLButtonElement
 const status = document.getElementById('status') as HTMLDivElement
 const output = document.getElementById('output') as HTMLPreElement
 const exportButton = document.createElement('button')
+const thumbnailPreviewPanel = document.createElement('section')
 const linetypePreviewPanel = document.createElement('section')
 const patSourceSelect = document.getElementById(
   'patSourceSelect'
@@ -49,8 +51,11 @@ exportButton.hidden = true
 exportButton.disabled = true
 exportButton.style.marginLeft = '8px'
 runButton.insertAdjacentElement('afterend', exportButton)
+status.insertAdjacentElement('afterend', thumbnailPreviewPanel)
 output.insertAdjacentElement('afterend', linetypePreviewPanel)
 
+thumbnailPreviewPanel.style.marginTop = '12px'
+thumbnailPreviewPanel.style.display = 'none'
 linetypePreviewPanel.style.marginTop = '16px'
 linetypePreviewPanel.style.display = 'none'
 
@@ -229,6 +234,53 @@ const renderLayers = (layerInfo?: { count: number; names: string[] }) => {
   const lines = [`Layers (${layerInfo.count})`]
   layerInfo.names.forEach(name => lines.push(`- ${name}`))
   return lines
+}
+
+/**
+ * Renders the drawing thumbnail preview when the parsed database contains one.
+ *
+ * Clears and hides the panel when `database` is null or has no thumbnail bytes.
+ *
+ * @param database - Parsed drawing database, or `null` to reset the panel.
+ */
+const renderThumbnailPreview = (database: AcDbDatabase | null) => {
+  thumbnailPreviewPanel.innerHTML = ''
+  if (!database?.thumbnailImage?.length) {
+    thumbnailPreviewPanel.style.display = 'none'
+    return
+  }
+
+  const dataUrl = acdbThumbnailImageToDataUrl(database.thumbnailImage)
+  if (!dataUrl) {
+    thumbnailPreviewPanel.style.display = 'none'
+    return
+  }
+
+  const title = document.createElement('h3')
+  title.textContent = 'Drawing preview'
+  title.style.margin = '0 0 8px 0'
+  title.style.fontSize = '16px'
+
+  const image = document.createElement('img')
+  image.src = dataUrl
+  image.alt = 'Drawing thumbnail preview'
+  image.style.display = 'block'
+  image.style.maxWidth = 'min(100%, 512px)'
+  image.style.height = 'auto'
+  image.style.border = '1px solid #dadada'
+  image.style.borderRadius = '6px'
+  image.style.background = '#f8f9fa'
+
+  const caption = document.createElement('div')
+  caption.textContent = `${database.thumbnailImage.length.toLocaleString()} bytes`
+  caption.style.marginTop = '6px'
+  caption.style.fontSize = '12px'
+  caption.style.color = '#5f6368'
+
+  thumbnailPreviewPanel.appendChild(title)
+  thumbnailPreviewPanel.appendChild(image)
+  thumbnailPreviewPanel.appendChild(caption)
+  thumbnailPreviewPanel.style.display = 'block'
 }
 
 /**
@@ -507,6 +559,7 @@ const applyPatSource = () => {
 const runParse = async () => {
   if (!lastFile || !lastBuffer) {
     output.textContent = 'Please select a DWG or DXF file first.'
+    renderThumbnailPreview(null)
     renderLinetypePreviews(null)
     return
   }
@@ -549,6 +602,7 @@ const runParse = async () => {
     lastParsedDatabase = parsedDatabase
     setStatus('')
     output.textContent = lines.join('\n')
+    renderThumbnailPreview(lastParsedDatabase)
     renderLinetypePreviews(lastParsedDatabase)
     runButton.disabled = false
     fileInput.disabled = false
@@ -561,6 +615,7 @@ fileInput.addEventListener('change', async () => {
   if (!file) return
   lastFile = file
   lastParsedDatabase = null
+  renderThumbnailPreview(null)
   renderLinetypePreviews(null)
   updateExportButton()
   output.textContent = 'Loading file...\n'

--- a/packages/graphic-interface/src/AcGiViewport.ts
+++ b/packages/graphic-interface/src/AcGiViewport.ts
@@ -9,6 +9,8 @@ export class AcGiViewport {
   private _height: number
   private _width: number
   private _viewCenter: AcGePoint3d
+  private _viewTarget: AcGePoint3d
+  private _viewTwistAngle: number
   private _viewHeight: number
   private _number: number
   private _id: string
@@ -22,6 +24,8 @@ export class AcGiViewport {
     this._height = 0
     this._width = 0
     this._viewCenter = new AcGePoint3d()
+    this._viewTarget = new AcGePoint3d()
+    this._viewTwistAngle = 0
     this._viewHeight = 0
   }
 
@@ -109,6 +113,29 @@ export class AcGiViewport {
   }
 
   /**
+   * The view target in WCS coordinates (DXF group 17).
+   *
+   * Paper-space viewports store the model view center in DCS (`viewCenter`);
+   * the WCS center is `viewTarget + rotate(viewCenter, viewTwistAngle)`.
+   */
+  get viewTarget() {
+    return this._viewTarget
+  }
+  set viewTarget(value: AcGePoint3d) {
+    this._viewTarget.copy(value)
+  }
+
+  /**
+   * The view twist angle in radians (DXF group 51).
+   */
+  get viewTwistAngle() {
+    return this._viewTwistAngle
+  }
+  set viewTwistAngle(value: number) {
+    this._viewTwistAngle = value
+  }
+
+  /**
    * The height (in display coordinate system coordinates) of the Model Space view within the viewport.
    * Zooming the view out within the viewport increases this value and zooming in decreases this value.
    */
@@ -128,15 +155,52 @@ export class AcGiViewport {
   }
 
   /**
-   * The bounding box (in display coordinate system coordinates) of the Model Space view within the viewport.
+   * The bounding box of the Model Space view shown through this viewport,
+   * expressed in WCS coordinates.
+   *
+   * `viewCenter` is stored in DCS; AutoCAD maps it to WCS by rotating by
+   * `viewTwistAngle` and translating by `viewTarget` (same rule as
+   * `AcDbViewportTableRecord.modelViewBox` for the *ACTIVE VPORT).
    */
   get viewBox() {
+    const wcsCenter = AcGiViewport.dcsCenterToWcs(
+      this.viewCenter,
+      this.viewTarget,
+      this.viewTwistAngle
+    )
     const box = new AcGeBox2d()
-    box.setFromCenterAndSize(this.viewCenter, {
+    box.setFromCenterAndSize(wcsCenter, {
       x: this.viewWidth,
       y: this.viewHeight
     })
     return box
+  }
+
+  /**
+   * Maps a DCS view center to WCS using the viewport target and twist.
+   */
+  static dcsCenterToWcs(
+    center: AcGePoint3d,
+    target: AcGePoint3d,
+    twistAngle: number
+  ): AcGePoint3d {
+    let wcsCenterX = center.x
+    let wcsCenterY = center.y
+    if (Number.isFinite(twistAngle) && twistAngle !== 0) {
+      const cos = Math.cos(twistAngle)
+      const sin = Math.sin(twistAngle)
+      wcsCenterX = center.x * cos - center.y * sin
+      wcsCenterY = center.x * sin + center.y * cos
+    }
+    if (
+      target &&
+      Number.isFinite(target.x) &&
+      Number.isFinite(target.y)
+    ) {
+      wcsCenterX += target.x
+      wcsCenterY += target.y
+    }
+    return new AcGePoint3d(wcsCenterX, wcsCenterY, 0)
   }
 
   /**
@@ -152,6 +216,8 @@ export class AcGiViewport {
     viewport.height = this.height
     viewport.width = this.width
     viewport.viewCenter.copy(this.viewCenter)
+    viewport.viewTarget.copy(this.viewTarget)
+    viewport.viewTwistAngle = this.viewTwistAngle
     viewport.viewHeight = this.viewHeight
     return viewport
   }
@@ -169,6 +235,8 @@ export class AcGiViewport {
     this.height = viewport.height
     this.width = viewport.width
     this.viewCenter.copy(viewport.viewCenter)
+    this.viewTarget.copy(viewport.viewTarget)
+    this.viewTwistAngle = viewport.viewTwistAngle
     this.viewHeight = viewport.viewHeight
     return this
   }

--- a/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
@@ -1,8 +1,14 @@
+import { AcDbDatabase } from '@mlightcad/data-model'
+
 import { AcDbLibreDwgConverter } from '../src/AcDbLibreDwgConverter'
 
 class TestLibreDwgConverter extends AcDbLibreDwgConverter {
   getFontsPublic(dwg: any) {
     return this.getFonts(dwg)
+  }
+
+  processHeaderPublic(model: any, db: AcDbDatabase) {
+    return this.processHeader(model, db)
   }
 }
 
@@ -180,5 +186,21 @@ describe('AcDbLibreDwgConverter', () => {
     })
 
     expect(fonts).toEqual(expect.arrayContaining(['romans', 'gdt.shx']))
+  })
+
+  it('sets thumbnailImage from model thumbnailImage bytes', () => {
+    const db = new AcDbDatabase()
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+    converter.processHeaderPublic(
+      {
+        header: {},
+        thumbnailImage: bytes
+      },
+      db
+    )
+
+    expect(db.thumbnailImage).toEqual(bytes)
   })
 })

--- a/packages/libredwg-converter/package.json
+++ b/packages/libredwg-converter/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "eslint --fix --quiet src/"
   },
   "dependencies": {
-    "@mlightcad/libredwg-web": "^0.7.8"
+    "@mlightcad/libredwg-web": "^0.7.9"
   },
   "devDependencies": {
     "@mlightcad/data-model": "workspace:*",

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -1298,6 +1298,32 @@ export class AcDbEntityConverter {
     dbViewport.width = viewport.width
     dbViewport.viewCenter.copy(viewport.displayCenter)
     dbViewport.viewHeight = viewport.viewHeight
+    if (viewport.targetPoint) {
+      dbViewport.viewTarget.copy(viewport.targetPoint)
+    }
+    if (viewport.viewTwistAngle != null) {
+      dbViewport.viewTwistAngle = viewport.viewTwistAngle
+    }
+
+    // LibreDWG sometimes leaves the default paper-space viewport's paper
+    // center at (0,0) while displayCenter still holds the sheet-local
+    // center. Repair that so downstream default detection
+    // (centerPoint == viewCenter) and zoom bounds stay on the sheet.
+    const eps = 1e-6
+    const centerAtOrigin =
+      Math.abs(dbViewport.centerPoint.x) < eps &&
+      Math.abs(dbViewport.centerPoint.y) < eps
+    const target = dbViewport.viewTarget
+    const targetAtOrigin =
+      Math.abs(target.x) < eps && Math.abs(target.y) < eps
+    const oneToOne =
+      Number.isFinite(dbViewport.height) &&
+      Number.isFinite(dbViewport.viewHeight) &&
+      Math.abs(dbViewport.viewHeight - dbViewport.height) < eps
+    if (centerAtOrigin && targetAtOrigin && oneToOne) {
+      dbViewport.centerPoint.copy(dbViewport.viewCenter)
+    }
+
     return dbViewport
   }
 

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -598,6 +598,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
   }
 
   protected processHeader(model: DwgDatabase, db: AcDbDatabase) {
+    const thumbnail = model.thumbnailImage
+    if (thumbnail?.length) {
+      db.thumbnailImage = thumbnail
+    }
+
     const header = model.header
     // Color index 256 is 'ByLayer'
     if (header.CECOLOR) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/libredwg-converter:
     dependencies:
       '@mlightcad/libredwg-web':
-        specifier: ^0.7.8
-        version: 0.7.8
+        specifier: ^0.7.9
+        version: 0.7.9
     devDependencies:
       '@mlightcad/data-model':
         specifier: workspace:*
@@ -1706,8 +1706,8 @@ packages:
   '@mlightcad/libdxfrw-web@0.0.9':
     resolution: {integrity: sha512-6fqGbjKWwI93cq8vwpXiFdAzWfdJjcIlLuAYwUvgTcEjx5jPvbd+tkzY7mX2/a8iMm/b/auGVzkgf1wxezHYIw==}
 
-  '@mlightcad/libredwg-web@0.7.8':
-    resolution: {integrity: sha512-3ol9nxsCr5YJarcUs8Pv5WM8MvF45H3Gi8M3/GA4o8sahwG0Ehfz8Nh3OnxuX+pxQCt+pm9n8DFCeOf7kaU81A==}
+  '@mlightcad/libredwg-web@0.7.9':
+    resolution: {integrity: sha512-tqjx0eCiR0CNI3TyO3LVYzl4ptuzSFm7asGn/C1YiJaEk7Vneto+lRrVUco85qw+PZDihaFLwWqdYIEse1swbA==}
     engines: {node: '>=20'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6699,7 +6699,7 @@ snapshots:
 
   '@mlightcad/libdxfrw-web@0.0.9': {}
 
-  '@mlightcad/libredwg-web@0.7.8': {}
+  '@mlightcad/libredwg-web@0.7.9': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `AcDbDatabase.thumbnailImage` plus `acdbThumbnailImageToDataUrl` so DXF `THUMBNAILIMAGE` / DWG preview bytes can be stored and displayed (PNG/JPEG/BMP), with converter wiring for dxf-json and libredwg.
- Persist paper-space viewport `viewTarget` / `viewTwistAngle` and map DCS `viewCenter` into WCS for `AcGiViewport.viewBox`, matching `AcDbViewportTableRecord.modelViewBox`.
- Bump `@mlightcad/libredwg-web` to `^0.7.9` and show thumbnail previews in the example app.

## Test plan
- [ ] Run data-model / dxf-json-converter / libredwg-converter unit tests covering thumbnail and viewport mapping
- [ ] Open a DXF with `THUMBNAILIMAGE` and a DWG with preview bitmap; confirm example app shows the preview
- [ ] Open a paper-space layout whose viewport has a non-zero view target; confirm framed model view lands on geometry (not empty space)
- [ ] Regression: viewport with zero target/twist still frames as before