### PR TITLE
fix(data-model): keep geometry of DXF entities without subclass markers

### DIFF
--- a/packages/data-model/__tests__/AcDbEntityWithoutSubclassMarker.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntityWithoutSubclassMarker.spec.ts
@@ -1,0 +1,115 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { acdbDxfInEntity } from '../src/dxf/AcDbDxfEntityFactory'
+import { AcDbCircle, AcDbLine, AcDbText } from '../src/entity'
+
+function createWorkingDb() {
+  const db = new AcDbDatabase()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+describe('entities written without (100, subclass) markers', () => {
+  beforeEach(() => {
+    createWorkingDb()
+  })
+
+  it('keeps LINE geometry in a DXF R12-style record', () => {
+    // No AcDbEntity / AcDbLine markers — how every AC1009 file is written.
+    const dxf = [
+      '0',
+      'LINE',
+      '8',
+      'A',
+      '62',
+      '3',
+      '10',
+      '1.0',
+      '20',
+      '2.0',
+      '30',
+      '0.0',
+      '11',
+      '4.0',
+      '21',
+      '6.0',
+      '31',
+      '0.0',
+      '0',
+      'ENDSEC'
+    ].join('\n')
+
+    const line = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf)) as AcDbLine
+    expect(line).toBeInstanceOf(AcDbLine)
+    // Common fields before the geometry are still read.
+    expect(line.layer).toBe('A')
+    expect(line.color.colorIndex).toBe(3)
+    expect(line.startPoint.x).toBeCloseTo(1)
+    expect(line.startPoint.y).toBeCloseTo(2)
+    expect(line.endPoint.x).toBeCloseTo(4)
+    expect(line.endPoint.y).toBeCloseTo(6)
+  })
+
+  it('keeps CIRCLE geometry in a marker-less record', () => {
+    const dxf = [
+      '0',
+      'CIRCLE',
+      '8',
+      '0',
+      '10',
+      '3.0',
+      '20',
+      '4.0',
+      '30',
+      '0.0',
+      '40',
+      '5.0',
+      '0',
+      'ENDSEC'
+    ].join('\n')
+
+    const circle = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf)) as AcDbCircle
+    expect(circle).toBeInstanceOf(AcDbCircle)
+    expect(circle.center.x).toBeCloseTo(3)
+    expect(circle.center.y).toBeCloseTo(4)
+    expect(circle.radius).toBeCloseTo(5)
+  })
+
+  it('still lets a marked entity carry trailing codes the base class ignores', () => {
+    // TEXT with markers present: group 7 (style) and 72/73 belong to the
+    // derived reader and must not terminate the common-field loop early.
+    const dxf = [
+      '0',
+      'TEXT',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '62',
+      '5',
+      '100',
+      'AcDbText',
+      '10',
+      '2.0',
+      '20',
+      '3.0',
+      '30',
+      '0.0',
+      '40',
+      '2.5',
+      '1',
+      'HELLO',
+      '7',
+      'STANDARD',
+      '0',
+      'ENDSEC'
+    ].join('\n')
+
+    const text = acdbDxfInEntity(AcDbDxfFiler.fromString(dxf)) as AcDbText
+    expect(text).toBeInstanceOf(AcDbText)
+    expect(text.color.colorIndex).toBe(5)
+    expect(text.textString).toBe('HELLO')
+    expect(text.height).toBeCloseTo(2.5)
+    expect(text.position.x).toBeCloseTo(2)
+  })
+})

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -425,7 +425,8 @@ export abstract class AcDbEntity extends AcDbObject {
     super.dxfInFields(filer)
 
     // Tolerate missing AcDbEntity marker (some writers omit it).
-    if (!filer.atSubclassData('AcDbEntity')) {
+    const hasSubclassMarker = filer.atSubclassData('AcDbEntity')
+    if (!hasSubclassMarker) {
       const next = filer.peekItem()
       if (next && Number(next.code) === 100) {
         // Different subclass — leave for derived class.
@@ -492,6 +493,20 @@ export abstract class AcDbEntity extends AcDbObject {
           // Stay resilient to unknown AcDbEntity codes (forward compatible).
           // Do not push back — that would abort derived subclass readers
           // (TEXT/MTEXT/DIMENSION/TABLE often carry layout/material extras).
+          //
+          // That reasoning only holds while a (100, subclass) marker delimits
+          // this section. Marker-less entities — every DXF R12 (AC1009) file,
+          // plus minimal writers that omit the markers in later versions —
+          // have no delimiter, so swallowing unknown codes consumes the whole
+          // record including the geometry (10/20/30, 11/21/31, ...). The
+          // derived reader then gets an exhausted filer, keeps its defaults,
+          // and every LINE collapses to a degenerate point at the origin,
+          // which makes the layout extents empty and the drawing render
+          // blank. Hand the first unknown code to the derived reader instead.
+          if (!hasSubclassMarker) {
+            filer.pushBackItem(item)
+            return this
+          }
           break
       }
     }


### PR DESCRIPTION
# fix(data-model): keep geometry of DXF entities without subclass markers

**Branch:** `fix/dxf-entity-without-subclass-marker`

## Problem

Drawings written without `(100, subclass)` markers open **completely blank**.
That is every DXF R12 (AC1009) file, plus minimal writers in later versions —
the `bridge`, `cube` and `diamond` samples shipped with DWG TrueView 2027 are
all affected.

## Root cause

`AcDbEntity.dxfInFields` reads the common entity fields in a loop whose
`default:` branch **drops** unrecognised group codes rather than pushing them
back. The existing comment explains why:

```ts
default:
  // Stay resilient to unknown AcDbEntity codes (forward compatible).
  // Do not push back — that would abort derived subclass readers
  // (TEXT/MTEXT/DIMENSION/TABLE often carry layout/material extras).
  break
```

That reasoning holds only while a `(100, subclass)` marker delimits the common
section — the loop breaks on code 100 and hands over.

With no marker there is no delimiter, so the loop runs to the end of the record
and swallows the geometry with it: `10/20/30`, `11/21/31`, and so on. The
derived reader (`AcDbLine.dxfInFields`, …) then receives an exhausted filer,
keeps its constructor defaults, and every `LINE` becomes a degenerate point at
the origin. Layout extents collapse to a zero box, zoom-extents has nothing to
frame, and the viewport is empty.

## Change

Push the first unrecognised code back when no marker was seen. The marked path
is untouched, so the forward-compatibility behaviour the comment protects is
preserved exactly.

## Validation

Geometric extents of the first entities, before → after:

```
sample_cube.dxf      (0,0)..(0,0)  ->  (-0.5,-0.5)..(0.5,-0.5)
mfg_min_ac1006.dxf   (0,0)..(0,0)  ->  (-0.5,-0.5)..(0.5,0.5)
mfg_ac1003_line.dxf  (0,0)..(0,0)  ->  (1.5,0)..(2,0)
sample_bridge.dxf    all 261 at origin -> real truss geometry
```

`pnpm test` 1100 passed (1097 on `main` + the 3 added here), `pnpm lint` and
`pnpm build` clean. The existing TEXT/MTEXT/DIMENSION/TABLE suites — the ones
the `default:` comment is about — all still pass.

## Tests

`packages/data-model/__tests__/AcDbEntityWithoutSubclassMarker.spec.ts`:

- marker-less `LINE`: layer and ACI *and* both endpoints survive
- marker-less `CIRCLE`: centre and radius survive
- marked `TEXT`: group 7 (style) after the derived fields still does not
  terminate the common loop early — the case the current `default:` protects
