### PR TITLE
fix(data-model): read HELIX, ARC_DIMENSION and 3DLINE from DXF

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfEntityAliases.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfEntityAliases.spec.ts
@@ -1,0 +1,275 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { acdbDxfInEntity } from '../src/dxf/AcDbDxfEntityFactory'
+import { AcDbArcDimension, AcDbLine, AcDbSpline } from '../src/entity'
+
+function createWorkingDb() {
+  const db = new AcDbDatabase()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+/** A degree-1 spline through four points, written as SPLINE group codes. */
+const SPLINE_PAIRS = [
+  '100',
+  'AcDbSpline',
+  '70',
+  '8',
+  '71',
+  '1',
+  '72',
+  '6',
+  '73',
+  '4',
+  '74',
+  '0',
+  '40',
+  '0.0',
+  '40',
+  '0.0',
+  '40',
+  '1.0',
+  '40',
+  '2.0',
+  '40',
+  '3.0',
+  '40',
+  '3.0',
+  '10',
+  '0.0',
+  '20',
+  '0.0',
+  '30',
+  '0.0',
+  '10',
+  '1.0',
+  '20',
+  '4.0',
+  '30',
+  '0.0',
+  '10',
+  '2.0',
+  '20',
+  '4.0',
+  '30',
+  '0.0',
+  '10',
+  '3.0',
+  '20',
+  '0.0',
+  '30',
+  '0.0'
+]
+
+describe('DXF entity type aliases', () => {
+  beforeEach(() => {
+    createWorkingDb()
+  })
+
+  it('reads 3DLINE, the DXF R10 name for LINE', () => {
+    const dxf = [
+      '0',
+      '3DLINE',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbLine',
+      '10',
+      '5.0',
+      '20',
+      '9.0',
+      '30',
+      '0.0',
+      '11',
+      '6.0',
+      '21',
+      '10.0',
+      '31',
+      '1.0',
+      '0',
+      'ENDSEC'
+    ].join('\n')
+
+    const entity = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf))
+    expect(entity).toBeInstanceOf(AcDbLine)
+    const line = entity as AcDbLine
+    expect(line.startPoint.x).toBeCloseTo(5)
+    expect(line.startPoint.y).toBeCloseTo(9)
+    expect(line.endPoint.x).toBeCloseTo(6)
+    expect(line.endPoint.y).toBeCloseTo(10)
+    expect(line.endPoint.z).toBeCloseTo(1)
+  })
+
+  it('reads ARC_DIMENSION, the arc-length dimension written under its own name', () => {
+    const dxf = [
+      '0',
+      'ARC_DIMENSION',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbDimension',
+      '10',
+      '50.0',
+      '20',
+      '40.0',
+      '30',
+      '0.0',
+      '11',
+      '50.0',
+      '21',
+      '41.875',
+      '31',
+      '0.0',
+      '70',
+      '40',
+      '100',
+      'AcDbArcDimension',
+      '13',
+      '30.0',
+      '23',
+      '20.0',
+      '33',
+      '0.0',
+      '14',
+      '70.0',
+      '24',
+      '20.0',
+      '34',
+      '0.0',
+      '15',
+      '50.0',
+      '25',
+      '-17.5',
+      '35',
+      '0.0',
+      '0',
+      'ENDSEC'
+    ].join('\n')
+
+    const entity = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf))
+    expect(entity).toBeInstanceOf(AcDbArcDimension)
+    const dim = entity as AcDbArcDimension
+    expect(dim.xLine1Point.x).toBeCloseTo(30)
+    expect(dim.xLine2Point.x).toBeCloseTo(70)
+    expect(dim.centerPoint.y).toBeCloseTo(-17.5)
+  })
+
+  it('reads HELIX through its AcDbSpline base class', () => {
+    const dxf = ['0', 'HELIX', '100', 'AcDbEntity', '8', '0']
+      .concat(SPLINE_PAIRS)
+      .concat(['0', 'ENDSEC'])
+      .join('\n')
+
+    const entity = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf))
+    expect(entity).toBeInstanceOf(AcDbSpline)
+    const extents = (entity as AcDbSpline).geometricExtents
+    expect(extents.min.x).toBeCloseTo(0)
+    expect(extents.max.x).toBeCloseTo(3)
+  })
+
+  it('stops HELIX at the AcDbHelix marker so axis fields are not read as spline data', () => {
+    // Groups 10/20/30 and 40 recur in the AcDbHelix section (axis base point
+    // and radius). Read as spline data they add a control point and a knot.
+    const helixTail = [
+      '100',
+      'AcDbHelix',
+      '90',
+      '33',
+      '91',
+      '29',
+      '10',
+      '900.0',
+      '20',
+      '900.0',
+      '30',
+      '0.0',
+      '11',
+      '0.0',
+      '21',
+      '0.0',
+      '31',
+      '0.0',
+      '12',
+      '0.0',
+      '22',
+      '0.0',
+      '32',
+      '1.0',
+      '40',
+      '6.82',
+      '41',
+      '3.0',
+      '42',
+      '0.333',
+      '290',
+      '1',
+      '280',
+      '1'
+    ]
+    const dxf = ['0', 'HELIX', '100', 'AcDbEntity', '8', '0']
+      .concat(SPLINE_PAIRS)
+      .concat(helixTail)
+      .concat(['0', 'ENDSEC'])
+      .join('\n')
+
+    const entity = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf))
+    expect(entity).toBeInstanceOf(AcDbSpline)
+    const extents = (entity as AcDbSpline).geometricExtents
+    // The (900, 900) axis base point must not have been folded into the curve.
+    expect(extents.max.x).toBeCloseTo(3)
+    expect(extents.max.y).toBeLessThan(10)
+  })
+
+  it('leaves the filer on the next entity after reading a HELIX', () => {
+    const dxf = ['0', 'HELIX', '100', 'AcDbEntity', '8', '0']
+      .concat(SPLINE_PAIRS)
+      .concat([
+        '100',
+        'AcDbHelix',
+        '90',
+        '33',
+        '40',
+        '6.82',
+        '0',
+        'LINE',
+        '100',
+        'AcDbEntity',
+        '8',
+        '0',
+        '100',
+        'AcDbLine',
+        '10',
+        '1.0',
+        '20',
+        '2.0',
+        '30',
+        '0.0',
+        '11',
+        '3.0',
+        '21',
+        '4.0',
+        '31',
+        '0.0',
+        '0',
+        'ENDSEC'
+      ])
+      .join('\n')
+
+    const filer = AcDbDxfFiler.fromString(dxf)
+    expect(acdbDxfInEntity(filer)).toBeInstanceOf(AcDbSpline)
+    // Trailing AcDbHelix pairs are left in the stream; the document reader
+    // skips non-zero codes, so mirror that before reading the next entity.
+    while (!filer.atEof) {
+      const item = filer.peekItem()
+      if (!item || Number(item.code) === 0) break
+      filer.readItem()
+    }
+    const line = acdbDxfInEntity(filer)
+    expect(line).toBeInstanceOf(AcDbLine)
+    expect((line as AcDbLine).endPoint.x).toBeCloseTo(3)
+  })
+})

