### PR TITLE
fix(data-model): draw a splined LEADER with fewer than four vertices

### DIFF
--- a/packages/data-model/__tests__/AcDbLeader.spec.ts
+++ b/packages/data-model/__tests__/AcDbLeader.spec.ts
@@ -1,4 +1,8 @@
-import { AcGeMatrix3d, AcGePoint3d, AcGeVector3d } from '@mlightcad/geometry-engine'
+import {
+  AcGeMatrix3d,
+  AcGePoint3d,
+  AcGeVector3d
+} from '@mlightcad/geometry-engine'
 import { AcGiMTextAttachmentPoint } from '@mlightcad/graphic-interface'
 
 import { acdbHostApplicationServices, AcDbDxfFiler } from '../src/base'
@@ -161,7 +165,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points).toHaveLength(3)
     expect(points[2]).toMatchObject({ x: 15, y: 5, z: 0 })
   })
@@ -186,7 +192,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points[2]).toMatchObject({ x: 28, y: 5, z: 0 })
   })
 
@@ -209,7 +217,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points).toHaveLength(3)
     expect(points[2]).toMatchObject({ x: 30, y: 6, z: 0 })
   })
@@ -233,7 +243,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points).toHaveLength(3)
     expect(points[2]).toMatchObject({ x: 26, y: 6, z: 0 })
   })
@@ -249,7 +261,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points[2]).toMatchObject({ x: 5, y: 5, z: 0 })
   })
 
@@ -279,7 +293,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points[2].x).toBeGreaterThan(100)
     expect(points[2].x).not.toBeCloseTo(20)
   })
@@ -325,7 +341,9 @@ describe('AcDbLeader', () => {
 
     const renderer = createRenderer()
     leader.subWorldDraw(renderer as never)
-    const points = (renderer.lines.mock.calls[0] as unknown[][])[0] as AcGePoint3d[]
+    const points = (
+      renderer.lines.mock.calls[0] as unknown[][]
+    )[0] as AcGePoint3d[]
     expect(points).toHaveLength(3)
     expect(points[2].x).toBeCloseTo(14)
     expect(points[2].y).toBeCloseTo(20)
@@ -476,5 +494,43 @@ describe('AcDbLeader', () => {
       nearestPoints
     )
     expect(nearestPoints).toHaveLength(1)
+  })
+  it.each([
+    [
+      'two',
+      [
+        [0, 0, 0],
+        [4, 3, 0]
+      ]
+    ],
+    [
+      'three',
+      [
+        [9.57, 10.07, 0],
+        [12.44, 12.75, 0],
+        [15.39, 12.75, 0]
+      ]
+    ]
+  ])('draws a splined leader with only %s vertices', (_label, points) => {
+    // AcGeSpline3d defaults to a cubic and needs degree + 1 fit points, so
+    // these used to throw ILLEGAL_PARAMETERS out of subWorldDraw and the
+    // leader disappeared. Seen on LibreDWG's 2000/2004/.../r14_Leader.dxf,
+    // which write group 72 = 1 with group 76 = 3.
+    const leader = new AcDbLeader()
+    for (const [x, y, z] of points as number[][]) {
+      leader.appendVertex(new AcGePoint3d(x, y, z))
+    }
+    leader.isSplined = true
+
+    const renderer = createRenderer()
+    expect(() => leader.subWorldDraw(renderer as never)).not.toThrow()
+    expect(renderer.lines).toHaveBeenCalled()
+
+    const extents = leader.geometricExtents
+    expect(extents.isEmpty()).toBe(false)
+    // The curve interpolates the vertices, so it spans their full width.
+    const xs = (points as number[][]).map(p => p[0])
+    expect(extents.min.x).toBeCloseTo(Math.min(...xs), 1)
+    expect(extents.max.x).toBeCloseTo(Math.max(...xs), 1)
   })
 })

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -24,7 +24,7 @@ import {
   acdbCollectLineSegmentOsnapPoints,
   acdbPickNearestOsnapPoint
 } from './AcDbOsnapHelpers'
