### PR TITLE
fix(data-model): apply ACIS body transform to solid geometry

### DIFF
--- a/packages/data-model/__tests__/AcDb3dSolid.spec.ts
+++ b/packages/data-model/__tests__/AcDb3dSolid.spec.ts
@@ -15,7 +15,7 @@ const REAL_CYLINDER_SAT = `400 0 1 0
 -0 body $1 $2 $-1 $3 #
 -1 display_attribute-st-attrib $-1 $4 $-1 $0 1 #
 -2 lump $-1 $-1 $5 $0 #
--3 transform $-1 1 0 0 0 -1 0 1 0 0 10 0 1 rotate no_reflect no_shear #
+-3 transform $-1 1 0 0 0 0 -1 0 1 0 0 10 0 1 rotate no_reflect no_shear #
 -4 rgb_color-st-attrib $-1 $6 $1 $0 0 1 0 #
 -5 shell $-1 $-1 $-1 $7 $-1 $2 #
 -6 id_attribute-st-attrib $-1 $-1 $-1 $4 $0 1 #
@@ -67,9 +67,15 @@ describe('AcDb3dSolid', () => {
     expect(solid.version).toBe(400)
     expect(solid.hasRenderableGeometry).toBe(true)
 
+    // Body transform maps (x,y,z) → (x, z+10, -y), so the two ellipse rings
+    // land at y=0 and y=20 with radius 10 in the XZ plane.
     const extents = solid.geometricExtents
-    expect(extents.min).toMatchObject({ x: -10, y: -10, z: -10 })
-    expect(extents.max).toMatchObject({ x: 10, y: 10, z: 10 })
+    expect(extents.min.x).toBeCloseTo(-10, 5)
+    expect(extents.min.y).toBeCloseTo(0, 5)
+    expect(extents.min.z).toBeCloseTo(-10, 5)
+    expect(extents.max.x).toBeCloseTo(10, 5)
+    expect(extents.max.y).toBeCloseTo(20, 5)
+    expect(extents.max.z).toBeCloseTo(10, 5)
   })
 
   it('computes a correct bounding box from a synthetic point set', () => {

--- a/packages/data-model/__tests__/AcDbAcisTransform.spec.ts
+++ b/packages/data-model/__tests__/AcDbAcisTransform.spec.ts
@@ -1,0 +1,63 @@
+import {
+  acdbAcisTransformDirection,
+  acdbAcisTransformIsIdentity,
+  acdbAcisTransformPoint,
+  acdbAcisTransformSegments,
+  type AcDbAcisAffineTransform,
+} from '../src/acis/AcDbAcisTransform'
+
+const translationOnly: AcDbAcisAffineTransform = {
+  xAxis: [1, 0, 0],
+  yAxis: [0, 1, 0],
+  zAxis: [0, 0, 1],
+  translation: [-6438.553441499935, -965.402812514523, 0],
+  scale: 1,
+}
+
+describe('AcDbAcisTransform', () => {
+  it('detects identity transforms', () => {
+    expect(
+      acdbAcisTransformIsIdentity({
+        xAxis: [1, 0, 0],
+        yAxis: [0, 1, 0],
+        zAxis: [0, 0, 1],
+        translation: [0, 0, 0],
+        scale: 1,
+      }),
+    ).toBe(true)
+    expect(acdbAcisTransformIsIdentity(translationOnly)).toBe(false)
+  })
+
+  it('maps body-space points into model space with translation', () => {
+    // Mirrors anteensolids equipment-03 solid A1AAD: body-space XY near
+    // (6437–6438, 962–968) plus the body transform lands on the same local
+    // frame as the block's LWPOLYLINE / LINE geometry.
+    expect(
+      acdbAcisTransformPoint([6437.353441499935, 962.277812514523, 14.2], translationOnly),
+    ).toEqual([-1.199999999999818, -3.125, 14.2])
+    expect(
+      acdbAcisTransformPoint([6438.553441499935, 968.527812514523, 14.5], translationOnly),
+    ).toEqual([0, 3.125, 14.5])
+  })
+
+  it('transforms directions without applying translation', () => {
+    expect(acdbAcisTransformDirection([1, 0, 0], translationOnly)).toEqual([
+      1, 0, 0,
+    ])
+  })
+
+  it('transforms wireframe segment endpoints', () => {
+    const segments = new Float32Array([
+      6437.353441499935, 962.277812514523, 14.2, 6438.553441499935,
+      968.527812514523, 14.5,
+    ])
+    const out = acdbAcisTransformSegments(segments, translationOnly)
+    // Float32Array storage rounds intermediates; check model-space placement.
+    expect(out[0]).toBeCloseTo(-1.2, 3)
+    expect(out[1]).toBeCloseTo(-3.125, 3)
+    expect(out[2]).toBeCloseTo(14.2, 5)
+    expect(out[3]).toBeCloseTo(0, 3)
+    expect(out[4]).toBeCloseTo(3.125, 3)
+    expect(out[5]).toBeCloseTo(14.5, 5)
+  })
+})

--- a/packages/data-model/__tests__/AcDbAcisTransform.spec.ts
+++ b/packages/data-model/__tests__/AcDbAcisTransform.spec.ts
@@ -1,8 +1,14 @@
+import type { AcDbAcisModel, AcDbAcisNode } from '../src/acis/AcDbAcisEntities'
+import { AcDbAcisSabTag } from '../src/acis/AcDbAcisSab'
+import { acdbAcisWireframeSegmentsFromSatText } from '../src/acis/AcDbAcisSatWireframe'
 import {
+  acdbAcisBuildNodeTransforms,
+  acdbAcisModelSpaceTransform,
   acdbAcisTransformDirection,
   acdbAcisTransformIsIdentity,
   acdbAcisTransformPoint,
   acdbAcisTransformSegments,
+  acdbAcisTransformsEqual,
   type AcDbAcisAffineTransform,
 } from '../src/acis/AcDbAcisTransform'
 
@@ -12,6 +18,70 @@ const translationOnly: AcDbAcisAffineTransform = {
   zAxis: [0, 0, 1],
   translation: [-6438.553441499935, -965.402812514523, 0],
   scale: 1,
+}
+
+function transformNode(
+  index: number,
+  transform: AcDbAcisAffineTransform,
+): AcDbAcisNode {
+  return {
+    index,
+    type: 'transform',
+    record: {
+      type: 'transform',
+      tokens: [
+        { tag: AcDbAcisSabTag.DirectionVec, value: transform.xAxis },
+        { tag: AcDbAcisSabTag.DirectionVec, value: transform.yAxis },
+        { tag: AcDbAcisSabTag.DirectionVec, value: transform.zAxis },
+        { tag: AcDbAcisSabTag.LocationVec, value: transform.translation },
+        { tag: AcDbAcisSabTag.Double, value: transform.scale },
+      ],
+    },
+    refs: [],
+  }
+}
+
+function mockNode(
+  index: number,
+  type: string,
+  refs: Array<AcDbAcisNode | null> = [],
+): AcDbAcisNode {
+  return {
+    index,
+    type,
+    record: { type, tokens: [] },
+    refs,
+  }
+}
+
+function mockModel(bodies: AcDbAcisNode[]): AcDbAcisModel {
+  const nodes: AcDbAcisNode[] = []
+  const visit = (node: AcDbAcisNode | null): void => {
+    if (node == null || nodes[node.index] === node) return
+    nodes[node.index] = node
+    for (const ref of node.refs) visit(ref)
+  }
+  for (const body of bodies) visit(body)
+  return {
+    header: {
+      signature: 'ACIS BinaryFile',
+      version: 700,
+      numRecords: nodes.length,
+      numEntities: nodes.length,
+      flags: 0,
+      productId: '',
+      acisVersion: '',
+      creationDate: '',
+      unitsInMm: 1,
+      resTol: 1e-6,
+      norTol: 1e-10,
+    },
+    nodes,
+    bodies,
+    typeCounts: new Map(),
+    nodesOfType: () => [],
+    pointLocations: () => [],
+  }
 }
 
 describe('AcDbAcisTransform', () => {
@@ -26,6 +96,21 @@ describe('AcDbAcisTransform', () => {
       }),
     ).toBe(true)
     expect(acdbAcisTransformIsIdentity(translationOnly)).toBe(false)
+  })
+
+  it('treats near-equal transforms as equal', () => {
+    const a: AcDbAcisAffineTransform = {
+      xAxis: [1, 0, 0],
+      yAxis: [0, 1, 0],
+      zAxis: [0, 0, 1],
+      translation: [1, 2, 3],
+      scale: 1,
+    }
+    const b: AcDbAcisAffineTransform = {
+      ...a,
+      translation: [1 + 1e-13, 2, 3],
+    }
+    expect(acdbAcisTransformsEqual(a, b)).toBe(true)
   })
 
   it('maps body-space points into model space with translation', () => {
@@ -59,5 +144,88 @@ describe('AcDbAcisTransform', () => {
     expect(out[3]).toBeCloseTo(0, 3)
     expect(out[4]).toBeCloseTo(3.125, 3)
     expect(out[5]).toBeCloseTo(14.5, 5)
+  })
+
+  it('keeps a shared model-space transform when bodies nearly agree', () => {
+    const shared: AcDbAcisAffineTransform = {
+      xAxis: [1, 0, 0],
+      yAxis: [0, 1, 0],
+      zAxis: [0, 0, 1],
+      translation: [10, 20, 30],
+      scale: 1,
+    }
+    const nearShared: AcDbAcisAffineTransform = {
+      ...shared,
+      translation: [10 + 1e-13, 20, 30],
+    }
+    const bodyA = mockNode(0, 'body', [transformNode(1, shared)])
+    const bodyB = mockNode(2, 'body', [transformNode(3, nearShared)])
+    const modelTransform = acdbAcisModelSpaceTransform(mockModel([bodyA, bodyB]))
+    expect(modelTransform.translation[0]).toBeCloseTo(10, 12)
+    expect(modelTransform.translation[1]).toBe(20)
+    expect(modelTransform.translation[2]).toBe(30)
+  })
+
+  it('returns identity for model-space transform when bodies disagree', () => {
+    const a: AcDbAcisAffineTransform = {
+      xAxis: [1, 0, 0],
+      yAxis: [0, 1, 0],
+      zAxis: [0, 0, 1],
+      translation: [1, 0, 0],
+      scale: 1,
+    }
+    const b: AcDbAcisAffineTransform = {
+      ...a,
+      translation: [2, 0, 0],
+    }
+    const bodyA = mockNode(0, 'body', [transformNode(1, a)])
+    const bodyB = mockNode(2, 'body', [transformNode(3, b)])
+    expect(
+      acdbAcisTransformIsIdentity(acdbAcisModelSpaceTransform(mockModel([bodyA, bodyB]))),
+    ).toBe(true)
+  })
+
+  it('assigns each topology node its owning body transform', () => {
+    const tA: AcDbAcisAffineTransform = {
+      xAxis: [1, 0, 0],
+      yAxis: [0, 1, 0],
+      zAxis: [0, 0, 1],
+      translation: [100, 0, 0],
+      scale: 1,
+    }
+    const tB: AcDbAcisAffineTransform = {
+      ...tA,
+      translation: [0, 200, 0],
+    }
+    const faceA = mockNode(2, 'face')
+    const faceB = mockNode(5, 'face')
+    const lumpA = mockNode(3, 'lump', [faceA])
+    const lumpB = mockNode(6, 'lump', [faceB])
+    const bodyA = mockNode(0, 'body', [lumpA, transformNode(1, tA)])
+    const bodyB = mockNode(4, 'body', [lumpB, transformNode(7, tB)])
+
+    const map = acdbAcisBuildNodeTransforms(mockModel([bodyA, bodyB]))
+    expect(map.get(faceA.index)?.translation).toEqual([100, 0, 0])
+    expect(map.get(faceB.index)?.translation).toEqual([0, 200, 0])
+  })
+})
+
+describe('acdbAcisWireframeSegmentsFromSatText transform', () => {
+  it('applies a body transform to straight-curve segments', () => {
+    const sat = `
+-0 body $1 $-1 $-1 $2 #
+-1 attrib $-1 #
+-2 transform $-1 1 0 0 0 1 0 0 0 1 5 6 7 1 no_rotate no_reflect no_shear #
+-3 straight-curve $-1 0 0 0 1 0 0 #
+End-of-ACIS-data
+`
+    const out = acdbAcisWireframeSegmentsFromSatText(sat)
+    expect(out.length).toBe(6)
+    expect(out[0]).toBeCloseTo(5, 5)
+    expect(out[1]).toBeCloseTo(6, 5)
+    expect(out[2]).toBeCloseTo(7, 5)
+    expect(out[3]).toBeCloseTo(6, 5)
+    expect(out[4]).toBeCloseTo(6, 5)
+    expect(out[5]).toBeCloseTo(7, 5)
   })
 })

--- a/packages/data-model/src/acis/AcDbAcisGeometry.ts
+++ b/packages/data-model/src/acis/AcDbAcisGeometry.ts
@@ -20,7 +20,8 @@ import type { AcDbAcisSabToken, AcDbAcisSabVector } from './AcDbAcisSab'
 import { AcDbAcisSabTag } from './AcDbAcisSab'
 import {
   type AcDbAcisAffineTransform,
-  acdbAcisModelSpaceTransform,
+  acdbAcisBuildNodeTransforms,
+  acdbAcisIdentityTransform,
   acdbAcisTransformDirection,
   acdbAcisTransformIsIdentity,
   acdbAcisTransformPoint,
@@ -521,19 +522,28 @@ function transformSurfaceParams(
  * Extract the B-rep geometry from a decoded ACIS model. Never throws; unresolved
  * topology/geometry is reported via `diagnostics` and `'unknown'` type labels.
  *
- * Coordinates are returned in model space: when the model has a single shared
- * body `transform`, it is applied to vertices, edge endpoints, and analytic
- * curve/surface parameters.
+ * Coordinates are returned in model space: each entity is mapped by its owning
+ * body's `transform` (multi-body models with distinct transforms are supported).
  *
  * @param model - Resolved ACIS model graph.
  * @returns Extracted vertices, edges, faces, bounding box, and diagnostics.
  */
 export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry {
   const diagnostics: string[] = [];
-  const transform = acdbAcisModelSpaceTransform(model)
-  const applyTransform = !acdbAcisTransformIsIdentity(transform)
-  const mapPoint = (p: AcDbAcisVec3 | null): AcDbAcisVec3 | null =>
-    p === null || !applyTransform ? p : acdbAcisTransformPoint(p, transform)
+  const transformsByNode = acdbAcisBuildNodeTransforms(model)
+  const identity = acdbAcisIdentityTransform()
+  const transformFor = (nodeIndex: number): AcDbAcisAffineTransform =>
+    transformsByNode.get(nodeIndex) ?? identity
+  const mapPoint = (
+    p: AcDbAcisVec3 | null,
+    nodeIndex: number,
+  ): AcDbAcisVec3 | null => {
+    if (p === null) return null
+    const transform = transformFor(nodeIndex)
+    return acdbAcisTransformIsIdentity(transform)
+      ? p
+      : acdbAcisTransformPoint(p, transform)
+  }
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   const grow = (p: AcDbAcisVec3): void => {
@@ -543,7 +553,7 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
   };
 
   const vertices: AcDbAcisVertex[] = model.nodesOfType('vertex').map(v => {
-    const point = mapPoint(vertexPoint(v));
+    const point = mapPoint(vertexPoint(v), v.index);
     if (point === null) diagnostics.push(`vertex#${String(v.index)}: no resolvable point`);
     else grow(point);
     return { nodeIndex: v.index, point };
