### PR TITLE
perf(data-model): load drawing fonts in one parallel batch

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -84,6 +84,52 @@ describe('AcDbDatabase', () => {
     expect(db.generateHandle()).toBe('FFFF')
   })
 
+  it('loads multiple fonts in one batch during FONT END', async () => {
+    const db = new AcDbDatabase()
+    const fileType = 'test-font-load-batch'
+    const fontLoader = {
+      load: jest.fn().mockResolvedValue(undefined),
+      getAvaiableFonts: jest.fn().mockResolvedValue([])
+    }
+    const converter = {
+      read: jest.fn(
+        async (
+          _data: ArrayBuffer,
+          _db: AcDbDatabase,
+          _minimumChunkSize: number,
+          progress?: (
+            percentage: number,
+            stage: string,
+            stageStatus: string,
+            data?: unknown
+          ) => Promise<void>
+        ) => {
+          if (progress) {
+            await progress(5, 'FONT', 'END', ['arial', 'simsun', 'hztxt'])
+          }
+        }
+      )
+    }
+    const manager = AcDbDatabaseConverterManager.instance
+    manager.register(fileType, converter as never)
+
+    try {
+      await db.read(
+        new ArrayBuffer(0),
+        { fontLoader, readOnly: true },
+        fileType
+      )
+      expect(fontLoader.load).toHaveBeenCalledTimes(1)
+      expect(fontLoader.load).toHaveBeenCalledWith([
+        'arial',
+        'simsun',
+        'hztxt'
+      ])
+    } finally {
+      manager.unregister(fileType)
+    }
+  })
+
   it('continues reading when font loading fails by default', async () => {
     const db = new AcDbDatabase()
     const fileType = 'test-font-load'

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -2314,28 +2314,23 @@ export class AcDbDatabase extends AcDbObject {
   }
 
   /**
-   * Loads fonts while emitting FONT IN-PROGRESS so the open-file bar keeps
-   * moving during multi-font downloads (native DXF parses on the main thread
-   * and previously appeared stuck at the FONT stage).
+   * Loads drawing fonts in one batch so {@link AcDbFontLoader.load} /
+   * FontManager can fetch+parse them in parallel (`Promise.allSettled`).
+   *
+   * Previously each font was awaited serially for finer progress ticks; on
+   * CDN-backed opens that turned FONT into a sum of download times (often
+   * tens of seconds). A single IN-PROGRESS event still nudges the open-file
+   * bar off FONT START before the batch wait.
    */
   private async loadFontsWithProgress(
     fontLoader: AcDbFontLoader,
     fonts: string[],
     basePercentage: number
   ): Promise<void> {
-    if (fonts.length <= 1) {
-      await fontLoader.load(fonts)
-      return
-    }
-
-    // Leave headroom before ENTITY (native converter starts ENTITY at 20%).
-    const span = Math.max(1, Math.min(5, 19 - basePercentage))
-    for (let i = 0; i < fonts.length; i++) {
-      await fontLoader.load([fonts[i]!])
-      const pct = Math.min(
-        19,
-        basePercentage + Math.round(((i + 1) / fonts.length) * span)
-      )
+    if (fonts.length > 1) {
+      // Leave headroom before ENTITY (native converter starts ENTITY at 20%).
+      const span = Math.max(1, Math.min(5, 19 - basePercentage))
+      const pct = Math.min(19, basePercentage + Math.round(span / 2))
       this.events.openProgress.dispatch({
         database: this,
         percentage: pct,
@@ -2345,6 +2340,8 @@ export class AcDbDatabase extends AcDbObject {
         data: fonts
       })
     }
+
+    await fontLoader.load(fonts)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Load all drawing fonts in a single `fontLoader.load(fonts)` call so FontManager can fetch and parse them in parallel instead of awaiting each font serially.
- Keep one FONT IN-PROGRESS progress tick for multi-font opens so the open-file bar does not appear stuck at FONT START.
- Add a unit test that asserts multiple fonts are passed to `load` in one batch during FONT END.

## Test plan
- [ ] Run `packages/data-model` unit tests, especially `AcDbDatabase.spec.ts`
- [ ] Open a drawing that references multiple CDN fonts and confirm FONT stage completes faster than serial loading
- [ ] Confirm open-file progress still advances off FONT START before fonts finish
- [ ] Confirm `failOnFontLoadError` / continue-on-error font failure behavior is unchanged
