### PR TITLE
fix(data-model): strip AutoCAD Resolved/Referenced bits on xref import

### DIFF
--- a/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts
@@ -22,4 +22,26 @@ describe('AcDbBlockTableRecord', () => {
     expect(overlay.isOverlayReference).toBe(true)
     expect(overlay.isUnresolvedXref).toBe(false)
   })
+
+  it('strips AutoCAD-internal Resolved/Referenced bits on import', () => {
+    // AutoCAD often writes 36 (Xref|Resolved) for attached xrefs whose geometry
+    // is not present in the host file.
+    const sanitized = AcDbBlockTableRecord.sanitizeImportedFlags(
+      AcDbBlockTableRecordFlag.Xref | AcDbBlockTableRecordFlag.Resolved
+    )
+    expect(sanitized).toBe(AcDbBlockTableRecordFlag.Xref)
+
+    const xref = new AcDbBlockTableRecord()
+    xref.flags = sanitized
+    xref.pathName = '.\\xref1.dwg'
+    expect(xref.isUnresolvedXref).toBe(true)
+
+    expect(
+      AcDbBlockTableRecord.sanitizeImportedFlags(
+        AcDbBlockTableRecordFlag.Xref |
+          AcDbBlockTableRecordFlag.Resolved |
+          AcDbBlockTableRecordFlag.Referenced
+      )
+    ).toBe(AcDbBlockTableRecordFlag.Xref)
+  })
 })

