### PR TITLE
fix(data-model): ignore a zero DXF group 420 that follows a real ACI

### DIFF
--- a/packages/data-model/__tests__/AcDbEntityZeroTrueColor.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntityZeroTrueColor.spec.ts
@@ -1,0 +1,68 @@
+import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
+import { AcDbDatabase } from '../src/database'
+import { acdbDxfInEntity } from '../src/dxf/AcDbDxfEntityFactory'
+import { AcDbLine } from '../src/entity'
+
+function createWorkingDb() {
+  const db = new AcDbDatabase()
+  acdbHostApplicationServices().workingDatabase = db
+  return db
+}
+
+function lineDxf(...colorPairs: string[]) {
+  return [
+    '0',
+    'LINE',
+    '100',
+    'AcDbEntity',
+    '8',
+    '0',
+    ...colorPairs,
+    '100',
+    'AcDbLine',
+    '10',
+    '0.0',
+    '20',
+    '0.0',
+    '30',
+    '0.0',
+    '11',
+    '1.0',
+    '21',
+    '1.0',
+    '31',
+    '0.0',
+    '0',
+    'ENDSEC'
+  ].join('\n')
+}
+
+describe('DXF group 420 with a zero true colour', () => {
+  beforeEach(() => {
+    createWorkingDb()
+  })
+
+  it('keeps the ACI when a writer emits 420 0 next to a real colour index', () => {
+    const line = acdbDxfInEntity(
+      AcDbDxfFiler.fromString(lineDxf('62', '18', '420', '0'))
+    ) as AcDbLine
+    expect(line.color.colorIndex).toBe(18)
+    expect(line.color.isByColor).toBe(false)
+  })
+
+  it('still applies a non-zero true colour over the ACI', () => {
+    const line = acdbDxfInEntity(
+      AcDbDxfFiler.fromString(lineDxf('62', '18', '420', String(0xff8000)))
+    ) as AcDbLine
+    expect(line.color.isByColor).toBe(true)
+    expect(line.color.RGB).toBe(0xff8000)
+  })
+
+  it('applies 420 0 as black when no colour index preceded it', () => {
+    const line = acdbDxfInEntity(
+      AcDbDxfFiler.fromString(lineDxf('420', '0'))
+    ) as AcDbLine
+    expect(line.color.isByColor).toBe(true)
+    expect(line.color.RGB).toBe(0)
+  })
+})

--- a/packages/data-model/__tests__/AcDbEntityZeroTrueColor.spec.ts
+++ b/packages/data-model/__tests__/AcDbEntityZeroTrueColor.spec.ts
@@ -1,5 +1,5 @@
 import { AcDbDxfFiler, acdbHostApplicationServices } from '../src/base'
-import { AcDbDatabase } from '../src/database'
+import { AcDbDatabase, AcDbLayerTableRecord } from '../src/database'
 import { acdbDxfInEntity } from '../src/dxf/AcDbDxfEntityFactory'
 import { AcDbLine } from '../src/entity'
 
@@ -64,5 +64,57 @@ describe('DXF group 420 with a zero true colour', () => {
     ) as AcDbLine
     expect(line.color.isByColor).toBe(true)
     expect(line.color.RGB).toBe(0)
+  })
+})
+
+describe('DXF group 420 with a zero true colour on a LAYER record', () => {
+  function readLayer(...colorPairs: string[]) {
+    // dxfIn expects the filer to sit just past the (0, LAYER) pair.
+    const dxf = [
+      '5',
+      '6E',
+      '100',
+      'AcDbSymbolTableRecord',
+      '100',
+      'AcDbLayerTableRecord',
+      '2',
+      'Default',
+      '70',
+      '0',
+      ...colorPairs,
+      '6',
+      'Continuous',
+      '0',
+      'ENDTAB'
+    ].join('\n')
+    const layer = new AcDbLayerTableRecord()
+    layer.dxfIn(AcDbDxfFiler.fromString(dxf))
+    return layer
+  }
+
+  beforeEach(() => {
+    createWorkingDb()
+  })
+
+  it('keeps the layer ACI when a writer emits 420 0 after it', () => {
+    // Worse here than on an entity: every ByLayer entity on the layer turns
+    // black and the drawing opens empty. bjnortier/dxf's 1x1rectangle.dxf
+    // writes `62 178` then `420 0` on layer "Default".
+    const layer = readLayer('62', '178', '420', '0')
+    expect(layer.name).toBe('Default')
+    expect(layer.color.colorIndex).toBe(178)
+    expect(layer.color.isByColor).toBe(false)
+  })
+
+  it('still applies a non-zero layer true colour', () => {
+    const layer = readLayer('62', '178', '420', String(0x336699))
+    expect(layer.color.isByColor).toBe(true)
+    expect(layer.color.RGB).toBe(0x336699)
+  })
+
+  it('applies 420 0 as black on a layer with no colour index', () => {
+    const layer = readLayer('420', '0')
+    expect(layer.color.isByColor).toBe(true)
+    expect(layer.color.RGB).toBe(0)
   })
 })

--- a/packages/data-model/src/database/AcDbLayerTableRecord.ts
+++ b/packages/data-model/src/database/AcDbLayerTableRecord.ts
@@ -420,6 +420,8 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
     filer.atSubclassData('AcDbSymbolTableRecord')
     filer.atSubclassData('AcDbLayerTableRecord')
 
