### PR TITLE
perf(data-model): transfer ArrayBuffer inputs to workers zero-copy

### DIFF
--- a/packages/data-model/src/converter/worker/AcDbWorkerManager.ts
+++ b/packages/data-model/src/converter/worker/AcDbWorkerManager.ts
@@ -154,11 +154,13 @@ export class AcDbWorkerManager {
       worker.addEventListener('message', messageHandler)
       worker.addEventListener('error', errorHandler)
 
-      // Send task to worker
-      worker.postMessage({
-        id: taskId,
-        input
-      })
+      // Zero-copy ArrayBuffer inputs into the worker (DWG file bytes).
+      const message = { id: taskId, input }
+      if (input instanceof ArrayBuffer) {
+        worker.postMessage(message, [input])
+      } else {
+        worker.postMessage(message)
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- Transfer `ArrayBuffer` inputs into parser workers via `postMessage` transfer list instead of structured clone
- Avoids copying large DWG file bytes on the main thread when dispatching worker parse tasks
- Non-`ArrayBuffer` inputs continue to use the previous clone path

## Test plan
- [ ] Open a large DWG with worker parsing enabled and confirm it still parses successfully
- [ ] Confirm main-thread callers do not reuse the input `ArrayBuffer` after `execute` (it is detached after transfer)
- [ ] Smoke-test a non-ArrayBuffer worker task path still works (string/object inputs)