--- a/packages/data-model/src/dxf/AcDbDxfEntityFactory.ts
+++ b/packages/data-model/src/dxf/AcDbDxfEntityFactory.ts
@@ -1,6 +1,6 @@
 import { AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
 
-import type { AcDbDxfFiler } from '../base/AcDbDxfFiler'
+import { AcDbDxfFiler } from '../base/AcDbDxfFiler'
 import { AcDb3dSolid } from '../entity/AcDb3dSolid'
 import { AcDbArc } from '../entity/AcDbArc'
 import { AcDbAttribute } from '../entity/AcDbAttribute'
@@ -34,6 +34,10 @@ import { AcDbViewport } from '../entity/AcDbViewport'
 import { AcDbWipeout } from '../entity/AcDbWipeout'
 import { AcDbXline } from '../entity/AcDbXline'
 import { acdbDxfInDimension } from './AcDbDxfDimensionAssembler'
+import {
+  acdbDrainDxfObjectPairs,
+  AcDbDxfPairArrayReader
+} from './AcDbDxfPairArrayReader'
 import { acdbDxfInPolyline } from './AcDbDxfPolylineAssembler'
 
 /**
@@ -43,7 +47,10 @@ import { acdbDxfInPolyline } from './AcDbDxfPolylineAssembler'
 export function acdbCreateEntityForDxfIn(typeName: string): AcDbEntity | null {
   const type = typeName.toUpperCase()
   switch (type) {
+    // DXF R10 wrote 3D lines as 3DLINE, with the same 10/20/30 + 11/21/31
+    // group codes AutoCAD later folded back into LINE.
     case 'LINE':
+    case '3DLINE':
       return new AcDbLine(new AcGePoint3d(), new AcGePoint3d())
     case 'CIRCLE':
       return new AcDbCircle(new AcGePoint3d(), 1)
@@ -134,6 +141,33 @@ export function acdbCreateEntityForDxfIn(typeName: string): AcDbEntity | null {
 }
 
 /**
+ * Reads a HELIX through its AcDbSpline base class.
+ *
+ * AcDbHelix derives from AcDbSpline, and the DXF record carries the complete
+ * `(100, AcDbSpline)` block, so the curve itself is fully described there.
+ * The trailing `(100, AcDbHelix)` fields have to be cut off first: they reuse
+ * groups 10/20/30 (axis base point) and 40 (radius), which the spline reader
+ * would otherwise append as a spurious control point and a knot that breaks
+ * the knot vector's ordering.
+ */
+function acdbDxfInHelix(filer: AcDbDxfFiler): AcDbEntity | null {
+  const pairs = acdbDrainDxfObjectPairs(filer)
+  const helixMarker = pairs.findIndex(
+    pair => pair.code === 100 && pair.value === 'AcDbHelix'
+  )
+  const spline = acdbCreateEntityForDxfIn('SPLINE')
+  if (!spline) return null
+  const replay = AcDbDxfFiler.forReading(
+    new AcDbDxfPairArrayReader(
+      helixMarker < 0 ? pairs : pairs.slice(0, helixMarker)
+    ),
+    { database: filer.database }
+  )
+  spline.dxfIn(replay)
+  return spline
+}
+
+/**
  * Create entity from the current filer position.
  * Expects the filer to be at (or just past) the type name pair (0, TYPENAME).
  * When `typeName` is omitted, reads the next (0, name) pair.
@@ -157,8 +191,14 @@ export function acdbDxfInEntity(
   if (upper === 'POLYLINE') {
     return acdbDxfInPolyline(filer)
   }
-  if (upper === 'DIMENSION') {
+  // ARC_DIMENSION is a DIMENSION record written under its own type name
+  // (AutoCAD 2004+ arc-length dimension). The assembler already dispatches
+  // AcDbArcDimension from the (100, subclass) marker, so it only needs routing.
+  if (upper === 'DIMENSION' || upper === 'ARC_DIMENSION') {
     return acdbDxfInDimension(filer)
+  }
+  if (upper === 'HELIX') {
+    return acdbDxfInHelix(filer)
   }
 
   const entity = acdbCreateEntityForDxfIn(name)


### PR DESCRIPTION
# fix(data-model): read HELIX, ARC_DIMENSION and 3DLINE from DXF

**Branch:** `fix/dxf-helix-arcdim-3dline`

## Problem

`acdbCreateEntityForDxfIn` has no case for these three DXF type names, so
`acdbDxfInEntity` returns `null` and `AcDbDxfDocumentReader` skips the record
with `skipToEndOfObject()`. Nothing is logged, so part — or all — of a drawing
disappears without a warning. `LibreDWG/test/test-data/2007_Helix.dxf` opens
completely blank for this reason.

In all three cases the reader that would handle the entity already exists.
Only the type-name dispatch was missing.

## Change

| Type | Why it is skipped today | Fix |
| --- | --- | --- |
| `ARC_DIMENSION` | AutoCAD 2004+ writes the arc-length dimension under its own type name, not as `DIMENSION` | Route to `acdbDxfInDimension`, which already dispatches `AcDbArcDimension` from the `(100, subclass)` marker |
| `3DLINE` | DXF R10 name for a 3D line | Case fallthrough to `AcDbLine`; the group codes (`10/20/30`, `11/21/31`) are identical |
| `HELIX` | no case | Read through the `AcDbSpline` base class |

### Why HELIX needs more than a fallthrough

`AcDbHelix` derives from `AcDbSpline` and the record carries the complete
`(100, AcDbSpline)` block, so the curve itself is fully described there.

But the trailing `(100, AcDbHelix)` section **reuses group codes 10/20/30**
(axis base point) and **40** (radius). Handing the whole record to the spline
reader appends them as an extra control point and an extra knot. In
`2007_Helix.dxf` that turns 44 control points / 48 knots into 45 / 49 — the
counts stay self-consistent by coincidence, so `fromControlPoints` succeeds, but
the appended knot (6.83) sits below the preceding ones and breaks the knot
vector's ordering:

| | max.x of the resulting curve |
| --- | --- |
| whole record to the spline reader | 8.60 |
| truncated at the `AcDbHelix` marker | **8.99** (matches the last control point, 8.989) |

So `acdbDxfInHelix` drains the record, cuts it at the marker and replays the
spline pairs through a `AcDbDxfPairArrayReader` — the same pattern
`acdbDxfInDimension` already uses. Leftover pairs stay in the stream and are
consumed by the document reader's existing "skip non-zero codes" loop.

## Tests

`packages/data-model/__tests__/AcDbDxfEntityAliases.spec.ts` — 5 cases,
including one that puts a `(900, 900)` axis base point in the `AcDbHelix` tail
and asserts it does not reach the curve, and one that checks the filer is left
positioned so the next entity still reads.

## Validation

Measured over a 2,535-file DXF corpus assembled from the LibreCAD, QCAD,
LibreDWG, ezdxf, bjnortier/dxf, CadQuery and FreeCAD test suites: **14 files
gain entities, none lose any.**

```
LibreDWG 2007_Helix.dxf                    0 ->  1
qcad dimarclength005.dxf                   2 ->  4
LibreDWG example_2000/04/07/10/13/18.dxf  64 -> 65   (6 files)
LibreDWG r9 / r10 / r2.6_entities.dxf   14~15 -> 15~16
ezdxf uncommon.dxf                        78 -> 79
qcad Edit_Esc_Tests entities.dxf          33 -> 34   (2 files)
```

`pnpm test` 1102 passed, `pnpm lint` and `pnpm build` clean.

## Note on 3DLINE

Real DXF R10 files are written without `(100, subclass)` markers, and
`AcDbEntity.dxfInFields` currently swallows the geometry of marker-less
entities. So on `main` this change creates the `AcDbLine` but its endpoints stay
at the origin. That is a separate defect — see the companion PR
"keep geometry of DXF entities without subclass markers". The two are
independent; this one is correct on its own and the tests here supply the
markers explicitly.

## Still skipped after this change

For the record, the type names present in that corpus that still have no
reader: `REGION` and the `*SURFACE` family (ACIS, needs a modeler), `MESH`,
`LIGHT`, `PDFUNDERLAY`, `SECTIONOBJECT`, `REPEAT`/`ENDREP` (DXF R2.10) and
`LARGE_RADIAL_DIMENSION`.

`LARGE_RADIAL_DIMENSION` was deliberately left out: its subclass marker is
`AcDbRadialDimensionLarge`, where groups 15/25/35 are the *override centre*,
while `AcDbRadialDimension` reads them as the point on the curve. Mapping it
would draw the dimension in the wrong place instead of omitting it — worse than
the current behaviour for the 2 instances in the corpus.