+    let sawAciColor = false
+
     while (!filer.atEndOfObject && !filer.atEof && !filer.atExtendedData) {
       const item = filer.readItem()
       if (!item) break
@@ -439,10 +441,18 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
           const aci = Number(item.value)
           this.isOff = aci < 0
           this.color.colorIndex = Math.abs(aci)
+          sawAciColor = true
           break
         }
         case 420:
-          this.color.setRGBValue(Number(item.value))
+          // Same writer bug as AcDbEntity: group 420 packs a 24-bit RGB, so 0
+          // is indistinguishable from "no true colour", and generators emit it
+          // next to a real index. On a layer it is worse than on an entity —
+          // every ByLayer entity on that layer turns black and the drawing
+          // opens empty. QCAD and dxflib samples do this on layer "0".
+          if (Number(item.value) !== 0 || !sawAciColor) {
+            this.color.setRGBValue(Number(item.value))
+          }
           break
         case 6:
           this.linetype = String(item.value)
@@ -466,4 +476,3 @@ export class AcDbLayerTableRecord extends AcDbSymbolTableRecord<AcDbLayerTableRe
     return this
   }
 }
-

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -433,6 +433,8 @@ export abstract class AcDbEntity extends AcDbObject {
       }
     }
 
+    let sawAciColor = false
+
     while (!filer.atEndOfObject && !filer.atEof && !filer.atExtendedData) {
       const item = filer.readItem()
       if (!item) break
@@ -459,9 +461,20 @@ export abstract class AcDbEntity extends AcDbObject {
           break
         case 62:
           this.color.colorIndex = Number(item.value)
+          sawAciColor = true
           break
         case 420:
-          this.color.setRGBValue(Number(item.value))
+          // Group 420 packs a 24-bit RGB, so 0 is indistinguishable from
+          // "no true colour was written". Some generators emit `420 0`
+          // unconditionally next to a real ACI — every entity in the
+          // deskproto CNC sample pairs `62 18` with `420 0`. Taking that
+          // literally repaints the whole drawing black, which is invisible
+          // against AutoCAD's black model space. When an explicit ACI came
+          // first, keep it; a genuinely black true colour is unreadable
+          // there anyway.
+          if (Number(item.value) !== 0 || !sawAciColor) {
+            this.color.setRGBValue(Number(item.value))
+          }
           break
         case 370:
           this.lineWeight = Number(item.value)


### PR DESCRIPTION
# fix(data-model): ignore a zero DXF group 420 that follows a real ACI

**Branch:** `fix/dxf-ignore-zero-truecolor`

## Problem

DXF group 420 packs a 24-bit RGB, so the value `0` is indistinguishable from
"no true colour was written".

Some generators emit `420 0` on every entity next to a meaningful colour index.
A free CNC sample from deskproto.com pairs `62 18` with `420 0` on all 96 of
its entities:

```
  0 | ARC
100 | AcDbEntity
  8 | 0
  6 | Continuous
 62 | 18
420 | 0        <- not a colour, just an unset field
370 | 15
```

Read literally, `setRGBValue(0)` switches the colour method to ByColor and
repaints the whole drawing black — invisible against AutoCAD's black model
space, so the file looks empty.

## The same bug on LAYER records — and there it hides whole drawings

`AcDbLayerTableRecord.dxfInFields` has the identical `case 420`. A layer read
as black makes every ByLayer entity on it invisible against the default black
background, so the drawing opens **completely empty** even though every entity
parsed correctly.

`bjnortier/dxf`'s `1x1rectangle.dxf` writes `62 178` then `420 0` on layer
"Default" and renders nothing at all. Across a 2,547-file corpus, 17 of the 84
drawings that parse but draw nothing carry this pattern; QCAD templates and
dxflib samples do it on layer "0". Re-rendering those 17 after the fix, 11 go
from an empty canvas to real geometry (the other 6 are blank for an unrelated
reason).

## Change

Keep the ACI when an explicit group 62 preceded a zero 420, on both
`AcDbEntity` and `AcDbLayerTableRecord`.

Deliberately narrow:

- a **non-zero** 420 still overrides the index, exactly as before
- a **lone** `420 0` with no preceding index is still honoured as black

so only the self-contradictory pairing is treated as the writer bug it is, and
input that is valid per the spec keeps its current meaning.

## Tests

`packages/data-model/__tests__/AcDbEntityZeroTrueColor.spec.ts` — one case per
branch above, for entities and for layer records (6 tests).

## Validation

`pnpm test` 1103 passed, `pnpm lint` and `pnpm build` clean. Browser
verification of the 17 affected drawings is described above.

## Honest caveat

This is a workaround for out-of-spec writers, not a spec correction — a
genuinely black true colour written after an ACI will now be ignored. The
argument for accepting it is that such a colour is unreadable on the default
black background anyway, so the information lost is not information a user
could have seen. If you would rather not carry a writer-specific heuristic in
the reader, that is a reasonable call — though the LAYER half of this is the
difference between a drawing opening and a drawing looking empty, so it may be
worth taking even if the entity half is not.