@@ -551,12 +561,17 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
 
   const edges: AcDbAcisEdge[] = model.nodesOfType('edge').map(e => {
     const verts = refsOfType(e, 'vertex');
-    const start = mapPoint(vertexPoint(verts[0] ?? null));
-    const end = mapPoint(vertexPoint(verts[1] ?? null));
+    const start = mapPoint(vertexPoint(verts[0] ?? null), e.index);
+    const end = mapPoint(vertexPoint(verts[1] ?? null), e.index);
     const curveNode = refOfType(e, '-curve');
     const curveType: AcDbAcisCurveKind = curveNode ? (CURVE_KIND[curveNode.type] ?? 'unknown') : 'unknown';
     let curve = curveNode ? curveParams(curveNode) : undefined;
-    if (curve !== undefined && curve.kind !== 'unknown' && applyTransform) {
+    const transform = transformFor(e.index)
+    if (
+      curve !== undefined &&
+      curve.kind !== 'unknown' &&
+      !acdbAcisTransformIsIdentity(transform)
+    ) {
       curve = transformCurveParams(curve, transform)
     }
     if (start !== null && end !== null && start[0] === end[0] && start[1] === end[1] && start[2] === end[2]) {
@@ -571,7 +586,12 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
     const surfaceNode = refOfType(f, '-surface');
     const surfaceType: AcDbAcisSurfaceKind = surfaceNode ? (SURFACE_KIND[surfaceNode.type] ?? 'unknown') : 'unknown';
     let surface = surfaceNode ? surfaceParams(surfaceNode) : undefined;
-    if (surface !== undefined && surface.kind !== 'unknown' && applyTransform) {
+    const transform = transformFor(f.index)
+    if (
+      surface !== undefined &&
+      surface.kind !== 'unknown' &&
+      !acdbAcisTransformIsIdentity(transform)
+    ) {
       surface = transformSurfaceParams(surface, transform)
     }
     // Walk the next-loop chain (loop-typed ref), guarded against cycles.

--- a/packages/data-model/src/acis/AcDbAcisGeometry.ts
+++ b/packages/data-model/src/acis/AcDbAcisGeometry.ts
@@ -18,6 +18,13 @@
 import type { AcDbAcisModel, AcDbAcisNode } from './AcDbAcisEntities'
 import type { AcDbAcisSabToken, AcDbAcisSabVector } from './AcDbAcisSab'
 import { AcDbAcisSabTag } from './AcDbAcisSab'
+import {
+  type AcDbAcisAffineTransform,
+  acdbAcisModelSpaceTransform,
+  acdbAcisTransformDirection,
+  acdbAcisTransformIsIdentity,
+  acdbAcisTransformPoint,
+} from './AcDbAcisTransform'
 
 /** 3D position or direction vector `[x, y, z]`. */
 export type AcDbAcisVec3 = AcDbAcisSabVector
@@ -422,14 +429,111 @@ function loopCoedgeCount(loop: AcDbAcisNode): number {
 }
 
 /**
+ * Applies a body transform to analytic curve parameters.
+ *
+ * @param curve - Parsed curve parameters in body space.
+ * @param transform - Body-to-model transform.
+ */
+function transformCurveParams(
+  curve: AcDbAcisCurveParams,
+  transform: AcDbAcisAffineTransform,
+): AcDbAcisCurveParams {
+  if (curve.kind === 'straight') {
+    return {
+      kind: 'straight',
+      origin: acdbAcisTransformPoint(curve.origin, transform),
+      direction: acdbAcisTransformDirection(curve.direction, transform),
+    }
+  }
+  if (curve.kind === 'ellipse') {
+    return {
+      kind: 'ellipse',
+      center: acdbAcisTransformPoint(curve.center, transform),
+      normal: acdbAcisTransformDirection(curve.normal, transform),
+      majorAxis: acdbAcisTransformDirection(curve.majorAxis, transform),
+      ratio: curve.ratio,
+    }
+  }
+  if (curve.kind === 'intcurve') {
+    return {
+      kind: 'intcurve',
+      controlPoints: curve.controlPoints.map(p =>
+        acdbAcisTransformPoint(p, transform),
+      ),
+    }
+  }
+  return curve
+}
+
+/**
+ * Applies a body transform to analytic surface parameters.
+ *
+ * @param surface - Parsed surface parameters in body space.
+ * @param transform - Body-to-model transform.
+ */
+function transformSurfaceParams(
+  surface: AcDbAcisSurfaceParams,
+  transform: AcDbAcisAffineTransform,
+): AcDbAcisSurfaceParams {
+  if (surface.kind === 'plane') {
+    return {
+      kind: 'plane',
+      origin: acdbAcisTransformPoint(surface.origin, transform),
+      normal: acdbAcisTransformDirection(surface.normal, transform),
+      ...(surface.uDir
+        ? { uDir: acdbAcisTransformDirection(surface.uDir, transform) }
+        : {}),
+    }
+  }
+  if (surface.kind === 'cone') {
+    return {
+      kind: 'cone',
+      origin: acdbAcisTransformPoint(surface.origin, transform),
+      axis: acdbAcisTransformDirection(surface.axis, transform),
+      majorAxis: acdbAcisTransformDirection(surface.majorAxis, transform),
+      ratio: surface.ratio,
+      sineAngle: surface.sineAngle,
+      cosineAngle: surface.cosineAngle,
+    }
+  }
+  if (surface.kind === 'torus') {
+    return {
+      kind: 'torus',
+      center: acdbAcisTransformPoint(surface.center, transform),
+      axis: acdbAcisTransformDirection(surface.axis, transform),
+      majorRadius: surface.majorRadius * transform.scale,
+      minorRadius: surface.minorRadius * transform.scale,
+    }
+  }
+  if (surface.kind === 'sphere') {
+    return {
+      kind: 'sphere',
+      center: acdbAcisTransformPoint(surface.center, transform),
+      radius: surface.radius * transform.scale,
+      uDir: acdbAcisTransformDirection(surface.uDir, transform),
+      poleAxis: acdbAcisTransformDirection(surface.poleAxis, transform),
+    }
+  }
+  return surface
+}
+
+/**
  * Extract the B-rep geometry from a decoded ACIS model. Never throws; unresolved
  * topology/geometry is reported via `diagnostics` and `'unknown'` type labels.
+ *
+ * Coordinates are returned in model space: when the model has a single shared
+ * body `transform`, it is applied to vertices, edge endpoints, and analytic
+ * curve/surface parameters.
  *
  * @param model - Resolved ACIS model graph.
  * @returns Extracted vertices, edges, faces, bounding box, and diagnostics.
  */
 export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry {
   const diagnostics: string[] = [];
+  const transform = acdbAcisModelSpaceTransform(model)
+  const applyTransform = !acdbAcisTransformIsIdentity(transform)
+  const mapPoint = (p: AcDbAcisVec3 | null): AcDbAcisVec3 | null =>
+    p === null || !applyTransform ? p : acdbAcisTransformPoint(p, transform)
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   const grow = (p: AcDbAcisVec3): void => {
@@ -439,7 +543,7 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
   };
 
   const vertices: AcDbAcisVertex[] = model.nodesOfType('vertex').map(v => {
-    const point = vertexPoint(v);
+    const point = mapPoint(vertexPoint(v));
     if (point === null) diagnostics.push(`vertex#${String(v.index)}: no resolvable point`);
     else grow(point);
     return { nodeIndex: v.index, point };
@@ -447,11 +551,14 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
 
   const edges: AcDbAcisEdge[] = model.nodesOfType('edge').map(e => {
     const verts = refsOfType(e, 'vertex');
-    const start = vertexPoint(verts[0] ?? null);
-    const end = vertexPoint(verts[1] ?? null);
+    const start = mapPoint(vertexPoint(verts[0] ?? null));
+    const end = mapPoint(vertexPoint(verts[1] ?? null));
     const curveNode = refOfType(e, '-curve');
     const curveType: AcDbAcisCurveKind = curveNode ? (CURVE_KIND[curveNode.type] ?? 'unknown') : 'unknown';
-    const curve = curveNode ? curveParams(curveNode) : undefined;
+    let curve = curveNode ? curveParams(curveNode) : undefined;
+    if (curve !== undefined && curve.kind !== 'unknown' && applyTransform) {
+      curve = transformCurveParams(curve, transform)
+    }
     if (start !== null && end !== null && start[0] === end[0] && start[1] === end[1] && start[2] === end[2]) {
       diagnostics.push(`edge#${String(e.index)}: degenerate (coincident endpoints)`);
     }
@@ -463,7 +570,10 @@ export function acdbExtractAcisGeometry(model: AcDbAcisModel): AcDbAcisGeometry 
   const faces: AcDbAcisFace[] = model.nodesOfType('face').map(f => {
     const surfaceNode = refOfType(f, '-surface');
     const surfaceType: AcDbAcisSurfaceKind = surfaceNode ? (SURFACE_KIND[surfaceNode.type] ?? 'unknown') : 'unknown';
-    const surface = surfaceNode ? surfaceParams(surfaceNode) : undefined;
+    let surface = surfaceNode ? surfaceParams(surfaceNode) : undefined;
+    if (surface !== undefined && surface.kind !== 'unknown' && applyTransform) {
+      surface = transformSurfaceParams(surface, transform)
+    }
     // Walk the next-loop chain (loop-typed ref), guarded against cycles.
     const loops: AcDbAcisFaceLoop[] = [];
     const seen = new Set<number>();

--- a/packages/data-model/src/acis/AcDbAcisSatWireframe.ts
+++ b/packages/data-model/src/acis/AcDbAcisSatWireframe.ts
@@ -8,6 +8,12 @@ import {
   type AcDbAcisVec3,
   acdbSampleAcisEllipseArc,
 } from './AcDbAcisGeometry'
+import {
+  type AcDbAcisAffineTransform,
+  acdbAcisIdentityTransform,
+  acdbAcisTransformSegments,
+  acdbAcisTransformsEqual,
+} from './AcDbAcisTransform'
 
 const DEFAULT_ELLIPSE_SAMPLES = 16
 
@@ -54,6 +60,95 @@ function splitSatRecords(satText: string): string[] {
     .filter(record => record.length > 0)
 }
 
+/**
+ * Indexes SAT entity records by pointer index.
+ *
+ * Uses an explicit `-N` sequence number when present; otherwise falls back to
+ * appearance order (ACIS files without sequence numbers).
+ *
+ * @param records - `#`-split SAT entity records.
+ */
+function indexSatRecords(records: readonly string[]): (string | undefined)[] {
+  const byIndex: (string | undefined)[] = []
+  records.forEach((record, appearanceIndex) => {
+    const match = /^-(\d+)\b/.exec(record)
+    const index = match ? Number(match[1]) : appearanceIndex
+    byIndex[index] = record
+  })
+  return byIndex
+}
+
+/**
+ * Parses a SAT `transform` record into an affine transform.
+ *
+ * Layout after pointers: three axis vectors (9 doubles), translation (3),
+ * then uniform scale.
+ *
+ * @param record - One SAT entity record.
+ */
+function parseSatTransform(record: string): AcDbAcisAffineTransform | null {
+  if (!/(?:^|\s)transform\b/.test(record)) return null
+  const values = readSatNumericTokens(record)
+  if (values.length < 13) return null
+  return {
+    xAxis: [values[0]!, values[1]!, values[2]!],
+    yAxis: [values[3]!, values[4]!, values[5]!],
+    zAxis: [values[6]!, values[7]!, values[8]!],
+    translation: [values[9]!, values[10]!, values[11]!],
+    scale: values[12]!,
+  }
+}
+
+/**
+ * Resolves the shared body-to-model transform from SAT text.
+ *
+ * Returns identity when bodies disagree (per-curve ownership is not available
+ * in this best-effort text path). When no body references a transform but
+ * exactly one transform record exists, that transform is used.
+ *
+ * @param satText - Plain SAT/ASM text payload.
+ */
+function satModelSpaceTransform(satText: string): AcDbAcisAffineTransform {
+  const identity = acdbAcisIdentityTransform()
+  const byIndex = indexSatRecords(splitSatRecords(satText))
+  const bodyTransforms: AcDbAcisAffineTransform[] = []
+
+  for (const record of byIndex) {
+    if (record == null || !/(?:^|\s)body\b/.test(record)) continue
+    const pointers = [...record.matchAll(/\$(-?\d+)/g)].map(match =>
+      Number(match[1]),
+    )
+    for (const pointer of pointers) {
+      if (pointer < 0) continue
+      const target = byIndex[pointer]
+      if (target == null) continue
+      const transform = parseSatTransform(target)
+      if (transform != null) {
+        bodyTransforms.push(transform)
+        break
+      }
+    }
+  }
+
+  if (bodyTransforms.length === 0) {
+    const transforms: AcDbAcisAffineTransform[] = []
+    for (const record of byIndex) {
+      if (record == null) continue
+      const transform = parseSatTransform(record)
+      if (transform != null) transforms.push(transform)
+    }
+    return transforms.length === 1 ? transforms[0]! : identity
+  }
+
+  const first = bodyTransforms[0]!
+  for (let i = 1; i < bodyTransforms.length; i++) {
+    if (!acdbAcisTransformsEqual(bodyTransforms[i]!, first)) {
+      return identity
+    }
+  }
+  return first
+}
+
 /** Parses a `straight-curve` SAT record into start/end segment endpoints. */
 function parseStraightCurve(record: string): [AcDbAcisVec3, AcDbAcisVec3] | null {
   if (!record.includes('straight-curve')) {
@@ -97,6 +192,9 @@ function parseEllipseCurve(record: string): AcDbAcisEllipseCurveParams | null {
  * Extract wireframe segments from a SAT text stream by matching common curve
  * records. This is a fallback when SAB decoding is unavailable.
  *
+ * Curve geometry is sampled in body space, then mapped through the shared body
+ * `transform` when one can be resolved.
+ *
  * @param satText - Plain SAT/ASM text payload.
  * @returns Flat `Float32Array` of line-segment endpoint pairs (`[x,y,z,x,y,z,...]`).
  */
@@ -122,5 +220,11 @@ export function acdbAcisWireframeSegmentsFromSatText(satText: string): Float32Ar
     }
   }
 
-  return new Float32Array(segments)
+  if (segments.length === 0) {
+    return new Float32Array(0)
+  }
+  return acdbAcisTransformSegments(
+    new Float32Array(segments),
+    satModelSpaceTransform(satText),
+  )
 }

--- a/packages/data-model/src/acis/AcDbAcisTransform.ts
+++ b/packages/data-model/src/acis/AcDbAcisTransform.ts
@@ -33,10 +33,43 @@ const IDENTITY: AcDbAcisAffineTransform = {
   scale: 1,
 }
 
+const NEAR_EPS = 1e-12
+
 const VEC_TAGS = new Set<number>([
   AcDbAcisSabTag.LocationVec,
   AcDbAcisSabTag.DirectionVec,
 ])
+
+const near = (a: number, b: number): boolean => Math.abs(a - b) <= NEAR_EPS
+
+const nearVec = (v: AcDbAcisSabVector, e: AcDbAcisSabVector): boolean =>
+  near(v[0], e[0]) && near(v[1], e[1]) && near(v[2], e[2])
+
+/**
+ * Returns the identity body transform.
+ */
+export function acdbAcisIdentityTransform(): AcDbAcisAffineTransform {
+  return IDENTITY
+}
+
+/**
+ * Returns true when two affine transforms are numerically equal.
+ *
+ * @param a - First transform.
+ * @param b - Second transform.
+ */
+export function acdbAcisTransformsEqual(
+  a: AcDbAcisAffineTransform,
+  b: AcDbAcisAffineTransform,
+): boolean {
+  return (
+    near(a.scale, b.scale) &&
+    nearVec(a.xAxis, b.xAxis) &&
+    nearVec(a.yAxis, b.yAxis) &&
+    nearVec(a.zAxis, b.zAxis) &&
+    nearVec(a.translation, b.translation)
+  )
+}
 
 /**
  * Parses an ACIS `transform` node into an affine transform.
@@ -97,16 +130,7 @@ export function acdbAcisTransformFromBody(
 export function acdbAcisTransformIsIdentity(
   transform: AcDbAcisAffineTransform,
 ): boolean {
-  const near = (a: number, b: number) => Math.abs(a - b) <= 1e-12
-  const nearVec = (v: AcDbAcisSabVector, e: AcDbAcisSabVector) =>
-    near(v[0], e[0]) && near(v[1], e[1]) && near(v[2], e[2])
-  return (
-    near(transform.scale, 1) &&
-    nearVec(transform.xAxis, IDENTITY.xAxis) &&
-    nearVec(transform.yAxis, IDENTITY.yAxis) &&
-    nearVec(transform.zAxis, IDENTITY.zAxis) &&
-    nearVec(transform.translation, IDENTITY.translation)
-  )
+  return acdbAcisTransformsEqual(transform, IDENTITY)
 }
 
 /**
@@ -150,11 +174,46 @@ export function acdbAcisTransformDirection(
 }
 
 /**
- * Picks the single body transform to apply to a whole model.
+ * Walks each body DAG and records the owning body's transform per node index.
+ *
+ * Attribute entities are skipped so owner back-pointers cannot cross bodies.
+ * Shared nodes keep the first body's transform.
+ *
+ * @param model - Resolved ACIS model graph.
+ */
+export function acdbAcisBuildNodeTransforms(
+  model: AcDbAcisModel,
+): ReadonlyMap<number, AcDbAcisAffineTransform> {
+  const map = new Map<number, AcDbAcisAffineTransform>()
+
+  const visit = (
+    node: AcDbAcisNode | null | undefined,
+    transform: AcDbAcisAffineTransform,
+    seen: Set<number>,
+  ): void => {
+    if (node == null || seen.has(node.index)) return
+    if (node.type.includes('attrib')) return
+    seen.add(node.index)
+    if (!map.has(node.index)) {
+      map.set(node.index, transform)
+    }
+    for (const ref of node.refs) {
+      visit(ref, transform, seen)
+    }
+  }
+
+  for (const body of model.bodies) {
+    visit(body, acdbAcisTransformFromBody(body), new Set())
+  }
+  return map
+}
+
+/**
+ * Picks a single body transform shared by every body in the model.
  *
  * Returns identity when there is no body, or when bodies disagree on
- * transform (multi-body with distinct transforms is not yet supported for
- * global application — callers keep body-space coords and can specialize).
+ * transform (callers that need per-body mapping should use
+ * {@link acdbAcisBuildNodeTransforms}).
  *
  * @param model - Resolved ACIS model graph.
  */
@@ -165,22 +224,7 @@ export function acdbAcisModelSpaceTransform(
   const transforms = model.bodies.map(acdbAcisTransformFromBody)
   const first = transforms[0]!
   for (let i = 1; i < transforms.length; i++) {
-    const other = transforms[i]!
-    if (
-      other.scale !== first.scale ||
-      other.xAxis[0] !== first.xAxis[0] ||
-      other.xAxis[1] !== first.xAxis[1] ||
-      other.xAxis[2] !== first.xAxis[2] ||
-      other.yAxis[0] !== first.yAxis[0] ||
-      other.yAxis[1] !== first.yAxis[1] ||
-      other.yAxis[2] !== first.yAxis[2] ||
-      other.zAxis[0] !== first.zAxis[0] ||
-      other.zAxis[1] !== first.zAxis[1] ||
-      other.zAxis[2] !== first.zAxis[2] ||
-      other.translation[0] !== first.translation[0] ||
-      other.translation[1] !== first.translation[1] ||
-      other.translation[2] !== first.translation[2]
-    ) {
+    if (!acdbAcisTransformsEqual(transforms[i]!, first)) {
       return IDENTITY
     }
   }

--- a/packages/data-model/src/acis/AcDbAcisTransform.ts
+++ b/packages/data-model/src/acis/AcDbAcisTransform.ts
@@ -1,0 +1,215 @@
+/**
+ * ACIS body `transform` entity parsing and application.
+ *
+ * Each `body` may reference a `transform` that maps body-space geometry into
+ * model space: `p' = scale * (x*px + y*py + z*pz) + translation`. Wireframe
+ * extraction must apply this or solids appear far from sibling 2D entities
+ * (common when ACIS points stay in a pre-block coordinate frame).
+ */
+
+import type { AcDbAcisModel, AcDbAcisNode } from './AcDbAcisEntities'
+import type { AcDbAcisSabVector } from './AcDbAcisSab'
+import { AcDbAcisSabTag } from './AcDbAcisSab'
+
+/** Affine transform carried by an ACIS `transform` entity. */
+export interface AcDbAcisAffineTransform {
+  /** Image of the unit X axis. */
+  readonly xAxis: AcDbAcisSabVector
+  /** Image of the unit Y axis. */
+  readonly yAxis: AcDbAcisSabVector
+  /** Image of the unit Z axis. */
+  readonly zAxis: AcDbAcisSabVector
+  /** Translation applied after rotation/scale. */
+  readonly translation: AcDbAcisSabVector
+  /** Uniform scale factor. */
+  readonly scale: number
+}
+
+const IDENTITY: AcDbAcisAffineTransform = {
+  xAxis: [1, 0, 0],
+  yAxis: [0, 1, 0],
+  zAxis: [0, 0, 1],
+  translation: [0, 0, 0],
+  scale: 1,
+}
+
+const VEC_TAGS = new Set<number>([
+  AcDbAcisSabTag.LocationVec,
+  AcDbAcisSabTag.DirectionVec,
+])
+
+/**
+ * Parses an ACIS `transform` node into an affine transform.
+ *
+ * SAB layout (after entity-type / pointers): three axis direction vectors,
+ * one translation vector, then a scale double. Returns `null` when the record
+ * does not carry four vectors.
+ *
+ * @param node - Resolved `transform` entity node.
+ */
+export function acdbAcisParseTransform(
+  node: AcDbAcisNode,
+): AcDbAcisAffineTransform | null {
+  const vectors: AcDbAcisSabVector[] = []
+  let scale: number | undefined
+  for (const token of node.record.tokens) {
+    if (VEC_TAGS.has(token.tag)) {
+      vectors.push(token.value as AcDbAcisSabVector)
+      continue
+    }
+    if (
+      token.tag === AcDbAcisSabTag.Double &&
+      vectors.length >= 4 &&
+      scale === undefined
+    ) {
+      scale = token.value as number
+    }
+  }
+  if (vectors.length < 4) return null
+  return {
+    xAxis: vectors[0]!,
+    yAxis: vectors[1]!,
+    zAxis: vectors[2]!,
+    translation: vectors[3]!,
+    scale: scale ?? 1,
+  }
+}
+
+/**
+ * Returns the affine transform referenced by a `body` node, or identity when
+ * the body has no resolvable `transform`.
+ *
+ * @param body - Resolved `body` entity node.
+ */
+export function acdbAcisTransformFromBody(
+  body: AcDbAcisNode,
+): AcDbAcisAffineTransform {
+  const transformNode = body.refs.find(ref => ref?.type === 'transform')
+  if (transformNode == null) return IDENTITY
+  return acdbAcisParseTransform(transformNode) ?? IDENTITY
+}
+
+/**
+ * Returns true when `transform` is (numerically) the identity.
+ *
+ * @param transform - Affine transform to test.
+ */
+export function acdbAcisTransformIsIdentity(
+  transform: AcDbAcisAffineTransform,
+): boolean {
+  const near = (a: number, b: number) => Math.abs(a - b) <= 1e-12
+  const nearVec = (v: AcDbAcisSabVector, e: AcDbAcisSabVector) =>
+    near(v[0], e[0]) && near(v[1], e[1]) && near(v[2], e[2])
+  return (
+    near(transform.scale, 1) &&
+    nearVec(transform.xAxis, IDENTITY.xAxis) &&
+    nearVec(transform.yAxis, IDENTITY.yAxis) &&
+    nearVec(transform.zAxis, IDENTITY.zAxis) &&
+    nearVec(transform.translation, IDENTITY.translation)
+  )
+}
+
+/**
+ * Transforms a point: `scale * (x*px + y*py + z*pz) + translation`.
+ *
+ * @param point - Body-space point.
+ * @param transform - Body transform.
+ */
+export function acdbAcisTransformPoint(
+  point: AcDbAcisSabVector,
+  transform: AcDbAcisAffineTransform,
+): AcDbAcisSabVector {
+  const s = transform.scale
+  const [px, py, pz] = point
+  const { xAxis: x, yAxis: y, zAxis: z, translation: t } = transform
+  return [
+    s * (x[0] * px + y[0] * py + z[0] * pz) + t[0],
+    s * (x[1] * px + y[1] * py + z[1] * pz) + t[1],
+    s * (x[2] * px + y[2] * py + z[2] * pz) + t[2],
+  ]
+}
+
+/**
+ * Transforms a direction / free vector (rotation + scale, no translation).
+ *
+ * @param direction - Body-space direction.
+ * @param transform - Body transform.
+ */
+export function acdbAcisTransformDirection(
+  direction: AcDbAcisSabVector,
+  transform: AcDbAcisAffineTransform,
+): AcDbAcisSabVector {
+  const s = transform.scale
+  const [dx, dy, dz] = direction
+  const { xAxis: x, yAxis: y, zAxis: z } = transform
+  return [
+    s * (x[0] * dx + y[0] * dy + z[0] * dz),
+    s * (x[1] * dx + y[1] * dy + z[1] * dz),
+    s * (x[2] * dx + y[2] * dy + z[2] * dz),
+  ]
+}
+
+/**
+ * Picks the single body transform to apply to a whole model.
+ *
+ * Returns identity when there is no body, or when bodies disagree on
+ * transform (multi-body with distinct transforms is not yet supported for
+ * global application — callers keep body-space coords and can specialize).
+ *
+ * @param model - Resolved ACIS model graph.
+ */
+export function acdbAcisModelSpaceTransform(
+  model: AcDbAcisModel,
+): AcDbAcisAffineTransform {
+  if (model.bodies.length === 0) return IDENTITY
+  const transforms = model.bodies.map(acdbAcisTransformFromBody)
+  const first = transforms[0]!
+  for (let i = 1; i < transforms.length; i++) {
+    const other = transforms[i]!
+    if (
+      other.scale !== first.scale ||
+      other.xAxis[0] !== first.xAxis[0] ||
+      other.xAxis[1] !== first.xAxis[1] ||
+      other.xAxis[2] !== first.xAxis[2] ||
+      other.yAxis[0] !== first.yAxis[0] ||
+      other.yAxis[1] !== first.yAxis[1] ||
+      other.yAxis[2] !== first.yAxis[2] ||
+      other.zAxis[0] !== first.zAxis[0] ||
+      other.zAxis[1] !== first.zAxis[1] ||
+      other.zAxis[2] !== first.zAxis[2] ||
+      other.translation[0] !== first.translation[0] ||
+      other.translation[1] !== first.translation[1] ||
+      other.translation[2] !== first.translation[2]
+    ) {
+      return IDENTITY
+    }
+  }
+  return first
+}
+
+/**
+ * Applies an affine transform to a flat wireframe segment buffer in place
+ * style (returns a new buffer).
+ *
+ * @param segments - `[x,y,z,x,y,z,...]` endpoint pairs.
+ * @param transform - Transform to apply to every endpoint.
+ */
+export function acdbAcisTransformSegments(
+  segments: Float32Array,
+  transform: AcDbAcisAffineTransform,
+): Float32Array {
+  if (acdbAcisTransformIsIdentity(transform) || segments.length < 3) {
+    return segments
+  }
+  const out = new Float32Array(segments.length)
+  for (let i = 0; i + 2 < segments.length; i += 3) {
+    const [x, y, z] = acdbAcisTransformPoint(
+      [segments[i]!, segments[i + 1]!, segments[i + 2]!],
+      transform,
+    )
+    out[i] = x
+    out[i + 1] = y
+    out[i + 2] = z
+  }
+  return out
+}

--- a/packages/data-model/src/acis/AcDbAcisWireframe.ts
+++ b/packages/data-model/src/acis/AcDbAcisWireframe.ts
@@ -9,6 +9,10 @@ import {
   acdbSampleAcisEllipseArc,
   acdbSampleAcisSphereWireframe,
 } from './AcDbAcisGeometry'
+import {
+  acdbAcisModelSpaceTransform,
+  acdbAcisTransformSegments,
+} from './AcDbAcisTransform'
 
 /** Default number of samples when tessellating ellipse edges for wireframe output. */
 const DEFAULT_ELLIPSE_SAMPLES = 16
@@ -107,11 +111,17 @@ export function acdbAcisWireframeSegmentsFromSab(
 ): Float32Array | null {
   const model = acdbDecodeAcisModel(sabBytes)
   if (model === null) return null
+  // Edge wireframe uses geometry already mapped to model space by extract.
   const geometry = acdbExtractAcisGeometry(model)
   const edgeWireframe = acdbAcisWireframeSegmentsFromGeometry(geometry, model)
   if (edgeWireframe.length > 0) {
     return edgeWireframe
   }
+  // Sphere fallback reads raw surface records — apply the body transform here.
   const sphereWireframe = acdbAcisWireframeSegmentsFromSphereFaces(model)
-  return sphereWireframe.length > 0 ? sphereWireframe : null
+  if (sphereWireframe.length === 0) return null
+  return acdbAcisTransformSegments(
+    sphereWireframe,
+    acdbAcisModelSpaceTransform(model),
+  )
 }

--- a/packages/data-model/src/acis/AcDbAcisWireframe.ts
+++ b/packages/data-model/src/acis/AcDbAcisWireframe.ts
@@ -10,8 +10,10 @@ import {
   acdbSampleAcisSphereWireframe,
 } from './AcDbAcisGeometry'
 import {
-  acdbAcisModelSpaceTransform,
-  acdbAcisTransformSegments,
+  acdbAcisBuildNodeTransforms,
+  acdbAcisIdentityTransform,
+  acdbAcisTransformIsIdentity,
+  acdbAcisTransformPoint,
 } from './AcDbAcisTransform'
 
 /** Default number of samples when tessellating ellipse edges for wireframe output. */
@@ -37,18 +39,30 @@ function pushPolyline(segments: number[], points: readonly AcDbAcisVec3[]): void
 /**
  * Builds wireframe rings for sphere faces when edge-based wireframe is empty.
  *
+ * Samples in body space, then maps each face through its owning body transform.
+ *
  * @param model - Resolved ACIS model graph.
  * @returns Line-segment endpoint pairs for sphere surface scaffolds.
  */
 function acdbAcisWireframeSegmentsFromSphereFaces(model: AcDbAcisModel): Float32Array {
   const segments: number[] = []
+  const transformsByNode = acdbAcisBuildNodeTransforms(model)
+  const identity = acdbAcisIdentityTransform()
   for (const face of model.nodesOfType('face')) {
     const surfaceNode = refOfType(face, '-surface')
     if (surfaceNode?.type !== 'sphere-surface') continue
     const params = acdbAcisParseSurfaceParams(surfaceNode)
     if (params.kind !== 'sphere') continue
+    const transform = transformsByNode.get(face.index) ?? identity
     for (const ring of acdbSampleAcisSphereWireframe(params)) {
-      pushPolyline(segments, ring)
+      if (acdbAcisTransformIsIdentity(transform)) {
+        pushPolyline(segments, ring)
+        continue
+      }
+      pushPolyline(
+        segments,
+        ring.map(p => acdbAcisTransformPoint(p, transform)),
+      )
     }
   }
   return new Float32Array(segments)
@@ -117,11 +131,7 @@ export function acdbAcisWireframeSegmentsFromSab(
   if (edgeWireframe.length > 0) {
     return edgeWireframe
   }
-  // Sphere fallback reads raw surface records — apply the body transform here.
+  // Sphere fallback samples raw surfaces and applies per-face body transforms.
   const sphereWireframe = acdbAcisWireframeSegmentsFromSphereFaces(model)
-  if (sphereWireframe.length === 0) return null
-  return acdbAcisTransformSegments(
-    sphereWireframe,
-    acdbAcisModelSpaceTransform(model),
-  )
+  return sphereWireframe.length > 0 ? sphereWireframe : null
 }

--- a/packages/data-model/src/acis/index.ts
+++ b/packages/data-model/src/acis/index.ts
@@ -63,3 +63,13 @@ export {
   acdbAcisWireframeSegmentsFromSab,
 } from './AcDbAcisWireframe'
 export { acdbAcisWireframeSegmentsFromSatText } from './AcDbAcisSatWireframe'
+export {
+  acdbAcisModelSpaceTransform,
+  acdbAcisParseTransform,
+  acdbAcisTransformDirection,
+  acdbAcisTransformFromBody,
+  acdbAcisTransformIsIdentity,
+  acdbAcisTransformPoint,
+  acdbAcisTransformSegments,
+} from './AcDbAcisTransform'
+export type { AcDbAcisAffineTransform } from './AcDbAcisTransform'

--- a/packages/data-model/src/acis/index.ts
+++ b/packages/data-model/src/acis/index.ts
@@ -64,6 +64,8 @@ export {
 } from './AcDbAcisWireframe'
 export { acdbAcisWireframeSegmentsFromSatText } from './AcDbAcisSatWireframe'
 export {
+  acdbAcisBuildNodeTransforms,
+  acdbAcisIdentityTransform,
   acdbAcisModelSpaceTransform,
   acdbAcisParseTransform,
   acdbAcisTransformDirection,
@@ -71,5 +73,6 @@ export {
   acdbAcisTransformIsIdentity,
   acdbAcisTransformPoint,
   acdbAcisTransformSegments,
+  acdbAcisTransformsEqual,
 } from './AcDbAcisTransform'
 export type { AcDbAcisAffineTransform } from './AcDbAcisTransform'


### PR DESCRIPTION
## Summary
- Parse ACIS `body` `transform` entities and map SAB geometry from body space into model space (`p' = scale * (R * p) + t`).
- Apply the shared body transform in `acdbExtractAcisGeometry` (vertices, edges, analytic curves/surfaces) and in the sphere wireframe fallback path.
- Add unit coverage for identity detection, translation mapping (real anteensolids sample), direction transforms, and segment buffers.

## Test plan
- [x] `pnpm exec jest packages/data-model/__tests__/AcDbAcisTransform.spec.ts`
- [ ] Open a DWG/DXF with block-local 3DSOLID SAB (e.g. anteensolids equipment-03) and confirm solid wireframe aligns with nearby LWPOLYLINE/LINE geometry
- [ ] Spot-check a solid with identity transform still renders at the same place
- [ ] Multi-body solids with differing transforms remain in body space (documented limitation)