### PR TITLE
fix(data-model): avoid working-database fallback on unbound object handles

### DIFF
--- a/packages/data-model/__tests__/AcDbObject.spec.ts
+++ b/packages/data-model/__tests__/AcDbObject.spec.ts
@@ -36,4 +36,20 @@ describe('AcDbObject', () => {
       slot.set(previousDb)
     }
   })
+
+  it('accepts a real handle on an unbound object without requiring a working database', () => {
+    const slot = getWorkingDatabaseSlot()
+    const previousDb = slot.get()
+    slot.set(null)
+    try {
+      const obj = new AcDbObject()
+      expect(() => {
+        obj.objectId = '1A2B'
+      }).not.toThrow()
+      expect(obj.objectId).toBe('1A2B')
+      expect(obj.isTemp).toBe(false)
+    } finally {
+      slot.set(previousDb)
+    }
+  })
 })

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -22,6 +22,20 @@ export function acdbSetHostApplicationServicesProvider(
   hostApplicationServicesProvider = provider
 }
 
+/**
+ * Assigns the host working database when the services provider is registered.
+ *
+ * No-op when the provider has not been installed yet (e.g. HostApplicationServices
+ * module not loaded). Used by {@link AcDbDatabase.read} so import paths that
+ * touch unbound objects still see a current database.
+ */
+export function acdbAssignWorkingDatabase(database: AcDbDatabase) {
+  if (!hostApplicationServicesProvider) {
+    return
+  }
+  hostApplicationServicesProvider().workingDatabase = database
+}
+
 export function acdbGetWorkingDatabase(): AcDbDatabase {
   if (hostApplicationServicesProvider) {
     return hostApplicationServicesProvider().workingDatabase
@@ -223,9 +237,17 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
   set objectId(value: AcDbObjectId) {
     this._attrs.set('objectId', value)
 
-    // Update the database's maxHandle if the new objectId is a valid hex handle
-    if (value && !value.startsWith(TEMP_OBJECT_ID_PREFIX)) {
-      this.database.updateMaxHandle(value)
+    // Update maxHandle only when this object is already bound. Unbound objects
+    // (typical during DXF/DWG import before append/add) must not fall back to
+    // the global working database — that fails when the host DB was never set,
+    // or when a second data-model singleton is in play (e.g. Vite + peer deps).
+    // commitObjectHandle updates maxHandle once the object is added.
+    if (
+      value &&
+      !value.startsWith(TEMP_OBJECT_ID_PREFIX) &&
+      this._database
+    ) {
+      this._database.updateMaxHandle(value)
     }
   }
 

--- a/packages/data-model/src/base/index.ts
+++ b/packages/data-model/src/base/index.ts
@@ -47,6 +47,8 @@ export {
 export {
   AcDbObject,
   TEMP_OBJECT_ID_PREFIX,
+  acdbAssignWorkingDatabase,
+  acdbGetWorkingDatabase,
   acdbSetHostApplicationServicesProvider
 } from './AcDbObject'
 export type { AcDbObjectAttrs, AcDbObjectId } from './AcDbObject'

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -8,7 +8,12 @@ import {
 } from '@mlightcad/common'
 
 import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
-import { AcDbObject, AcDbObjectId, TEMP_OBJECT_ID_PREFIX } from '../base/AcDbObject'
+import {
+  AcDbObject,
+  AcDbObjectId,
+  TEMP_OBJECT_ID_PREFIX,
+  acdbAssignWorkingDatabase
+} from '../base/AcDbObject'
 import { AcDbOpenMode } from '../base/AcDbOpenMode'
 import { AcDbRegenerator } from '../converter/AcDbRegenerator'
 import {
@@ -2202,6 +2207,12 @@ export class AcDbDatabase extends AcDbObject {
     if (options?.fileName) {
       this.setDwgName(options.fileName)
     }
+
+    // Ensure this database is the host working database for the duration of
+    // conversion. Converters (including peer packages such as dxf-json-converter)
+    // assign real handles on unbound objects; some entity getters still fall
+    // back to the working database before append/add binds them.
+    acdbAssignWorkingDatabase(this)
 
     try {
       await converter.read(

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -14,6 +14,8 @@ export {
   acdbMakeBinaryDxfPairReader,
   acdbMakeUtf8AsciiDxfPairReader,
   acdbPeekDxfHeaderInfo,
+  acdbAssignWorkingDatabase,
+  acdbGetWorkingDatabase,
   acdbSetHostApplicationServicesProvider,
   acdbSetLayoutManagerFactory,
   acdbDxfValueType,

--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -141,9 +141,30 @@
     hidden
   >
     <h2>DWG / DXF Parse Demo</h2>
-    <div>
+    <p class="panel-intro">
+      Select a DWG or DXF file, choose a converter when applicable, then click
+      <strong>Run parse</strong>. DWG always uses LibreDWG in a web worker. For
+      DXF you can pick native streaming or dxf-json-converter (worker).
+    </p>
+    <div class="bench-controls">
       <input type="file" id="fileInput" accept=".dwg,.dxf" />
       <button id="runButton" type="button">Run parse</button>
+    </div>
+    <div id="dxfConverterOptions" class="bench-controls" hidden style="margin-top: 8px">
+      <span>DXF converter:</span>
+      <label>
+        <input
+          type="radio"
+          name="dxfConverter"
+          value="native"
+          checked
+        />
+        Native (<code>AcDbNativeDxfConverter</code>)
+      </label>
+      <label>
+        <input type="radio" name="dxfConverter" value="dxf-json" />
+        dxf-json-converter (<code>AcDbDxfConverter</code>, web worker)
+      </label>
     </div>
     <div id="status"></div>
     <pre id="output"></pre>

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -2,9 +2,9 @@
  * @fileoverview Example web application entry point for DWG/DXF parsing and PAT preview.
  *
  * This module wires up the demo UI: DXF converter performance comparison
- * (native vs dxf-json-converter → AcDbDatabase), file selection, web-worker
- * parsing, layer/linetype inspection, DXF export, and hatch pattern (PAT)
- * parsing with SVG previews.
+ * (native vs dxf-json-converter → AcDbDatabase), file selection with optional
+ * DXF converter choice, deferred parse on "Run parse", layer/linetype
+ * inspection, DXF export, and hatch pattern (PAT) parsing with SVG previews.
  *
  * @module example/main
  */
@@ -16,6 +16,7 @@ import {
   AcDbFileType,
   acdbFormatMemoryEstimate,
   acdbHostApplicationServices,
+  AcDbNativeDxfConverter,
   AcDbOpenDatabaseOptions,
   AcDbPatDocument,
   AcDbPatParser,
@@ -24,6 +25,7 @@ import {
   AcDbPredefinedAcadPat,
   acdbThumbnailImageToDataUrl
 } from '@mlightcad/data-model'
+import { AcDbDxfConverter } from '@mlightcad/dxf-json-converter'
 import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
 
 import type { DxfBenchmarkSample } from './dxfBenchmarkSamples'
@@ -31,11 +33,14 @@ import {
   benchmarkBuiltinSample,
   benchmarkBuiltinSamples,
   benchmarkSample,
-  formatBenchmarkResults
-} from './dxfConverterBenchmark'
+  type DxfConverterKind,
+  formatBenchmarkResults} from './dxfConverterBenchmark'
 
 const fileInput = document.getElementById('fileInput') as HTMLInputElement
 const runButton = document.getElementById('runButton') as HTMLButtonElement
+const dxfConverterOptions = document.getElementById(
+  'dxfConverterOptions'
+) as HTMLDivElement
 const status = document.getElementById('status') as HTMLDivElement
 const output = document.getElementById('output') as HTMLPreElement
 const exportButton = document.createElement('button')
@@ -122,13 +127,38 @@ const patSvgRenderer = new AcDbPatSvgRenderer()
 const patParser = new AcDbPatParser()
 
 /**
- * Registers the DWG database converter with the global converter manager.
+ * Reads the DXF converter radio selection from the parse demo UI.
  *
- * DXF already defaults to AcDbNativeDxfConverter, which the converter manager
- * registers automatically. DWG still needs an explicit converter (LibreDWG worker
- * for license isolation). Registration failures are logged but do not throw.
+ * @returns `'native'` for {@link AcDbNativeDxfConverter}, or `'dxf-json'` for
+ *   worker-based {@link AcDbDxfConverter}.
  */
-const registerConverters = () => {
+const getSelectedDxfConverter = (): DxfConverterKind => {
+  const selected = document.querySelector<HTMLInputElement>(
+    'input[name="dxfConverter"]:checked'
+  )
+  return selected?.value === 'dxf-json' ? 'dxf-json' : 'native'
+}
+
+/**
+ * Shows or hides the DXF converter picker based on the selected file type.
+ *
+ * @param fileType - Inferred type of the currently loaded file, or `null` when
+ *   no file is selected.
+ */
+const updateDxfConverterOptionsUi = (fileType: AcDbFileType | null) => {
+  dxfConverterOptions.hidden = fileType !== AcDbFileType.DXF
+}
+
+/**
+ * Registers DWG and (when needed) DXF converters with the global manager.
+ *
+ * DWG always uses LibreDWG in a web worker. For DXF, registers either the native
+ * streaming converter or dxf-json-converter based on {@link getSelectedDxfConverter}.
+ * Registration failures are logged but do not throw.
+ *
+ * @param fileType - Format being parsed; DXF registration is skipped for DWG.
+ */
+const registerConverters = (fileType: AcDbFileType) => {
   try {
     const converter = new AcDbLibreDwgConverter({
       convertByEntityType: false,
@@ -139,6 +169,44 @@ const registerConverters = () => {
   } catch (error) {
     console.error('Failed to register dwg converter: ', error)
   }
+
+  if (fileType !== AcDbFileType.DXF) return
+
+  try {
+    const kind = getSelectedDxfConverter()
+    if (kind === 'dxf-json') {
+      AcDbDatabaseConverterManager.instance.register(
+        AcDbFileType.DXF,
+        new AcDbDxfConverter({
+          convertByEntityType: false,
+          useWorker: true,
+          parserWorkerUrl: './assets/dxf-parser-worker.js'
+        })
+      )
+    } else {
+      AcDbDatabaseConverterManager.instance.register(
+        AcDbFileType.DXF,
+        new AcDbNativeDxfConverter({
+          convertByEntityType: false,
+          useWorker: false
+        })
+      )
+    }
+  } catch (error) {
+    console.error('Failed to register dxf converter: ', error)
+  }
+}
+
+/**
+ * Human-readable label for the converter used in a parse run.
+ */
+const describeConverterMode = (fileType: AcDbFileType): string => {
+  if (fileType === AcDbFileType.DWG) {
+    return 'LibreDWG (web worker)'
+  }
+  return getSelectedDxfConverter() === 'dxf-json'
+    ? 'dxf-json-converter AcDbDxfConverter (web worker)'
+    : 'native AcDbNativeDxfConverter (main thread)'
 }
 
 /**
@@ -209,7 +277,7 @@ const parseOnce = async (
   buffer: ArrayBuffer,
   fileType: AcDbFileType
 ): Promise<ParseResult> => {
-  registerConverters()
+  registerConverters(fileType)
 
   const database = new AcDbDatabase()
   acdbHostApplicationServices().workingDatabase = database
@@ -592,11 +660,12 @@ const applyPatSource = () => {
 }
 
 /**
- * Main parse workflow triggered by file selection or the Run button.
+ * Main parse workflow triggered by the Run parse button.
  *
- * Validates that a file buffer is loaded, parses via web worker, writes timing
- * and layer output, refreshes linetype previews, and updates export button state.
- * UI controls are disabled for the duration of parsing to prevent concurrent runs.
+ * Validates that a file buffer is loaded, registers the selected converter,
+ * parses the drawing, writes timing and layer output, refreshes linetype
+ * previews, and updates export button state. UI controls are disabled for the
+ * duration of parsing to prevent concurrent runs.
  */
 const runParse = async () => {
   if (!lastFile || !lastBuffer) {
@@ -607,6 +676,7 @@ const runParse = async () => {
   }
 
   const fileType = getFileType(lastFile.name)
+  const converterMode = describeConverterMode(fileType)
   const lines: string[] = []
   let parsedDatabase: AcDbDatabase | null = null
 
@@ -615,21 +685,26 @@ const runParse = async () => {
 
   runButton.disabled = true
   fileInput.disabled = true
+  dxfConverterOptions
+    .querySelectorAll<HTMLInputElement>('input[name="dxfConverter"]')
+    .forEach(input => {
+      input.disabled = true
+    })
   exportButton.disabled = true
 
   try {
-    setStatus('Parsing in web worker.')
+    setStatus(`Parsing with ${converterMode}…`)
     lines.push(`File: ${lastFile.name}`)
-    lines.push('Mode: web worker')
+    lines.push(`Converter: ${converterMode}`)
     lines.push('')
 
     const result = await parseOnce(lastBuffer.slice(0), fileType)
     setStatus('')
     if (result.skipped) {
-      lines.push(`Worker: skipped (${result.reason})`)
+      lines.push(`Parse: skipped (${result.reason})`)
     } else {
       parsedDatabase = result.database
-      lines.push(`Worker: ${formatMs(result.durationMs)}`)
+      lines.push(`Parse: ${formatMs(result.durationMs)}`)
       lines.push('')
       lines.push(...renderLayers(result.layers))
       lines.push('')
@@ -648,6 +723,11 @@ const runParse = async () => {
     renderLinetypePreviews(lastParsedDatabase)
     runButton.disabled = false
     fileInput.disabled = false
+    dxfConverterOptions
+      .querySelectorAll<HTMLInputElement>('input[name="dxfConverter"]')
+      .forEach(input => {
+        input.disabled = false
+      })
     updateExportButton()
   }
 }
@@ -660,9 +740,19 @@ fileInput.addEventListener('change', async () => {
   renderThumbnailPreview(null)
   renderLinetypePreviews(null)
   updateExportButton()
+
+  const fileType = getFileType(file.name)
+  updateDxfConverterOptionsUi(fileType)
+
   output.textContent = 'Loading file...\n'
+  setStatus('Loading file…')
   lastBuffer = await file.arrayBuffer()
-  await runParse()
+  output.textContent = `Loaded: ${file.name} (${lastBuffer.byteLength.toLocaleString()} bytes)\n\nClick "Run parse" to start.`
+  setStatus(
+    fileType === AcDbFileType.DXF
+      ? 'DXF loaded. Choose a converter, then click "Run parse".'
+      : 'File loaded. Click "Run parse" to start.'
+  )
 })
 
 runButton.addEventListener('click', async () => {

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -2,6 +2,18 @@ import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
+  optimizeDeps: {
+    // Do not prebundle GPL converters: Vite would inline @mlightcad/data-model
+    // into the optimized chunk, creating a second HostApplicationServices /
+    // workingDatabase singleton. The app then sets workingDatabase on one copy
+    // while converter-created entities read the other →
+    // "The current working database must be set before using it!".
+    exclude: [
+      '@mlightcad/dxf-json-converter',
+      '@mlightcad/libredwg-converter',
+      '@mlightcad/data-model'
+    ]
+  },
   build: {
     outDir: 'dist'
   },


### PR DESCRIPTION
## Summary
- Fix `AcDbObject.objectId` setter so assigning a real handle on an unbound object no longer touches the host working database (avoids failures when it is unset or when a second data-model singleton is in play).
- Call `acdbAssignWorkingDatabase` at the start of `AcDbDatabase.read` so converters that still rely on the working-database fallback during import see the correct database.
- Example: choose native vs dxf-json DXF converter in the UI, and defer parse until "Run parse".

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbObject.spec.ts`
- [ ] Open a DXF in the example with native converter and confirm parse succeeds
- [ ] Open the same DXF with dxf-json-converter and confirm parse succeeds
- [ ] Open a DWG and confirm LibreDWG worker path still works