### PR TITLE
fix(data-model): skip a malformed DXF entity instead of aborting the read

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfMalformedEntity.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfMalformedEntity.spec.ts
@@ -1,0 +1,176 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { AcDbDxfDocumentReader } from '../src/dxf'
+import { AcDbLine } from '../src/entity'
+
+function createWorkingDb() {
+  const db = new AcDbDatabase()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+function entity(type: string, ...pairs: string[]) {
+  return ['0', type, '100', 'AcDbEntity', '8', '0', ...pairs]
+}
+
+/**
+ * A CIRCLE with a negative radius — AcGeCircArc3d rejects it with
+ * "Illegal Parameters".
+ * Sits between two well-formed LINEs so a swallowed exception is visible as
+ * missing geometry rather than as a thrown error.
+ */
+const DXF_WITH_BAD_CIRCLE = [
+  '0',
+  'SECTION',
+  '2',
+  'ENTITIES',
+  ...entity(
+    'LINE',
+    '100',
+    'AcDbLine',
+    '10',
+    '0.0',
+    '20',
+    '0.0',
+    '30',
+    '0.0',
+    '11',
+    '10.0',
+    '21',
+    '0.0',
+    '31',
+    '0.0'
+  ),
+  ...entity(
+    'CIRCLE',
+    '100',
+    'AcDbCircle',
+    '10',
+    '5.0',
+    '20',
+    '5.0',
+    '30',
+    '0.0',
+    '40',
+    '-1.0'
+  ),
+  ...entity(
+    'LINE',
+    '100',
+    'AcDbLine',
+    '10',
+    '0.0',
+    '20',
+    '20.0',
+    '30',
+    '0.0',
+    '11',
+    '10.0',
+    '21',
+    '20.0',
+    '31',
+    '0.0'
+  ),
+  '0',
+  'ENDSEC',
+  '0',
+  'EOF'
+].join('\n')
+
+describe('AcDbDxfDocumentReader malformed entity handling', () => {
+  let warn: jest.SpyInstance
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it('skips an entity whose reader throws and keeps the rest of the drawing', async () => {
+    const db = createWorkingDb()
+    const reader = new AcDbDxfDocumentReader(db)
+    const result = await reader.read(
+      AcDbDxfFiler.fromString(DXF_WITH_BAD_CIRCLE)
+    )
+
+    const entities = [...db.tables.blockTable.modelSpace.newIterator()]
+    expect(entities).toHaveLength(2)
+    expect(entities.every(e => e instanceof AcDbLine)).toBe(true)
+    // Crucially the LINE *after* the bad CIRCLE survives.
+    expect((entities[1] as AcDbLine).startPoint.y).toBeCloseTo(20)
+
+    expect(result.malformedEntityCount).toBe(1)
+    expect(result.unknownEntityCount).toBe(0)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped malformed CIRCLE entity')
+    )
+  })
+
+  it('counts an unknown type name separately from a malformed one', async () => {
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      ...entity('NOT_A_REAL_ENTITY', '90', '1'),
+      ...entity(
+        'LINE',
+        '100',
+        'AcDbLine',
+        '10',
+        '0.0',
+        '20',
+        '0.0',
+        '30',
+        '0.0',
+        '11',
+        '1.0',
+        '21',
+        '1.0',
+        '31',
+        '0.0'
+      ),
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF'
+    ].join('\n')
+
+    const db = createWorkingDb()
+    const reader = new AcDbDxfDocumentReader(db)
+    const result = await reader.read(AcDbDxfFiler.fromString(dxf))
+
+    expect([...db.tables.blockTable.modelSpace.newIterator()]).toHaveLength(1)
+    expect(result.unknownEntityCount).toBe(1)
+    expect(result.malformedEntityCount).toBe(0)
+  })
+
+  it('stops warning after the first ten malformed entities', async () => {
+    const badCircle = entity(
+      'CIRCLE',
+      '100',
+      'AcDbCircle',
+      '10',
+      '0.0',
+      '20',
+      '0.0',
+      '30',
+      '0.0',
+      '40',
+      '-1.0'
+    )
+    const dxf = ['0', 'SECTION', '2', 'ENTITIES']
+      .concat(...Array.from({ length: 12 }, () => badCircle))
+      .concat(['0', 'ENDSEC', '0', 'EOF'])
+      .join('\n')
+
+    const db = createWorkingDb()
+    const reader = new AcDbDxfDocumentReader(db)
+    const result = await reader.read(AcDbDxfFiler.fromString(dxf))
+
+    expect(result.malformedEntityCount).toBe(12)
+    expect(warn).toHaveBeenCalledTimes(10)
+  })
+})