-import { acdbOffsetVertexPathAsPolyline,AcDbPolyline } from './AcDbPolyline'
+import { acdbOffsetVertexPathAsPolyline, AcDbPolyline } from './AcDbPolyline'
 import {
   acdbCollectMTextOrientedCorners,
   acdbEstimatePlainTextWidth,
@@ -605,8 +605,7 @@ export class AcDbLeader extends AcDbCurve {
   private resolveHookLineLength(lastVertex: AcGePoint3d): number {
     const dimStyle = this.resolveDimensionStyle()
     const gap =
-      (dimStyle?.dimgap ??
-        AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimgap) *
+      (dimStyle?.dimgap ?? AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimgap) *
       (dimStyle?.dimscale ??
         AcDbDimStyleTableRecord.DEFAULT_DIM_VALUES.dimscale)
     let length = this._textWidth + gap
@@ -798,7 +797,16 @@ export class AcDbLeader extends AcDbCurve {
       this.numVertices >= 2 &&
       (this._splineGeo == null || this._updated)
     ) {
-      this._splineGeo = new AcGeSpline3d(this._vertices, 'Uniform')
+      // AcGeSpline3d needs degree + 1 fit points and defaults to a cubic, so a
+      // splined leader with 2 or 3 vertices threw ILLEGAL_PARAMETERS out of
+      // subWorldDraw and the leader vanished from the drawing. Drop to the
+      // highest degree the vertex count supports: quadratic for 3 points,
+      // a straight interpolation for 2.
+      this._splineGeo = new AcGeSpline3d(
+        this._vertices,
+        'Uniform',
+        Math.min(3, this.numVertices - 1)
+      )
       this._updated = false
     }
   }
@@ -1001,7 +1009,11 @@ export class AcDbLeader extends AcDbCurve {
    * @returns Offset polyline along the leader path, or `null` when offset fails
    */
   private createOffsetCurve(offsetDist: number): AcDbCurve | null {
-    return acdbOffsetVertexPathAsPolyline(this.collectPath2d(), false, offsetDist)
+    return acdbOffsetVertexPathAsPolyline(
+      this.collectPath2d(),
+      false,
+      offsetDist
+    )
   }
 
   /**
@@ -1033,4 +1045,3 @@ export class AcDbLeader extends AcDbCurve {
     )
   }
 }
-


### PR DESCRIPTION
# fix(data-model): draw a splined LEADER with fewer than four vertices

**Branch:** `fix/dxf-splined-leader-degree`

## Problem

`AcDbLeader.createSplineIfNeeded` builds an `AcGeSpline3d` as soon as the leader
has 2 vertices, but leaves the degree at its default of 3:

```ts
if (this.isSplined && this.numVertices >= 2 && (this._splineGeo == null || this._updated)) {
  this._splineGeo = new AcGeSpline3d(this._vertices, 'Uniform')
```

`AcGeSpline3d` requires `degree + 1` fit points:

```ts
if (this._fitPoints.length + tangentCount < this._degree + 1) {
  throw AcCmErrors.ILLEGAL_PARAMETERS
}
```

So a splined leader with 2 or 3 vertices throws out of `subWorldDraw` and the
leader is dropped from the drawing:

```
[AcTrView2d] Failed to convert entity 72E (Leader): ReferenceError: Illegal Parameters
    at new AcGeSpline3d
    at AcDbLeader.createSplineIfNeeded
    at AcDbLeader.get splineGeo
    at AcDbLeader.collectDrawPoints
    at AcDbLeader.subWorldDraw
```

Three vertices is what AutoCAD normally writes for a splined leader.
`LibreDWG/test/test-data/{2000,2004,2007,2010,2013,2018,r14}_Leader.dxf` all
carry group `72 = 1` (splined) with group `76 = 3`, and none of them render
their LEADER.

`geometricExtents` goes through the same getter, so it throws too.

## Change

Clamp the degree to what the vertex count supports:

```ts
new AcGeSpline3d(this._vertices, 'Uniform', Math.min(3, this.numVertices - 1))
```

Quadratic for three points, a straight interpolation for two. Four or more
vertices are unchanged.

## Tests

`packages/data-model/__tests__/AcDbLeader.spec.ts` gains a two-case table test
covering 2 and 3 vertices: `subWorldDraw` must not throw, the renderer must
receive lines, and the extents must span the vertices. Both cases fail on
`main` with `Illegal Parameters` — verified by reverting the source fix and
re-running.

## Validation

`pnpm test` 1099 passed, `pnpm lint` and `pnpm build` clean.

Re-rendered the 7 affected files in a browser after the fix: the
`Failed to convert entity … (Leader)` console error is gone from all of them,
and the LEADER now reports real geometry — extents `(9.57, 10.07)..(15.39, 13.09)`
for vertices `(9.574, 10.070)`, `(12.438, 12.754)`, `(15.391, 12.754)`, i.e. the
quadratic interpolates the vertices with the expected slight overshoot.

Found by rendering a 2,547-file DXF/DWG corpus in a browser. A parse-only scan
cannot see this class of defect — the entity reads fine and only fails at draw
time.