--- a/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
@@ -877,6 +877,75 @@ describe('AcDbNativeDxfConverter', () => {
     expect(xref).toBeDefined()
     expect(xref!.pathName).toBe('C:\\refs\\other.dwg')
     expect(xref!.flags & AcDbBlockTableRecordFlag.Xref).toBeTruthy()
+    expect(xref!.isUnresolvedXref).toBe(true)
+  })
+
+  it('treats AutoCAD Resolved xref blocks (flag 36) as unresolved', async () => {
+    // Matches attached xrefs written by AutoCAD: empty BLOCK, path on code 1,
+    // flags = Xref|Resolved (36). Geometry is not bound into the host file.
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'BLOCKS',
+      '0',
+      'BLOCK',
+      '5',
+      '298',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbBlockBegin',
+      '2',
+      'xref1',
+      '70',
+      '36',
+      '10',
+      '0.0',
+      '20',
+      '0.0',
+      '30',
+      '0.0',
+      '3',
+      'xref1',
+      '1',
+      '.\\xref1.dwg',
+      '0',
+      'ENDBLK',
+      '5',
+      '299',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbBlockEnd',
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF',
+      ''
+    ].join('\n')
+
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const converter = new AcDbNativeDxfConverter()
+    const buffer = new TextEncoder().encode(dxf).buffer
+    await converter.read(buffer, db, 50)
+
+    const xref = db.tables.blockTable.getAt('xref1')
+    expect(xref).toBeDefined()
+    expect(xref!.pathName).toBe('.\\xref1.dwg')
+    expect(xref!.isXref).toBe(true)
+    expect(xref!.flags & AcDbBlockTableRecordFlag.Resolved).toBe(0)
+    expect(xref!.isUnresolvedXref).toBe(true)
+    expect(db.tables.blockTable.getUnresolvedXrefs().map(b => b.name)).toEqual([
+      'xref1'
+    ])
   })
 
   it('streams OBJECTS layouts, imagedefs, styles, and ATTRIB→INSERT linking', async () => {

--- a/packages/data-model/src/database/AcDbBlockTableRecord.ts
+++ b/packages/data-model/src/database/AcDbBlockTableRecord.ts
@@ -142,6 +142,28 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
   }
 
   /**
+   * Clears AutoCAD-internal xref status bits from BLOCK flags read from a file.
+   *
+   * DXF group 70 bits 32 ({@link AcDbBlockTableRecordFlag.Resolved}) and 64
+   * ({@link AcDbBlockTableRecordFlag.Referenced}) are documented as AutoCAD
+   * internal and ignored on input. Web converters do not bind xref geometry, so
+   * those bits must not suppress {@link isUnresolvedXref}. Runtime code (for
+   * example XATTACH overlay load) may set Resolved after content is available.
+   *
+   * @param flags - Raw block-type flags from DXF/DWG.
+   * @returns Flags with Resolved and Referenced cleared.
+   */
+  static sanitizeImportedFlags(flags: number) {
+    return (
+      flags &
+      ~(
+        AcDbBlockTableRecordFlag.Resolved |
+        AcDbBlockTableRecordFlag.Referenced
+      )
+    )
+  }
+
+  /**
    * Creates a new AcDbBlockTableRecord instance.
    *
    * @param attrs - Input attribute values for this block table record
@@ -297,8 +319,10 @@ export class AcDbBlockTableRecord extends AcDbSymbolTableRecord<AcDbBlockTableRe
   /**
    * True when this is an xref whose content has not been loaded into the block.
    *
-   * Uses the Resolved flag when set by the converter; otherwise treats an empty
-   * xref block as unresolved (the web converters do not yet bind xref content).
+   * File importers clear the Resolved bit via {@link sanitizeImportedFlags}
+   * because AutoCAD often writes Resolved even though web converters do not bind
+   * xref geometry. Runtime loaders (for example XATTACH) may set Resolved once
+   * an overlay session is available, even when the BTR stays empty.
    */
   get isUnresolvedXref() {
     if (!this.isXref) return false

--- a/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
+++ b/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
@@ -723,7 +723,7 @@ export class AcDbDxfDocumentReader {
     }
 
     btr.origin.copy(header.origin)
-    let flags = header.flags
+    let flags = AcDbBlockTableRecord.sanitizeImportedFlags(header.flags)
     if (header.pathName) {
       btr.pathName = header.pathName
       if (

--- a/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
+++ b/packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts
@@ -333,6 +333,37 @@ describe('AcDbDxfConverter', () => {
     expect(block.origin.y).toBeCloseTo(191.3692592886388)
   })
 
+  it('strips Resolved bit so attached xrefs stay unresolved', () => {
+    const db = new AcDbDatabase()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const converter = new TestDxfConverter({ useWorker: false })
+    // AutoCAD writes type 36 (Xref|Resolved) for attached, empty xref blocks.
+    converter.processBlocksPublic(
+      {
+        blocks: {
+          xref1: {
+            name: 'xref1',
+            handle: '298',
+            type: 36,
+            xrefPath: '.\\xref1.dwg',
+            position: { x: 0, y: 0, z: 0 },
+            entities: []
+          }
+        },
+        entities: []
+      },
+      db
+    )
+
+    const xref = db.tables.blockTable.getAt('xref1')
+    expect(xref).toBeDefined()
+    expect(xref!.pathName).toBe('.\\xref1.dwg')
+    expect(xref!.isXref).toBe(true)
+    expect(xref!.flags & 32).toBe(0)
+    expect(xref!.isUnresolvedXref).toBe(true)
+  })
+
   it('sets thumbnailImage from THUMBNAILIMAGE buffer or hex payload', () => {
     const db = new AcDbDatabase()
     const converter = new TestDxfConverter({ useWorker: false })

--- a/packages/dxf-json-converter/src/AcDbDxfConverter.ts
+++ b/packages/dxf-json-converter/src/AcDbDxfConverter.ts
@@ -441,7 +441,11 @@ export class AcDbDxfConverter extends AcDbDatabaseConverter<ParsedDxf> {
       // processBlockTables may create the record first without a base point.
       // Always sync origin from the BLOCKS section before expanding entities.
       dbBlock.origin.copy(block.position)
-      const blockFlags = block.type ?? 0
+      // Strip AutoCAD-internal Resolved/Referenced bits — converters do not bind
+      // xref geometry, and AutoCAD often writes Resolved on attached xrefs.
+      const blockFlags = AcDbBlockTableRecord.sanitizeImportedFlags(
+        block.type ?? 0
+      )
       dbBlock.flags = blockFlags
       if (block.xrefPath) {
         dbBlock.pathName = block.xrefPath

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -482,7 +482,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
         dbBlock.name = btr.name
         dbBlock.ownerId = btr.ownerHandle
         dbBlock.layoutId = btr.layout
-        dbBlock.flags = btr.flags ?? 0
+        // Strip AutoCAD-internal Resolved/Referenced bits — converters do not
+        // bind xref geometry, so those bits must not hide unresolved xrefs.
+        dbBlock.flags = AcDbBlockTableRecord.sanitizeImportedFlags(
+          btr.flags ?? 0
+        )
         dbBlock.blockInsertUnits = btr.insertionUnits
         dbBlock.explodability = btr.explodability
         dbBlock.blockScaling = btr.scalability as AcDbBlockScaling


### PR DESCRIPTION
## Summary
- Add `AcDbBlockTableRecord.sanitizeImportedFlags` to clear AutoCAD-internal Resolved (32) and Referenced (64) bits when reading BLOCK flags from DXF/DWG.
- Apply sanitization in native DXF, dxf-json, and LibreDWG converters so attached empty xrefs (often written as flag 36) stay `isUnresolvedXref`.
- Add unit coverage for flag 36 / Resolved stripping across converters.

## Test plan
- [x] `pnpm exec jest packages/data-model/__tests__/AcDbBlockTableRecord.spec.ts packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts packages/dxf-json-converter/__tests__/AcDbDxfConverter.spec.ts`
- [ ] Open a DWG/DXF with attached xrefs that AutoCAD marks Resolved and confirm unresolved xref detection / overlay attach still works
- [ ] Confirm runtime XATTACH that sets Resolved still reports resolved (not unresolved)