--- a/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
+++ b/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
@@ -62,8 +62,13 @@ export interface AcDbDxfDocumentReaderResult {
   unknownEntityCount: number
   /** OBJECTS-section types that were skipped (no native reader yet). */
   unknownObjectCount: number
+  /** Entities of a known type whose reader threw and were skipped. */
+  malformedEntityCount: number
   fonts: string[]
 }
+
+/** How many malformed entities are reported to the console before going quiet. */
+const MALFORMED_ENTITY_WARN_LIMIT = 10
 
 /**
  * Single-pass streaming DXF document reader.
@@ -75,6 +80,7 @@ export interface AcDbDxfDocumentReaderResult {
 export class AcDbDxfDocumentReader {
   private _unknownEntityCount = 0
   private _unknownObjectCount = 0
+  private _malformedEntityCount = 0
   private readonly _fonts = new Set<string>()
   /** ATTRIB entities waiting for their owning INSERT (keyed by INSERT objectId). */
   private readonly _attributeMap = new Map<AcDbObjectId, AcDbAttribute[]>()
@@ -97,6 +103,10 @@ export class AcDbDxfDocumentReader {
     return this._unknownObjectCount
   }
 
+  get malformedEntityCount() {
+    return this._malformedEntityCount
+  }
+
   get fonts(): string[] {
     return [...this._fonts]
   }
