### PR TITLE
chore: update dwg-converter package references in helper scripts

### DIFF
--- a/tools/setup-private-packages.mjs
+++ b/tools/setup-private-packages.mjs
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url'
 const toolsDir = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(toolsDir, '..')
 const targetDir = path.join(rootDir, 'packages', 'dwg-converter')
-const defaultRepoUrl = 'https://github.com/mlightcad/dwg-converter.git'
+const defaultRepoUrl = 'https://github.com/mlight-cad/dwg-converter.git'
 const repoUrl = process.env.DWG_CONVERTER_REPO_URL || defaultRepoUrl
 
 function run(command, args) {
@@ -30,7 +30,7 @@ function run(command, args) {
 function printNextSteps(prefix) {
   console.log(prefix)
   console.log('  pnpm install')
-  console.log('  pnpm --filter @mlightcad/dwg-converter build')
+  console.log('  pnpm --filter @mlight-cad/dwg-converter build')
   console.log('')
   console.log(
     'Note: pnpm install may add packages/dwg-converter to pnpm-lock.yaml.'

--- a/tools/use-dwg-converter.mjs
+++ b/tools/use-dwg-converter.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
- * Point the example app at the private @mlightcad/dwg-converter package
+ * Point the example app at the private @mlight-cad/dwg-converter package
  * instead of @mlightcad/libredwg-converter.
  *
  * Updates packages/example:
  *   - index.html: LibreDWG → dwg-converter
  *   - package.json: dependency name
- *   - vite.config.ts: package references
+ *   - vite.config.ts: package references + dwg-codepage-*.bin static copy
  *   - src/main.ts: import, class name and worker file references
+ *
+ * If packages/dwg-converter/package.json exists:
+ *   - set @mlightcad/data-model version to workspace:*
  */
-import { readFile, writeFile } from 'node:fs/promises'
+import { access, readFile, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -18,7 +22,35 @@ const rootDir = path.resolve(toolsDir, '..')
 const exampleDir = path.join(rootDir, 'packages', 'example')
 
 const FROM_PKG = '@mlightcad/libredwg-converter'
-const TO_PKG = '@mlightcad/dwg-converter'
+const LEGACY_TO_PKG = '@mlightcad/dwg-converter'
+const TO_PKG = '@mlight-cad/dwg-converter'
+const DATA_MODEL_PKG = '@mlightcad/data-model'
+
+const WORKER_SRC_SNIPPET = `${TO_PKG}/dist/*-worker.js`
+const CODEPAGE_SRC = `./node_modules/${TO_PKG}/dist/dwg-codepage-*.bin`
+
+/**
+ * @param {string} content
+ * @returns {string}
+ */
+function replaceConverterPkg(content) {
+  return content
+    .replaceAll(FROM_PKG, TO_PKG)
+    .replaceAll(LEGACY_TO_PKG, TO_PKG)
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<boolean>}
+ */
+async function fileExists(filePath) {
+  try {
+    await access(filePath, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
 
 /**
  * @param {string} filePath
@@ -35,6 +67,55 @@ async function updateFile(filePath, transform) {
   return true
 }
 
+/**
+ * Insert dwg-codepage-*.bin viteStaticCopy target after the dwg-converter
+ * worker target. Uses line splitting so CRLF/LF both work.
+ *
+ * @param {string} content
+ * @returns {{ content: string, added: boolean }}
+ */
+function ensureCodepageCopyTarget(content) {
+  if (content.includes('dwg-codepage-*.bin')) {
+    return { content, added: false }
+  }
+
+  const nl = content.includes('\r\n') ? '\r\n' : '\n'
+  const lines = content.split(/\r?\n/)
+  const workerLineIdx = lines.findIndex(
+    (line) =>
+      line.includes(WORKER_SRC_SNIPPET) ||
+      line.includes(`${LEGACY_TO_PKG}/dist/*-worker.js`)
+  )
+  if (workerLineIdx === -1) {
+    return { content, added: false }
+  }
+
+  let closeIdx = -1
+  for (let i = workerLineIdx; i < lines.length; i++) {
+    if (/^[ \t]*\}$/.test(lines[i])) {
+      closeIdx = i
+      break
+    }
+  }
+  if (closeIdx === -1) {
+    return { content, added: false }
+  }
+
+  const indent = lines[closeIdx].match(/^[ \t]*/)[0]
+  const propIndent = `${indent}  `
+  lines[closeIdx] = `${indent}},`
+  lines.splice(
+    closeIdx + 1,
+    0,
+    `${indent}{`,
+    `${propIndent}src: '${CODEPAGE_SRC}',`,
+    `${propIndent}dest: 'assets'`,
+    `${indent}}`
+  )
+
+  return { content: lines.join(nl), added: true }
+}
+
 const changes = []
 
 const indexHtmlPath = path.join(exampleDir, 'index.html')
@@ -47,37 +128,51 @@ if (
 }
 
 const packageJsonPath = path.join(exampleDir, 'package.json')
-if (
-  await updateFile(packageJsonPath, (content) => {
-    const pkg = JSON.parse(content)
-    const deps = pkg.dependencies ?? {}
-    if (!(FROM_PKG in deps)) {
-      return content
-    }
-    const version = deps[FROM_PKG]
-    delete deps[FROM_PKG]
+{
+  const before = await readFile(packageJsonPath, { encoding: 'utf8' })
+  const pkg = JSON.parse(before)
+  const deps = pkg.dependencies ?? {}
+  const fromKey = [FROM_PKG, LEGACY_TO_PKG].find((key) => key in deps)
+  if (fromKey && fromKey !== TO_PKG) {
+    const version = deps[fromKey]
+    delete deps[fromKey]
     deps[TO_PKG] = version === undefined ? 'workspace:*' : version
     pkg.dependencies = deps
-    return `${JSON.stringify(pkg, null, 2)}\n`
-  })
-) {
-  changes.push(`package.json: ${FROM_PKG} → ${TO_PKG}`)
+    const after = `${JSON.stringify(pkg, null, 2)}\n`
+    if (after !== before) {
+      await writeFile(packageJsonPath, after, { encoding: 'utf8' })
+      changes.push(`package.json: ${fromKey} → ${TO_PKG}`)
+    }
+  }
 }
 
 const viteConfigPath = path.join(exampleDir, 'vite.config.ts')
-if (
-  await updateFile(viteConfigPath, (content) =>
-    content.replaceAll(FROM_PKG, TO_PKG)
-  )
-) {
-  changes.push(`vite.config.ts: ${FROM_PKG} → ${TO_PKG}`)
+{
+  const before = await readFile(viteConfigPath, { encoding: 'utf8' })
+  let next = replaceConverterPkg(before)
+  const renamed = next !== before
+  const ensured = ensureCodepageCopyTarget(next)
+  next = ensured.content
+
+  if (next !== before) {
+    await writeFile(viteConfigPath, next, { encoding: 'utf8' })
+  }
+  if (renamed) {
+    changes.push(`vite.config.ts: converter package → ${TO_PKG}`)
+  }
+  if (ensured.added) {
+    changes.push('vite.config.ts: add dwg-codepage-*.bin static copy target')
+  } else if (!next.includes('dwg-codepage-*.bin')) {
+    console.warn(
+      'Warning: could not insert dwg-codepage-*.bin copy target into vite.config.ts'
+    )
+  }
 }
 
 const mainTsPath = path.join(exampleDir, 'src', 'main.ts')
 if (
   await updateFile(mainTsPath, (content) =>
-    content
-      .replaceAll(FROM_PKG, TO_PKG)
+    replaceConverterPkg(content)
       .replaceAll('AcDbLibreDwgConverter', 'AcDbDwgConverter')
       .replaceAll('libredwg-parser-worker.js', 'dwg-parser-worker.js')
   )
@@ -85,12 +180,49 @@ if (
   changes.push('src/main.ts: AcDbLibreDwgConverter → AcDbDwgConverter')
 }
 
+const dwgConverterPkgPath = path.join(
+  rootDir,
+  'packages',
+  'dwg-converter',
+  'package.json'
+)
+if (await fileExists(dwgConverterPkgPath)) {
+  if (
+    await updateFile(dwgConverterPkgPath, (content) => {
+      const pkg = JSON.parse(content)
+      let changed = false
+      for (const section of [
+        'dependencies',
+        'devDependencies',
+        'peerDependencies'
+      ]) {
+        const deps = pkg[section]
+        if (
+          deps?.[DATA_MODEL_PKG] != null &&
+          deps[DATA_MODEL_PKG] !== 'workspace:*'
+        ) {
+          deps[DATA_MODEL_PKG] = 'workspace:*'
+          changed = true
+        }
+      }
+      if (!changed) {
+        return content
+      }
+      return `${JSON.stringify(pkg, null, 2)}\n`
+    })
+  ) {
+    changes.push(
+      `packages/dwg-converter/package.json: ${DATA_MODEL_PKG} → workspace:*`
+    )
+  }
+}
+
 if (changes.length === 0) {
-  console.log('Example already uses @mlightcad/dwg-converter. Nothing to do.')
+  console.log(`Example already uses ${TO_PKG}. Nothing to do.`)
   process.exit(0)
 }
 
-console.log('Updated packages/example to use @mlightcad/dwg-converter:')
+console.log(`Updated to use ${TO_PKG}:`)
 for (const line of changes) {
   console.log(`  - ${line}`)
 }
@@ -98,4 +230,4 @@ console.log('')
 console.log('Next steps (if needed):')
 console.log('  pnpm setup:private')
 console.log('  pnpm install')
-console.log('  pnpm --filter @mlightcad/dwg-converter build')
+console.log(`  pnpm --filter ${TO_PKG} build`)


### PR DESCRIPTION
## Summary
- update `tools/setup-private-packages.mjs` to use the new `@mlight-cad/dwg-converter` repo/package naming in defaults and next-step output
- enhance `tools/use-dwg-converter.mjs` to migrate both legacy and new package names safely, and centralize replacement logic
- add automatic insertion of `dwg-codepage-*.bin` static-copy config and optional `workspace:*` alignment for `@mlightcad/data-model` in `packages/dwg-converter/package.json`

## Test plan
- [x] `node --check tools/setup-private-packages.mjs`
- [x] `node --check tools/use-dwg-converter.mjs`
