### PR TITLE
feat(data-model): ACDSDATA SAB solids, DXF open progress, MTEXT spacing

### DIFF
--- a/packages/data-model/__tests__/AcDbMText.spec.ts
+++ b/packages/data-model/__tests__/AcDbMText.spec.ts
@@ -95,7 +95,7 @@ describe('AcDbMText', () => {
     mtext.lineSpacingFactor = 1
     mtext.location = { x: 0, y: 0, z: 0 }
 
-    expect(mtext.geometricExtents.min.y).toBeCloseTo(-4)
+    expect(mtext.geometricExtents.min.y).toBeCloseTo(-(2 + (5 / 3) * 2))
     expect(mtext.geometricExtents.max.y).toBeCloseTo(0)
   })
 

--- a/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
@@ -20,7 +20,8 @@ import {
   AcDbSpline,
   AcDbTable,
   AcDbText,
-  AcDbXline
+  AcDbXline,
+  AcDb3dSolid
 } from '../src/entity'
 
 describe('AcDbNativeDxfConverter', () => {
@@ -2174,7 +2175,7 @@ describe('AcDbNativeDxfConverter', () => {
       }
     })
 
-    expect(stages).toEqual([
+    expect(stages.filter(s => !s.endsWith(':IN-PROGRESS'))).toEqual([
       'START:START',
       'PARSE:START',
       'PARSE:END',
@@ -2188,6 +2189,84 @@ describe('AcDbNativeDxfConverter', () => {
 
     const style = db.tables.textStyleTable.getAt('标准')
     expect(style?.fileName).toBe('SimSun')
+  })
+
+  it('emits PARSE IN-PROGRESS while streaming entities', async () => {
+    const lines = [
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES'
+    ]
+    for (let i = 0; i < 40; i++) {
+      lines.push(
+        '0',
+        'LINE',
+        '5',
+        (0x100 + i).toString(16).toUpperCase(),
+        '100',
+        'AcDbEntity',
+        '8',
+        '0',
+        '100',
+        'AcDbLine',
+        '10',
+        String(i),
+        '20',
+        '0',
+        '30',
+        '0',
+        '11',
+        String(i + 1),
+        '20',
+        '1',
+        '30',
+        '0'
+      )
+    }
+    lines.push('0', 'ENDSEC', '0', 'EOF')
+
+    const stages: string[] = []
+    const percentages: number[] = []
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const converter = new AcDbNativeDxfConverter()
+    const buffer = new TextEncoder().encode(lines.join('\n')).buffer
+    await converter.read(buffer, db, 5, async (pct, stage, status) => {
+      stages.push(`${stage}:${status}`)
+      percentages.push(pct)
+    })
+
+    expect(stages).toContain('PARSE:IN-PROGRESS')
+    expect(stages).toContain('ENTITY:IN-PROGRESS')
+    expect(stages.filter(s => !s.endsWith(':IN-PROGRESS'))).toEqual([
+      'START:START',
+      'PARSE:START',
+      'PARSE:END',
+      'FONT:START',
+      'FONT:END',
+      'ENTITY:START',
+      'ENTITY:END',
+      'END:END'
+    ])
+    const parseProgressPcts = percentages.filter(
+      (_, i) => stages[i] === 'PARSE:IN-PROGRESS'
+    )
+    expect(parseProgressPcts.length).toBeGreaterThan(0)
+    for (const pct of parseProgressPcts) {
+      expect(pct).toBeLessThan(12)
+    }
+    for (let i = 1; i < parseProgressPcts.length; i++) {
+      expect(parseProgressPcts[i]!).toBeGreaterThanOrEqual(parseProgressPcts[i - 1]!)
+    }
+    const entityProgressPcts = percentages.filter(
+      (_, i) => stages[i] === 'ENTITY:IN-PROGRESS'
+    )
+    expect(entityProgressPcts.length).toBeGreaterThan(0)
+    expect(entityProgressPcts[0]!).toBeGreaterThanOrEqual(20)
+    expect(entityProgressPcts[entityProgressPcts.length - 1]!).toBeLessThanOrEqual(98)
   })
 
   it('does not count SEQEND as an unknown entity', async () => {
@@ -2432,5 +2511,114 @@ describe('AcDbNativeDxfConverter', () => {
     const result = await reader.read(AcDbDxfFiler.fromString(dxf))
     expect(result.unknownObjectCount).toBe(1)
     expect(result.unknownEntityCount).toBe(0)
+  })
+
+  it('attaches ACDSDATA ASM_Data SAB bytes to matching 3DSOLID entities', async () => {
+    // Hex for ASCII "ACIS BinaryFile...." — enough to verify ownership wiring.
+    const sabHex = '414349532042696E61727946696C65'
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      '0',
+      '3DSOLID',
+      '5',
+      '7E9',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbModelerGeometry',
+      '290',
+      '0',
+      '2',
+      '{00000000-0000-0000-0000-000000000000}',
+      '100',
+      'AcDb3dSolid',
+      '350',
+      '100',
+      '0',
+      'ENDSEC',
+      '0',
+      'SECTION',
+      '2',
+      'ACDSDATA',
+      '0',
+      'ACDSRECORD',
+      '320',
+      '7E9',
+      '2',
+      'ASM_Data',
+      '310',
+      sabHex,
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF',
+      ''
+    ].join('\n')
+
+    const converter = new AcDbNativeDxfConverter()
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    await converter.read(new TextEncoder().encode(dxf).buffer, db, 50)
+
+    const solids = [...db.tables.blockTable.modelSpace.newIterator()].filter(
+      e => e instanceof AcDb3dSolid
+    )
+    expect(solids).toHaveLength(1)
+    const solid = solids[0] as AcDb3dSolid
+    expect(solid.historyObjectSoftId).toBe('100')
+    expect(solid.guid).toBe('{00000000-0000-0000-0000-000000000000}')
+    expect(solid.sabBytes).toBeDefined()
+    expect(String.fromCharCode(...solid.sabBytes!.subarray(0, 4))).toBe('ACIS')
+  })
+
+  it('decrypts obfuscated inline ACIS SAT groups 1/3 on 3DSOLID', async () => {
+    const { acdbDecryptAcisData } = await import('../src/acis')
+    const plain = 'point $-1 1 2 3 #'
+    const encrypted = acdbDecryptAcisData(plain) // involution
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      '0',
+      '3DSOLID',
+      '5',
+      'A1',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbModelerGeometry',
+      '70',
+      '400',
+      '1',
+      encrypted,
+      '100',
+      'AcDb3dSolid',
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF',
+      ''
+    ].join('\n')
+
+    const converter = new AcDbNativeDxfConverter()
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+    await converter.read(new TextEncoder().encode(dxf).buffer, db, 50)
+
+    const solid = [...db.tables.blockTable.modelSpace.newIterator()].find(
+      e => e instanceof AcDb3dSolid
+    ) as AcDb3dSolid
+    expect(solid).toBeDefined()
+    expect(solid.version).toBe(400)
+    expect(solid.acisData).toContain('point $-1 1 2 3')
+    expect(solid.hasRenderableGeometry).toBe(true)
   })
 })

--- a/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
+++ b/packages/data-model/__tests__/AcDbTextExtentsHelpers.spec.ts
@@ -75,9 +75,14 @@ describe('AcDbTextExtentsHelpers', () => {
     })
 
     it('adds inter-line spacing for multiple lines', () => {
-      expect(acdbEstimateMTextHeight(2, 2, 1)).toBeCloseTo(4)
-      expect(acdbEstimateMTextHeight(2, 2, 0.25)).toBeCloseTo(2.5)
-      expect(acdbEstimateMTextHeight(3, 2, 1.5)).toBeCloseTo(8)
+      // Baseline distance = factor × (5/3) × textHeight
+      expect(acdbEstimateMTextHeight(2, 2, 1)).toBeCloseTo(2 + (5 / 3) * 2)
+      expect(acdbEstimateMTextHeight(2, 2, 0.25)).toBeCloseTo(
+        2 + 0.25 * (5 / 3) * 2
+      )
+      expect(acdbEstimateMTextHeight(3, 2, 1.5)).toBeCloseTo(
+        2 + 2 * 1.5 * (5 / 3) * 2
+      )
     })
   })
 

--- a/packages/data-model/src/acis/AcDbAcisDecrypt.ts
+++ b/packages/data-model/src/acis/AcDbAcisDecrypt.ts
@@ -1,0 +1,111 @@
+/**
+ * Decrypts obfuscated ACIS SAT text stored in DXF group codes 1 and 3.
+ *
+ * AutoCAD applies `chr(159 - ord(c))` to every character above ASCII space.
+ * See LibreDWG `dec_sat.pl` and the DXF reference for 3DSOLID/REGION/BODY.
+ *
+ * Ported from `@mlightcad/dxf-json` `parser/acis/decrypt.ts`.
+ */
+
+/**
+ * Decrypts an obfuscated SAT fragment from a DXF group 1 or 3 value.
+ *
+ * @param encrypted - Obfuscated SAT fragment.
+ */
+export function acdbDecryptAcisData(encrypted: string): string {
+  let decrypted = ''
+  for (let i = 0; i < encrypted.length; i++) {
+    const code = encrypted.charCodeAt(i)
+    decrypted += code <= 32 ? encrypted[i]! : String.fromCharCode(159 - code)
+  }
+  return decrypted
+}
+
+/**
+ * Returns true when `data` looks like encrypted ACIS rather than plain SAT/ASM
+ * text (which typically starts with a version number or "ACIS"/"ASM").
+ *
+ * @param data - Raw group 1/3 value before decryption.
+ */
+export function acdbIsEncryptedAcisData(data: string): boolean {
+  const trimmed = data.trimStart()
+  if (!trimmed) {
+    return false
+  }
+  if (/^\d/.test(trimmed) || /^ACIS/i.test(trimmed) || /^ASM/i.test(trimmed)) {
+    return false
+  }
+  if (
+    /^(body|point|plane|cone|cylinder|sphere|torus|lump|shell|face|edge|wire|transform)\b/i.test(
+      trimmed
+    )
+  ) {
+    return false
+  }
+  if (/\b(body|point|straight-curve|ellipse-curve)\s+\$/.test(trimmed)) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Decrypts ACIS data when it is still in the DXF obfuscated form; otherwise
+ * returns the input unchanged.
+ *
+ * @param data - Raw or already-decrypted SAT fragment.
+ */
+export function acdbNormalizeAcisData(data: string): string {
+  if (!data || !acdbIsEncryptedAcisData(data)) {
+    return data
+  }
+  return acdbDecryptAcisData(data)
+}
+
+/**
+ * Decrypts each SAT line and joins them with `\n`.
+ *
+ * @param lines - One logical SAT line per group-code 1 (group 3 fragments are
+ *   already stitched onto the preceding line).
+ */
+export function acdbJoinAcisPayloadLines(lines: readonly string[]): string {
+  if (lines.length === 0) {
+    return ''
+  }
+  return lines.map(line => acdbNormalizeAcisData(line)).join('\n')
+}
+
+/**
+ * Stitches group-code 1/3 SAT fragments: group 1 starts a new SAT line and
+ * group 3 continues the previous line (255-character splits).
+ *
+ * @param lines - Mutable accumulator for logical SAT lines.
+ * @param code - DXF group code (1 or 3).
+ * @param value - Raw group value to append.
+ */
+export function acdbAppendAcisPayloadFragment(
+  lines: string[],
+  code: 1 | 3,
+  value: string
+): void {
+  if (code === 1) {
+    lines.push(value)
+    return
+  }
+  if (lines.length === 0) {
+    lines.push(value)
+    return
+  }
+  lines[lines.length - 1] += value
+}
+
+/**
+ * Joins encrypted ACSH OBJECT group-1 chunks (no newlines between chunks).
+ *
+ * @param chunks - Ordered group 1/3 fragments from an ACSH OBJECT entry.
+ */
+export function acdbJoinAcisObjectChunks(chunks: readonly string[]): string {
+  if (chunks.length === 0) {
+    return ''
+  }
+  return acdbNormalizeAcisData(chunks.join(''))
+}

--- a/packages/data-model/src/acis/index.ts
+++ b/packages/data-model/src/acis/index.ts
@@ -3,6 +3,14 @@
  *
  * @packageDocumentation
  */
+export {
+  acdbAppendAcisPayloadFragment,
+  acdbDecryptAcisData,
+  acdbIsEncryptedAcisData,
+  acdbJoinAcisObjectChunks,
+  acdbJoinAcisPayloadLines,
+  acdbNormalizeAcisData
+} from './AcDbAcisDecrypt'
 export { acdbParseAcisSab, AcDbAcisSabTag } from './AcDbAcisSab'
 export type {
   AcDbAcisSabData,

--- a/packages/data-model/src/base/AcDbDxfFiler.ts
+++ b/packages/data-model/src/base/AcDbDxfFiler.ts
@@ -256,6 +256,17 @@ export class AcDbDxfFiler {
   }
 
   /**
+   * Current read position in the underlying pair stream.
+   * Useful for byte-based parse progress while streaming a DXF.
+   */
+  position(): { line?: number; byteOffset: number } {
+    if (this._mode !== 'read' || !this._reader) {
+      return { byteOffset: 0 }
+    }
+    return this._reader.position()
+  }
+
+  /**
    * True if the next pair starts a new object (group code 0) or EOF.
    * Does not consume the pair.
    */

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -817,6 +817,68 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
+   * Ends the outermost event batch, flushing `entityAppended` notifications in
+   * chunks so converters can report ENTITY progress while the viewer adds/renders.
+   *
+   * Nested batches still require matching {@link endEventBatch} /
+   * {@link endEventBatchChunked} calls; only the outermost close flushes.
+   *
+   * @param chunkSize - Max entities per `entityAppended` dispatch
+   * @param onChunk - Called after each chunk with `(flushed, total)`
+   */
+  async endEventBatchChunked(
+    chunkSize: number,
+    onChunk?: (flushed: number, total: number) => void | Promise<void>
+  ): Promise<void> {
+    if (this._eventBatchDepth <= 0) {
+      return
+    }
+    this._eventBatchDepth--
+    if (this._eventBatchDepth !== 0) {
+      return
+    }
+
+    this.transactionManager.flushPendingEntityModifiedEvents()
+    this.transactionManager.flushPendingLayerModifiedEvents()
+
+    const appended = this._pendingEntityAppended
+    this._pendingEntityAppended = []
+    const total = appended.length
+    const size = Math.max(1, chunkSize)
+
+    if (total === 0) {
+      this.flushEventBatchRemainder()
+      return
+    }
+
+    // Dispatch in chunks; if onChunk throws, still flush remaining appends and
+    // erase/dict queues so catch paths calling endEventBatch() are not needed.
+    let flushed = 0
+    try {
+      for (let i = 0; i < total; i += size) {
+        const end = Math.min(i + size, total)
+        const chunk = appended.slice(i, end)
+        this.events.entityAppended.dispatch({
+          database: this,
+          entity: chunk
+        })
+        flushed = end
+        if (onChunk) {
+          await onChunk(end, total)
+        }
+      }
+    } finally {
+      if (flushed < total) {
+        this.events.entityAppended.dispatch({
+          database: this,
+          entity: appended.slice(flushed)
+        })
+      }
+      this.flushEventBatchRemainder()
+    }
+  }
+
+  /**
    * Returns true when database events are being batched.
    */
   isEventBatched(): boolean {
@@ -908,6 +970,11 @@ export class AcDbDatabase extends AcDbObject {
       })
     }
 
+    this.flushEventBatchRemainder()
+  }
+
+  /** Flushes non-append batch queues (erase / dictionary) after entity appends. */
+  private flushEventBatchRemainder(): void {
     if (this._pendingEntityErased.length > 0) {
       const erased = this._pendingEntityErased
       this._pendingEntityErased = []
@@ -2195,7 +2262,7 @@ export class AcDbDatabase extends AcDbObject {
           ? (data as string[])
           : this.tables.textStyleTable.fonts
         try {
-          await options.fontLoader.load(fonts)
+          await this.loadFontsWithProgress(options.fontLoader, fonts, percentage)
         } catch (error) {
           if (options.failOnFontLoadError) {
             throw error
@@ -2218,6 +2285,40 @@ export class AcDbDatabase extends AcDbObject {
           })
         }
       }
+    }
+  }
+
+  /**
+   * Loads fonts while emitting FONT IN-PROGRESS so the open-file bar keeps
+   * moving during multi-font downloads (native DXF parses on the main thread
+   * and previously appeared stuck at the FONT stage).
+   */
+  private async loadFontsWithProgress(
+    fontLoader: AcDbFontLoader,
+    fonts: string[],
+    basePercentage: number
+  ): Promise<void> {
+    if (fonts.length <= 1) {
+      await fontLoader.load(fonts)
+      return
+    }
+
+    // Leave headroom before ENTITY (native converter starts ENTITY at 20%).
+    const span = Math.max(1, Math.min(5, 19 - basePercentage))
+    for (let i = 0; i < fonts.length; i++) {
+      await fontLoader.load([fonts[i]!])
+      const pct = Math.min(
+        19,
+        basePercentage + Math.round(((i + 1) / fonts.length) * span)
+      )
+      this.events.openProgress.dispatch({
+        database: this,
+        percentage: pct,
+        stage: 'CONVERSION',
+        subStage: 'FONT',
+        subStageStatus: 'IN-PROGRESS',
+        data: fonts
+      })
     }
   }
 

--- a/packages/data-model/src/dxf/AcDbDxfAcdsDataReader.ts
+++ b/packages/data-model/src/dxf/AcDbDxfAcdsDataReader.ts
@@ -1,0 +1,116 @@
+import type { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { acdbCombineDxfBinaryChunks } from '../misc/proxyGraphic'
+
+const ASM_DATA_TYPE = 'ASM_Data'
+
+/** Parsed ACDSDATA section (R2013+ binary ASM payloads linked to entities). */
+export interface AcDbAcdsDataSection {
+  /** ASM_Data payloads keyed by owner entity handle (uppercase, trimmed). */
+  byOwnerHandle: Record<string, Uint8Array>
+}
+
+/** Normalizes a DXF handle for cross-section lookups (uppercase, trimmed). */
+export function acdbNormalizeDxfHandle(handle: string): string {
+  return String(handle).trim().toUpperCase()
+}
+
+/**
+ * Looks up an ASM_Data payload by owner handle with normalized matching.
+ *
+ * @param section - Parsed ACDSDATA section.
+ * @param ownerHandle - Owning entity handle (group 5 / ACDS group 320).
+ */
+export function acdbGetAcdsDataByOwnerHandle(
+  section: AcDbAcdsDataSection,
+  ownerHandle: string
+): Uint8Array | undefined {
+  return section.byOwnerHandle[acdbNormalizeDxfHandle(ownerHandle)]
+}
+
+/**
+ * Parses one `ACDSRECORD` starting after its `(0, ACDSRECORD)` marker.
+ *
+ * @param filer - DXF reader positioned at the first field of the record.
+ */
+function parseAcdsRecord(filer: AcDbDxfFiler): {
+  ownerHandle?: string
+  hexChunks: Array<string | Uint8Array>
+} {
+  let ownerHandle: string | undefined
+  let currentDataType: string | undefined
+  const chunksByType: Record<string, Array<string | Uint8Array>> = {}
+
+  while (!filer.atEndOfObject && !filer.atEof) {
+    const item = filer.readItem()
+    if (!item) break
+    const code = Number(item.code)
+    switch (code) {
+      case 320:
+        ownerHandle = acdbNormalizeDxfHandle(String(item.value))
+        break
+      case 2:
+        currentDataType = String(item.value)
+        chunksByType[currentDataType] ??= []
+        break
+      case 310:
+        if (currentDataType) {
+          if (item.value instanceof Uint8Array) {
+            chunksByType[currentDataType]!.push(item.value)
+          } else {
+            chunksByType[currentDataType]!.push(String(item.value))
+          }
+        }
+        break
+      default:
+        break
+    }
+  }
+
+  return {
+    ownerHandle,
+    hexChunks: chunksByType[ASM_DATA_TYPE] ?? []
+  }
+}
+
+/**
+ * Parses the DXF `ACDSDATA` section and indexes `ASM_Data` binary payloads by
+ * the owning entity handle (group 320).
+ *
+ * Caller must have already consumed the `(0, SECTION)` / `(2, ACDSDATA)` header.
+ *
+ * @param filer - DXF reader positioned at the first pair inside ACDSDATA.
+ */
+export function acdbDxfInAcdsData(filer: AcDbDxfFiler): AcDbAcdsDataSection {
+  const byOwnerHandle: Record<string, Uint8Array> = {}
+
+  while (!filer.atEof) {
+    const item = filer.peekItem()
+    if (!item) break
+    if (Number(item.code) !== 0) {
+      filer.readItem()
+      continue
+    }
+
+    const name = String(item.value).toUpperCase()
+    if (name === 'ENDSEC' || name === 'EOF') {
+      filer.readItem()
+      break
+    }
+
+    filer.readItem()
+    if (name === 'ACDSRECORD') {
+      const record = parseAcdsRecord(filer)
+      if (record.ownerHandle && record.hexChunks.length > 0) {
+        const payload = acdbCombineDxfBinaryChunks(record.hexChunks)
+        if (payload.length > 0) {
+          byOwnerHandle[record.ownerHandle] = payload
+        }
+      }
+    } else {
+      // ACDSSCHEMA / unknown — skip until next code 0.
+      filer.skipToEndOfObject()
+    }
+  }
+
+  return { byOwnerHandle }
+}

--- a/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
+++ b/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
@@ -9,7 +9,6 @@ import {
 } from '../database/AcDbBlockTableRecord'
 import type { AcDbClass } from '../database/AcDbClass'
 import type { AcDbDatabase } from '../database/AcDbDatabase'
-import type { AcDbConversionProgressCallback } from '../database/AcDbDatabaseConverter'
 import { AcDbDimStyleTableRecord } from '../database/AcDbDimStyleTableRecord'
 import { AcDbLayerTableRecord } from '../database/AcDbLayerTableRecord'
 import { AcDbLinetypeTableRecord } from '../database/AcDbLinetypeTableRecord'
@@ -18,11 +17,16 @@ import { AcDbTextStyleTableRecord } from '../database/AcDbTextStyleTableRecord'
 import { AcDbUcsTableRecord } from '../database/AcDbUcsTableRecord'
 import { AcDbViewportTableRecord } from '../database/AcDbViewportTableRecord'
 import { AcDbViewTableRecord } from '../database/AcDbViewTableRecord'
+import { AcDb3dSolid } from '../entity/AcDb3dSolid'
 import { AcDbAttribute } from '../entity/AcDbAttribute'
 import { AcDbBlockReference } from '../entity/AcDbBlockReference'
 import type { AcDbEntity } from '../entity/AcDbEntity'
 import { AcDbMText } from '../entity/AcDbMText'
 import { acdbCombineDxfBinaryChunks } from '../misc/proxyGraphic'
+import {
+  acdbDxfInAcdsData,
+  acdbNormalizeDxfHandle
+} from './AcDbDxfAcdsDataReader'
 import { acdbDxfInEntity } from './AcDbDxfEntityFactory'
 import { acdbDxfInHeader } from './AcDbDxfHeaderReader'
 import { AcDbDxfObjectsReader } from './AcDbDxfObjectsReader'
@@ -30,7 +34,13 @@ import { AcDbDxfObjectsReader } from './AcDbDxfObjectsReader'
 export interface AcDbDxfDocumentReaderOptions {
   /** Yield to the event loop every N entities (keeps UI responsive). */
   entityBatchSize?: number
-  progress?: AcDbConversionProgressCallback
+  /**
+   * Called with approximate parse completion in `[0, 1]` based on byte
+   * offset. Used by the native converter to emit mid-PARSE progress.
+   */
+  onProgress?: (ratio: number) => void | Promise<void>
+  /** Total DXF byte length for {@link onProgress}. */
+  totalBytes?: number
 }
 
 export interface AcDbDxfDocumentReaderResult {
@@ -113,37 +123,78 @@ export class AcDbDxfDocumentReader {
   private async readSection(filer: AcDbDxfFiler, section: string) {
     switch (section) {
       case 'HEADER':
-        await this.notify('HEADER', 'START')
         acdbDxfInHeader(filer, this._db)
-        await this.notify('HEADER', 'END')
+        await this.reportParseProgress(filer)
         break
       case 'CLASSES':
         this.readClassesSection(filer)
+        await this.reportParseProgress(filer)
         break
       case 'TABLES':
-        await this.readTablesSection(filer)
+        this.readTablesSection(filer)
+        await this.reportParseProgress(filer)
         break
       case 'BLOCKS':
         await this.readBlocksSection(filer)
+        await this.reportParseProgress(filer)
         break
       case 'ENTITIES':
         await this.readEntitiesSection(filer)
+        await this.reportParseProgress(filer)
         break
       case 'OBJECTS':
-        await this.notify('OBJECT', 'START')
         {
           const objectsReader = new AcDbDxfObjectsReader(this._db)
           objectsReader.read(filer)
           this._unknownObjectCount += objectsReader.unknownObjectCount
         }
-        await this.notify('OBJECT', 'END')
+        await this.reportParseProgress(filer)
+        break
+      case 'ACDSDATA':
+        this.applyAcdsDataToSolids(acdbDxfInAcdsData(filer))
+        await this.reportParseProgress(filer)
         break
       case 'THUMBNAILIMAGE':
         this.readThumbnailImageSection(filer)
+        await this.reportParseProgress(filer)
         break
       default:
         this.skipUntilEndSec(filer)
+        await this.reportParseProgress(filer)
         break
+    }
+  }
+
+  /**
+   * Attaches ACDSDATA `ASM_Data` SAB payloads to matching {@link AcDb3dSolid}
+   * entities (keyed by entity handle / group 5).
+   *
+   * Modern DXF files often store 3DSOLID geometry only in ACDSDATA rather than
+   * inline encrypted SAT groups 1/3 — without this step solids render empty.
+   */
+  private applyAcdsDataToSolids(section: {
+    byOwnerHandle: Record<string, Uint8Array>
+  }): void {
+    const ownerHandles = Object.keys(section.byOwnerHandle)
+    if (ownerHandles.length === 0) return
+
+    // Build a handle → solid map once (handles may differ in case from DXF).
+    const solidsByHandle = new Map<string, AcDb3dSolid>()
+    for (const btr of this._db.tables.blockTable.newIterator()) {
+      for (const entity of btr.newIterator()) {
+        if (entity instanceof AcDb3dSolid) {
+          solidsByHandle.set(acdbNormalizeDxfHandle(entity.objectId), entity)
+        }
+      }
+    }
+
+    for (const ownerHandle of ownerHandles) {
+      const sabBytes = section.byOwnerHandle[ownerHandle]
+      if (!sabBytes) continue
+      const solid = solidsByHandle.get(acdbNormalizeDxfHandle(ownerHandle))
+      if (solid) {
+        solid.setSabBytes(sabBytes)
+      }
     }
   }
 
@@ -260,7 +311,7 @@ export class AcDbDxfDocumentReader {
     return result
   }
 
-  private async readTablesSection(filer: AcDbDxfFiler) {
+  private readTablesSection(filer: AcDbDxfFiler) {
     while (!filer.atEof) {
       const item = filer.peekItem()
       if (!item) break
@@ -277,7 +328,7 @@ export class AcDbDxfDocumentReader {
       if (name === 'TABLE') {
         filer.readItem()
         const tableName = this.readTableName(filer)
-        await this.readTable(filer, tableName)
+        this.readTable(filer, tableName)
         continue
       }
 
@@ -301,17 +352,14 @@ export class AcDbDxfDocumentReader {
     return ''
   }
 
-  private async readTable(filer: AcDbDxfFiler, tableName: string) {
+  private readTable(filer: AcDbDxfFiler, tableName: string) {
     switch (tableName) {
       case 'LAYER':
-        await this.notify('LAYER', 'START')
         this.readNamedTable(filer, 'LAYER', () => new AcDbLayerTableRecord(), r => {
           if (r.name) this._db.tables.layerTable.add(r)
         })
-        await this.notify('LAYER', 'END')
         break
       case 'LTYPE':
-        await this.notify('LTYPE', 'START')
         this.readNamedTable(
           filer,
           'LTYPE',
@@ -320,10 +368,8 @@ export class AcDbDxfDocumentReader {
             if (r.name) this._db.tables.linetypeTable.add(r)
           }
         )
-        await this.notify('LTYPE', 'END')
         break
       case 'STYLE':
-        await this.notify('STYLE', 'START')
         this.readNamedTable(
           filer,
           'STYLE',
@@ -334,10 +380,8 @@ export class AcDbDxfDocumentReader {
             this.collectFontFromStyleRecord(r)
           }
         )
-        await this.notify('STYLE', 'END')
         break
       case 'DIMSTYLE':
-        await this.notify('DIMSTYLE', 'START')
         this.readNamedTable(
           filer,
           'DIMSTYLE',
@@ -346,10 +390,8 @@ export class AcDbDxfDocumentReader {
             if (r.name) this._db.tables.dimStyleTable.add(r)
           }
         )
-        await this.notify('DIMSTYLE', 'END')
         break
       case 'VPORT':
-        await this.notify('VPORT', 'START')
         this.readNamedTable(
           filer,
           'VPORT',
@@ -358,7 +400,6 @@ export class AcDbDxfDocumentReader {
             if (r.name) this._db.tables.viewportTable.add(r)
           }
         )
-        await this.notify('VPORT', 'END')
         break
       case 'APPID':
         this.readNamedTable(
@@ -391,9 +432,7 @@ export class AcDbDxfDocumentReader {
         )
         break
       case 'BLOCK_RECORD':
-        await this.notify('BLOCK_RECORD', 'START')
         this.readBlockRecordTable(filer)
-        await this.notify('BLOCK_RECORD', 'END')
         break
       default:
         this.skipUntilEndTab(filer)
@@ -488,7 +527,6 @@ export class AcDbDxfDocumentReader {
   }
 
   private async readBlocksSection(filer: AcDbDxfFiler) {
-    await this.notify('BLOCK', 'START')
     const batchSize = Math.max(1, this._options.entityBatchSize ?? 200)
     let sinceYield = 0
 
@@ -519,8 +557,6 @@ export class AcDbDxfDocumentReader {
       filer.readItem()
       filer.skipToEndOfObject()
     }
-
-    await this.notify('BLOCK', 'END')
   }
 
   /**
@@ -559,7 +595,7 @@ export class AcDbDxfDocumentReader {
         sinceYield += 1
         if (sinceYield >= batchSize) {
           sinceYield = 0
-          await Promise.resolve()
+          await this.yieldAndReportProgress(filer)
         }
         continue
       }
@@ -579,7 +615,7 @@ export class AcDbDxfDocumentReader {
       sinceYield += 1
       if (sinceYield >= batchSize) {
         sinceYield = 0
-        await Promise.resolve()
+        await this.yieldAndReportProgress(filer)
       }
     }
 
@@ -704,7 +740,6 @@ export class AcDbDxfDocumentReader {
   }
 
   private async readEntitiesSection(filer: AcDbDxfFiler) {
-    await this.notify('ENTITY', 'START')
     const batchSize = Math.max(1, this._options.entityBatchSize ?? 200)
     let sinceYield = 0
     const modelSpace = this._db.tables.blockTable.modelSpace
@@ -729,7 +764,7 @@ export class AcDbDxfDocumentReader {
         sinceYield += 1
         if (sinceYield >= batchSize) {
           sinceYield = 0
-          await Promise.resolve()
+          await this.yieldAndReportProgress(filer)
         }
         continue
       }
@@ -745,11 +780,9 @@ export class AcDbDxfDocumentReader {
       sinceYield += 1
       if (sinceYield >= batchSize) {
         sinceYield = 0
-        await Promise.resolve()
+        await this.yieldAndReportProgress(filer)
       }
     }
-
-    await this.notify('ENTITY', 'END')
   }
 
   /**
@@ -917,13 +950,37 @@ export class AcDbDxfDocumentReader {
     }
   }
 
-  private async notify(
-    stage: Parameters<AcDbConversionProgressCallback>[1],
-    status: Parameters<AcDbConversionProgressCallback>[2],
-    data?: unknown
-  ) {
-    const progress = this._options.progress
-    if (!progress) return
-    await progress(0, stage, status, data)
+  private async reportParseProgress(filer: AcDbDxfFiler) {
+    const { onProgress, totalBytes } = this._options
+    if (!onProgress || !totalBytes || totalBytes <= 0) return
+    const ratio = Math.min(1, Math.max(0, filer.position().byteOffset / totalBytes))
+    await onProgress(ratio)
+  }
+
+  /**
+   * Yields to the browser so loading overlays can paint/animate.
+   * `Promise.resolve()` alone stays on the microtask queue and does not paint.
+   */
+  private yieldToUi(): Promise<void> {
+    return new Promise(resolve => {
+      if (
+        typeof globalThis !== 'undefined' &&
+        typeof (globalThis as { requestAnimationFrame?: unknown })
+          .requestAnimationFrame === 'function'
+      ) {
+        ;(
+          globalThis as unknown as {
+            requestAnimationFrame: (cb: () => void) => number
+          }
+        ).requestAnimationFrame(() => resolve())
+      } else {
+        setTimeout(resolve, 0)
+      }
+    })
+  }
+
+  private async yieldAndReportProgress(filer: AcDbDxfFiler) {
+    await this.reportParseProgress(filer)
+    await this.yieldToUi()
   }
 }

--- a/packages/data-model/src/dxf/AcDbNativeDxfConverter.ts
+++ b/packages/data-model/src/dxf/AcDbNativeDxfConverter.ts
@@ -8,6 +8,40 @@ import {
 import { AcDbDxfDocumentReader } from './AcDbDxfDocumentReader'
 
 /**
+ * Progress weights mirror typical open cost: a small PARSE slice, a short FONT
+ * download, then most of the bar for ENTITY add/render (same idea as the old
+ * converter where ENTITY carried the largest step).
+ */
+const PARSE_START_PCT = 1
+const PARSE_END_PCT = 12
+const FONT_START_PCT = 13
+const FONT_END_PCT = 18
+const ENTITY_START_PCT = 20
+const ENTITY_END_PCT = 98
+
+/**
+ * Yields so the browser can paint loading UI before main-thread parse work.
+ */
+function yieldForPaint(): Promise<void> {
+  return new Promise(resolve => {
+    if (
+      typeof globalThis !== 'undefined' &&
+      typeof (globalThis as { requestAnimationFrame?: unknown })
+        .requestAnimationFrame === 'function'
+    ) {
+      const raf = (
+        globalThis as unknown as {
+          requestAnimationFrame: (cb: () => void) => number
+        }
+      ).requestAnimationFrame
+      raf(() => raf(() => resolve()))
+    } else {
+      setTimeout(resolve, 0)
+    }
+  })
+}
+
+/**
  * Native DXF → database converter.
  *
  * Streams DXF pairs through {@link AcDbDxfFiler} / {@link AcDbDxfDocumentReader}
@@ -19,6 +53,9 @@ import { AcDbDxfDocumentReader } from './AcDbDxfDocumentReader'
  * (entity-appended events batched); fonts load on FONT; then the batch flushes
  * so the first draw happens with fonts already available — no mid-parse FONT
  * or post-open regen.
+ *
+ * Mid-PARSE byte progress, chunked ENTITY flush, and paint yields keep the
+ * status bar / spinner responsive while main-thread work runs.
  */
 export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
   constructor(config: AcDbDatabaseConverterConfig = {}) {
@@ -49,7 +86,9 @@ export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
     }
 
     await emit(0, 'START', 'START')
-    await emit(5, 'PARSE', 'START')
+    await emit(PARSE_START_PCT, 'PARSE', 'START')
+    // Let the open-file overlay paint before sync-heavy parse work.
+    await yieldForPaint()
 
     // Suppress entityAppended (and related) until FONT finishes so the viewer
     // does not worldDraw text before fontLoader.load has run.
@@ -57,23 +96,56 @@ export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
     let batchOpen = true
     try {
       const filer = AcDbDxfFiler.fromBuffer(data, { database: db })
+      const totalBytes = data.byteLength
+      let lastParsePct = PARSE_START_PCT
+
       const reader = new AcDbDxfDocumentReader(db, {
-        entityBatchSize: Math.max(1, minimumChunkSize || 200)
-        // No progress callback: this converter owns all stage events.
+        entityBatchSize: Math.max(1, minimumChunkSize || 200),
+        totalBytes,
+        onProgress: async ratio => {
+          const pct = Math.min(
+            PARSE_END_PCT - 1,
+            PARSE_START_PCT +
+              Math.floor(ratio * (PARSE_END_PCT - PARSE_START_PCT))
+          )
+          if (pct <= lastParsePct) return
+          lastParsePct = pct
+          await emit(pct, 'PARSE', 'IN-PROGRESS')
+        }
       })
       const result = await reader.read(filer)
 
-      await emit(40, 'PARSE', 'END')
+      await emit(PARSE_END_PCT, 'PARSE', 'END', {
+        unknownEntityCount: result.unknownEntityCount
+      })
 
       // Same FONT contract as AcDbDxfConverter / AcDbDatabaseConverter.
-      await emit(45, 'FONT', 'START')
-      await emit(50, 'FONT', 'END', result.fonts)
+      await emit(FONT_START_PCT, 'FONT', 'START')
+      await emit(FONT_END_PCT, 'FONT', 'END', result.fonts)
 
-      await emit(60, 'ENTITY', 'START')
-      // Flush queued entityAppended → first draw with fonts loaded.
-      db.endEventBatch()
+      await emit(ENTITY_START_PCT, 'ENTITY', 'START')
+      const chunkSize = Math.max(1, minimumChunkSize || 200)
+      let lastEntityPct = ENTITY_START_PCT
+      // Flush queued entityAppended in chunks → first draw with fonts loaded,
+      // while advancing most of the open-file progress bar.
+      await db.endEventBatchChunked(chunkSize, async (flushed, total) => {
+        const pct =
+          total <= 0
+            ? ENTITY_END_PCT
+            : Math.min(
+                ENTITY_END_PCT,
+                ENTITY_START_PCT +
+                  Math.floor(
+                    (flushed / total) * (ENTITY_END_PCT - ENTITY_START_PCT)
+                  )
+              )
+        if (pct <= lastEntityPct) return
+        lastEntityPct = pct
+        await emit(pct, 'ENTITY', 'IN-PROGRESS')
+        await yieldForPaint()
+      })
       batchOpen = false
-      await emit(95, 'ENTITY', 'END')
+      await emit(ENTITY_END_PCT, 'ENTITY', 'END')
 
       await emit(100, 'END', 'END')
     } catch (error) {

--- a/packages/data-model/src/dxf/index.ts
+++ b/packages/data-model/src/dxf/index.ts
@@ -4,6 +4,12 @@ export type {
   AcDbDxfDocumentReaderOptions,
   AcDbDxfDocumentReaderResult
 } from './AcDbDxfDocumentReader'
+export {
+  acdbDxfInAcdsData,
+  acdbGetAcdsDataByOwnerHandle,
+  acdbNormalizeDxfHandle
+} from './AcDbDxfAcdsDataReader'
+export type { AcDbAcdsDataSection } from './AcDbDxfAcdsDataReader'
 export { acdbDxfInHeader } from './AcDbDxfHeaderReader'
 export { AcDbNativeDxfConverter } from './AcDbNativeDxfConverter'
 export { AcDbDxfObjectsReader } from './AcDbDxfObjectsReader'

--- a/packages/data-model/src/entity/AcDb3dSolid.ts
+++ b/packages/data-model/src/entity/AcDb3dSolid.ts
@@ -7,7 +7,9 @@ import { AcGiRenderer } from '@mlightcad/graphic-interface'
 
 import {
   acdbAcisWireframeSegmentsFromSab,
-  acdbAcisWireframeSegmentsFromSatText
+  acdbAcisWireframeSegmentsFromSatText,
+  acdbAppendAcisPayloadFragment,
+  acdbJoinAcisPayloadLines
 } from '../acis'
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDbEntity } from './AcDbEntity'
@@ -158,6 +160,8 @@ export class AcDb3dSolid extends AcDbEntity {
 
   /** Raw ACIS SAT text preserved for DXF round-trip and future B-rep parsing. */
   private _acisData: string
+  /** Binary SAB/ASM payload from ACDSDATA, when present. */
+  private _sabBytes?: Uint8Array
   /** DXF group 70 ACIS version number, when present. */
   private _version?: number
   /** Soft-pointer to ACSH history object (DXF group 350). */
@@ -167,9 +171,9 @@ export class AcDb3dSolid extends AcDbEntity {
   /** Whether the ASM/ACIS payload uses SAT text caching (DXF group 290). */
   private _satCache?: boolean
   /** Vertex positions used for extents and fallback bounding-box rendering. */
-  private _points: AcGePoint3d[]
+  private _points: AcGePoint3d[] = []
   /** Line-segment endpoint pairs for wireframe rendering (`[x,y,z,...]`). */
-  private _wireframe: Float32Array
+  private _wireframe: Float32Array = new Float32Array(0)
 
   /**
    * Creates a new 3D solid entity from raw ACIS data.
@@ -191,22 +195,9 @@ export class AcDb3dSolid extends AcDbEntity {
     super()
     const payload = resolveSolidPayload(acisDataOrOptions, version)
     this._acisData = payload.satText
+    this._sabBytes = payload.sabBytes
     this._version = payload.version
-
-    let wireframe = new Float32Array(0)
-    if (payload.sabBytes && payload.sabBytes.length > 0) {
-      wireframe = acdbAcisWireframeSegmentsFromSab(payload.sabBytes) ?? new Float32Array(0)
-    }
-    if (wireframe.length === 0 && payload.satText) {
-      wireframe = acdbAcisWireframeSegmentsFromSatText(payload.satText)
-    }
-    this._wireframe = wireframe
-
-    if (wireframe.length > 0) {
-      this._points = pointsFromWireframe(wireframe)
-    } else {
-      this._points = extractAcisPointCloud(payload.satText)
-    }
+    this.rebuildGeometryCaches()
   }
 
   /**
@@ -264,12 +255,42 @@ export class AcDb3dSolid extends AcDbEntity {
     if (version != null) {
       this._version = version
     }
-    this._wireframe = this._acisData
-      ? acdbAcisWireframeSegmentsFromSatText(this._acisData)
-      : new Float32Array(0)
+    this.rebuildGeometryCaches()
+  }
+
+  /**
+   * Attaches binary SAB/ASM bytes (typically from ACDSDATA) and rebuilds
+   * wireframe / point caches. Preferred over SAT text when both are present.
+   *
+   * @param sabBytes - Raw ASM_Data payload for this solid.
+   */
+  setSabBytes(sabBytes: Uint8Array | undefined) {
+    this._sabBytes =
+      sabBytes && sabBytes.length > 0 ? sabBytes : undefined
+    this.rebuildGeometryCaches()
+  }
+
+  /** Binary SAB/ASM payload attached via ACDSDATA or construction options. */
+  get sabBytes(): Uint8Array | undefined {
+    return this._sabBytes
+  }
+
+  /**
+   * Rebuilds `_wireframe` / `_points` from SAB bytes (preferred) or SAT text.
+   */
+  private rebuildGeometryCaches() {
+    let wireframe = new Float32Array(0)
+    if (this._sabBytes && this._sabBytes.length > 0) {
+      wireframe =
+        acdbAcisWireframeSegmentsFromSab(this._sabBytes) ?? new Float32Array(0)
+    }
+    if (wireframe.length === 0 && this._acisData) {
+      wireframe = acdbAcisWireframeSegmentsFromSatText(this._acisData)
+    }
+    this._wireframe = wireframe
     this._points =
-      this._wireframe.length > 0
-        ? pointsFromWireframe(this._wireframe)
+      wireframe.length > 0
+        ? pointsFromWireframe(wireframe)
         : extractAcisPointCloud(this._acisData)
   }
 
@@ -400,20 +421,39 @@ export class AcDb3dSolid extends AcDbEntity {
 
   override dxfInFields(filer: AcDbDxfFiler): this {
     super.dxfInFields(filer)
-    filer.atSubclassData('AcDb3dSolid')
 
-    const chunks: string[] = []
+    // DXF order: AcDbModelerGeometry (version + SAT chunks) then AcDb3dSolid
+    // (history / guid / satCache). Consume both subclass markers when present.
+    filer.atSubclassData('AcDbModelerGeometry')
+
+    const lines: string[] = []
     let version = this._version
 
     while (!filer.atEndOfObject && !filer.atEof && !filer.atExtendedData) {
-      const item = filer.readItem()
+      const item = filer.peekItem()
       if (!item) break
       const code = Number(item.code)
+
+      // Nested subclass marker for AcDb3dSolid — consume and continue.
+      if (code === 100) {
+        filer.readItem()
+        const marker = String(item.value)
+        if (marker === 'AcDb3dSolid') {
+          continue
+        }
+        // Unknown subclass — push back and stop so callers can handle it.
+        filer.pushBackItem(item)
+        break
+      }
+
+      filer.readItem()
       const n = Number(item.value)
       switch (code) {
         case 1:
+          acdbAppendAcisPayloadFragment(lines, 1, String(item.value))
+          break
         case 3:
-          chunks.push(String(item.value))
+          acdbAppendAcisPayloadFragment(lines, 3, String(item.value))
           break
         case 70:
           version = n
@@ -432,7 +472,8 @@ export class AcDb3dSolid extends AcDbEntity {
       }
     }
 
-    this.setAcisData(chunks.join('\n'), version)
+    // Decrypt obfuscated SAT fragments (DXF groups 1/3) the same way dxf-json does.
+    this.setAcisData(acdbJoinAcisPayloadLines(lines), version)
     return this
   }
 }

--- a/packages/data-model/src/entity/AcDbMText.ts
+++ b/packages/data-model/src/entity/AcDbMText.ts
@@ -127,7 +127,7 @@ export class AcDbMText extends AcDbEntity {
     this._height = 0
     this._width = 0
     this._extentsWidth = 0
-    this._lineSpacingFactor = 0.25
+    this._lineSpacingFactor = 1.0
     this._lineSpacingStyle = 0
     this._backgroundFill = false
     this._backgroundFillColor = 0xc8c8c8
@@ -271,7 +271,10 @@ export class AcDbMText extends AcDbEntity {
   }
 
   /**
-   * The line spacing factor (a value between 0.25 and 4.00).
+   * The line spacing factor (DXF group 44).
+   *
+   * Ratio of actual baseline spacing to AutoCAD single spacing
+   * (`5/3` of text height). Valid range is typically 0.25–4.00; default is 1.0.
    */
   get lineSpacingFactor() {
     return this._lineSpacingFactor
@@ -909,12 +912,7 @@ export class AcDbMText extends AcDbEntity {
           // Vertical character height — documented as unused by AutoCAD; skip.
           break
         case 44:
-          // DXF group 44 is AutoCAD's "multiple of 3-on-5" line spacing (~1.0).
-          // AcDbMText.lineSpacingFactor is passed straight to mtext-renderer as a
-          // gap coefficient (ctor default 0.25). Applying group 44 here makes
-          // multi-line MTEXT far too tall. dxf-json convertMText also never
-          // copied this field. Keep the renderer-compatible default until the
-          // renderer accepts AutoCAD group-44 semantics.
+          this.lineSpacingFactor = n
           break
         case 45:
           this.backgroundScaleFactor = n

--- a/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
+++ b/packages/data-model/src/entity/AcDbTextExtentsHelpers.ts
@@ -101,8 +101,8 @@ export function acdbCountMTextLines(text: string): number {
 /**
  * Estimates total MTEXT height from line count and line-spacing factor.
  *
- * Line spacing factor multiplies text height to get the distance between
- * consecutive line baselines (AutoCAD DXF group 44 semantics).
+ * Uses AutoCAD DXF group-44 semantics: baseline-to-baseline distance is
+ * `lineSpacingFactor × (5/3) × textHeight`.
  */
 export function acdbEstimateMTextHeight(
   lineCount: number,
@@ -112,24 +112,8 @@ export function acdbEstimateMTextHeight(
   if (textHeight <= 0 || lineCount <= 0) return 0
   if (lineCount === 1) return textHeight
 
-  const spacing = Math.max(lineSpacingFactor, 0)
+  const spacing = Math.max(lineSpacingFactor, 0) * (5 / 3)
   return textHeight + (lineCount - 1) * textHeight * spacing
-}
-
-/**
- * Converts AutoCAD DXF group-44 line spacing factor to the gap factor expected
- * by `@mlightcad/mtext-renderer`.
- *
- * AutoCAD: baseline distance = `factor × (5/3) × textHeight`
- * (factor is a multiple of default 3-on-5 single-line spacing).
- *
- * Renderer: `lineHeight ≈ textHeight × (1 + gapFactor × 5/3)`
- *
- * Therefore `gapFactor = factor - 3/5`.
- */
-export function acdbMTextRendererLineSpaceFactor(dxfFactor: number): number {
-  if (!Number.isFinite(dxfFactor)) return 0
-  return Math.max(0, dxfFactor - 0.6)
 }
 
 interface LocalBounds {

--- a/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbEntitiyConverter.ts
@@ -944,6 +944,12 @@ export class AcDbEntityConverter {
     }
     dbEntity.drawingDirection =
       mtext.drawingDirection as unknown as AcGiMTextFlowDirection
+    if (mtext.lineSpacing != null) {
+      dbEntity.lineSpacingFactor = mtext.lineSpacing
+    }
+    if (mtext.lineSpacingStyle != null) {
+      dbEntity.lineSpacingStyle = mtext.lineSpacingStyle
+    }
     const extentsWidth = this.readMTextExtentsWidth(mtext)
     if (extentsWidth != null && extentsWidth > 0) {
       dbEntity.extentsWidth = extentsWidth

--- a/packages/graphic-interface/src/AcGiTextStyle.ts
+++ b/packages/graphic-interface/src/AcGiTextStyle.ts
@@ -46,6 +46,11 @@ export interface AcGiMTextData {
   directionVector?: AcGeVector3dLike
   attachmentPoint?: AcGiMTextAttachmentPoint
   drawingDirection?: AcGiMTextFlowDirection
+  /**
+   * AutoCAD DXF group-44 line spacing factor.
+   * Ratio of actual baseline spacing to single spacing (`5/3` of text height).
+   * Default is `1.0`.
+   */
   lineSpaceFactor?: number
   widthFactor?: number
 }


### PR DESCRIPTION
## Summary
- Attach ACDSDATA `ASM_Data` SAB payloads to matching `3DSOLID` entities and decrypt obfuscated inline ACIS SAT (groups 1/3) in the native DXF path.
- Stream mid-PARSE / chunked ENTITY open progress (plus FONT progress) so main-thread native DXF opens keep the status bar responsive; harden `endEventBatchChunked` so a failing progress callback still flushes remaining events.
- Align MTEXT `lineSpacingFactor` with AutoCAD DXF group-44 semantics (default 1.0, `5/3` baseline spacing) and pass spacing through from `dxf-json-converter`.

## Test plan
- [x] `pnpm exec jest` for `AcDbNativeDxfConverter`, `AcDbMText`, `AcDbTextExtentsHelpers`
- [ ] Open a modern DXF with `ACDSDATA` / `3DSOLID` and confirm solids render wireframe
- [ ] Open a large DXF via native converter and confirm PARSE/ENTITY IN-PROGRESS updates on the open-file bar
- [ ] Spot-check multi-line MTEXT line spacing vs AutoCAD