@@ -104,6 +114,7 @@ export class AcDbDxfDocumentReader {
   async read(filer: AcDbDxfFiler): Promise<AcDbDxfDocumentReaderResult> {
     this._unknownEntityCount = 0
     this._unknownObjectCount = 0
+    this._malformedEntityCount = 0
     this._fonts.clear()
     this._attributeMap.clear()
     filer.database = this._db
@@ -127,8 +138,48 @@ export class AcDbDxfDocumentReader {
     return {
       unknownEntityCount: this._unknownEntityCount,
       unknownObjectCount: this._unknownObjectCount,
+      malformedEntityCount: this._malformedEntityCount,
       fonts: this.fonts
     }
+  }
+
+  /**
+   * Reads one entity, treating a reader that throws as a skipped entity.
+   *
+   * Real drawings ship the occasional out-of-spec record — a CIRCLE with
+   * radius 0 makes the geometry engine throw `Illegal Parameters` — and
+   * letting that escape aborts the whole document, so one bad entity costs
+   * the caller every other entity in the file. Skip it the same way an
+   * unknown type name is skipped.
+   *
+   * Also absorbs the unknown-type case, so both kinds of skip advance the
+   * filer past the record exactly once.
+   *
+   * @returns The entity, or `null` when the type is unknown or the read threw
+   */
+  private readEntityTolerantly(
+    filer: AcDbDxfFiler,
+    typeName: string
+  ): AcDbEntity | null {
+    let entity: AcDbEntity | null = null
+    try {
+      entity = acdbDxfInEntity(filer, typeName)
+    } catch (error) {
+      this._malformedEntityCount += 1
+      if (this._malformedEntityCount <= MALFORMED_ENTITY_WARN_LIMIT) {
+        const reason = error instanceof Error ? error.message : String(error)
+        console.warn(
+          `[AcDbDxfDocumentReader] Skipped malformed ${typeName} entity: ${reason}`
+        )
+      }
+      filer.skipToEndOfObject()
+      return null
+    }
+    if (!entity) {
+      this._unknownEntityCount += 1
+      filer.skipToEndOfObject()
+    }
+    return entity
   }
 
   private readSectionName(filer: AcDbDxfFiler): string {
@@ -375,9 +426,14 @@ export class AcDbDxfDocumentReader {
   private readTable(filer: AcDbDxfFiler, tableName: string) {
     switch (tableName) {
       case 'LAYER':
-        this.readNamedTable(filer, 'LAYER', () => new AcDbLayerTableRecord(), r => {
-          if (r.name) this._db.tables.layerTable.add(r)
-        })
+        this.readNamedTable(
+          filer,
+          'LAYER',
+          () => new AcDbLayerTableRecord(),
+          r => {
+            if (r.name) this._db.tables.layerTable.add(r)
+          }
+        )
         break
       case 'LTYPE':
         this.readNamedTable(
@@ -620,16 +676,13 @@ export class AcDbDxfDocumentReader {
         continue
       }
       // POLYLINE/DIMENSION composites are handled inside acdbDxfInEntity.
-      const entity = acdbDxfInEntity(filer, typeName)
+      const entity = this.readEntityTolerantly(filer, typeName)
       if (entity) {
         // Model/paper geometry lives in ENTITIES; skip space BTRs here to
         // avoid duplicating entities that also appear with group 67 / owner.
         if (this.shouldAcceptBlockEntity(btr)) {
           this.acceptEntity(entity, btr)
         }
-      } else {
-        this._unknownEntityCount += 1
-        filer.skipToEndOfObject()
       }
 
       sinceYield += 1
@@ -789,12 +842,9 @@ export class AcDbDxfDocumentReader {
         continue
       }
       // POLYLINE/DIMENSION composites are handled inside acdbDxfInEntity.
-      const entity = acdbDxfInEntity(filer, name)
+      const entity = this.readEntityTolerantly(filer, name)
       if (entity) {
         this.acceptEntity(entity, this.resolveEntityOwner(entity, modelSpace))
-      } else {
-        this._unknownEntityCount += 1
-        filer.skipToEndOfObject()
       }
 
       sinceYield += 1
@@ -832,10 +882,7 @@ export class AcDbDxfDocumentReader {
   /**
    * Appends an entity (or links ATTRIB → INSERT) and collects inline fonts.
    */
-  private acceptEntity(
-    entity: AcDbEntity,
-    owner: AcDbBlockTableRecord
-  ): void {
+  private acceptEntity(entity: AcDbEntity, owner: AcDbBlockTableRecord): void {
     if (entity instanceof AcDbAttribute) {
       this.collectInlineFontsFromEntity(entity)
       this.linkOrDeferAttribute(entity, owner)
@@ -966,7 +1013,10 @@ export class AcDbDxfDocumentReader {
   private async reportParseProgress(filer: AcDbDxfFiler) {
     const { onProgress, totalBytes } = this._options
     if (!onProgress || !totalBytes || totalBytes <= 0) return
-    const ratio = Math.min(1, Math.max(0, filer.position().byteOffset / totalBytes))
+    const ratio = Math.min(
+      1,
+      Math.max(0, filer.position().byteOffset / totalBytes)
+    )
     await onProgress(ratio)
   }
 


### PR DESCRIPTION
# fix(data-model): skip a malformed DXF entity instead of aborting the read

**Branch:** `fix/dxf-skip-malformed-entity`

## Problem

`acdbDxfInEntity` can throw on an out-of-spec record. A `CIRCLE` with a
negative radius makes `AcGeCircArc3d` reject it with `Illegal Parameters`;
`ezdxf/examples/dxf/circle_radius_le_0.dxf` contains exactly that.

Nothing catches it, so the exception propagates out of
`AcDbDxfDocumentReader.read` and the whole open fails. One bad entity costs the
caller **every other entity in the file** — a 100k-entity drawing fails to open
because of a single degenerate circle.

## Change

Catch at the same place an unknown type name is already handled: warn, count,
`skipToEndOfObject()`, carry on.

The two skip paths (unknown type / throwing reader) are now one helper,
`readEntityTolerantly`, so each advances the filer past the record exactly once
— on `main` the `else` branch is duplicated at both call sites.

`AcDbDxfDocumentReaderResult` gains `malformedEntityCount` alongside the
existing `unknownEntityCount`, so a host can distinguish a partially-read
drawing from a clean one and surface that to the user.

Console warnings stop after 10 entities so a badly-generated file cannot flood
the console.

## Tests

`packages/data-model/__tests__/AcDbDxfMalformedEntity.spec.ts` — 3 cases:

- a bad `CIRCLE` between two `LINE`s; the second `LINE` still lands in model
  space and `malformedEntityCount` is 1
- an unknown type name counts as `unknownEntityCount`, not `malformedEntityCount`
- 12 bad circles produce exactly 10 warnings

## Validation

`pnpm test` 1100 passed, `pnpm lint` and `pnpm build` clean.

Over a 2,535-file DXF corpus (LibreCAD, QCAD, LibreDWG, ezdxf, bjnortier/dxf,
CadQuery, FreeCAD test suites) this is the only entity in the whole set that
throws — but without the guard it takes its entire file down with it.

## Note

This makes a genuinely broken record survivable, which also means a systematic
reader bug now shows up as a warning stream rather than a hard failure. That is
why the count is returned rather than only logged: `malformedEntityCount > 0`
is meant to be actionable for the host, not silently swallowed.
