### PR TITLE
fix(data-model): normalize a zero INSERT scale factor to 1

### DIFF
--- a/packages/data-model/__tests__/AcDbBlockReference.spec.ts
+++ b/packages/data-model/__tests__/AcDbBlockReference.spec.ts
@@ -520,4 +520,50 @@ describe('AcDbBlockReference', () => {
     expect(filerWithoutAttrs.toString()).not.toContain('\n0\nATTRIB\n')
     expect(filerWithoutAttrs.toString()).not.toContain('\n0\nSEQEND\n')
   })
+  it.each([
+    ['z', ['41', '1.0', '42', '1.0', '43', '0.0'], [1, 1, 1]],
+    ['x and y', ['41', '0.0', '42', '0.0', '43', '1.0'], [1, 1, 1]],
+    ['none', ['41', '0.5', '42', '0.5', '43', '2.0'], [0.5, 0.5, 2]]
+  ])(
+    'normalizes a zero INSERT scale factor (%s zeroed)',
+    (_label, scalePairs, expected) => {
+      // A zero scale makes the block transform singular, and Matrix4.decompose
+      // divides by it, so NaN spreads into every derived bound. 2D writers emit
+      // `43 0` routinely — bjnortier/dxf's arrayed-holes.dxf and LibreCAD's
+      // symbol library both do.
+      createDb()
+      const dxf = [
+        '100',
+        'AcDbEntity',
+        '8',
+        '0',
+        '100',
+        'AcDbBlockReference',
+        '2',
+        'BLOCK_6',
+        '10',
+        '1.0',
+        '20',
+        '2.0',
+        '30',
+        '0.0',
+        ...(scalePairs as string[]),
+        '0',
+        'ENDSEC'
+      ].join('\n')
+
+      const blockRef = new AcDbBlockReference('')
+      blockRef.dxfIn(AcDbDxfFiler.fromString(dxf))
+
+      const [ex, ey, ez] = expected as number[]
+      expect(blockRef.scaleFactors.x).toBeCloseTo(ex)
+      expect(blockRef.scaleFactors.y).toBeCloseTo(ey)
+      expect(blockRef.scaleFactors.z).toBeCloseTo(ez)
+
+      // The resulting transform must stay invertible, which is what keeps a
+      // renderer from decomposing it into NaN.
+      const m = blockRef.blockTransform.elements
+      expect(m.every((v: number) => Number.isFinite(v))).toBe(true)
+    }
+  )
 })

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -25,6 +25,23 @@ import { acdbMovePrimaryGripPointAt } from './AcDbGripHelpers'
 import { acdbPickNearestOsnapPoint } from './AcDbOsnapHelpers'
 
 /**
+ * Coerces a DXF INSERT scale factor (group 41/42/43) to a usable value.
+ *
+ * A scale of 0 collapses the block transform to a singular matrix. AutoCAD
+ * never produces one — the DXF default for all three groups is 1.0 — but 2D
+ * writers routinely emit `43 0` to mean "no Z", and `Matrix4.decompose` on the
+ * result divides by that zero, so NaN spreads through the transform into
+ * whatever geometry and bounds a renderer derives from it. Treat 0 (and
+ * non-finite input) as the spec default.
+ *
+ * @param value - Raw group 41/42/43 value
+ * @returns The scale factor to apply
+ */
+function normalizeScaleFactor(value: number): number {
+  return Number.isFinite(value) && value !== 0 ? value : 1
+}
+
+/**
  * Represents a block reference entity in AutoCAD.
  *
  * A block reference is used to place, size, and display an instance of the collection
@@ -1132,7 +1149,11 @@ export class AcDbBlockReference extends AcDbEntity {
 
     const commit = () => {
       this.position = new AcGePoint3d(x, y, z)
-      this.scaleFactors = new AcGePoint3d(sx, sy, sz)
+      this.scaleFactors = new AcGePoint3d(
+        normalizeScaleFactor(sx),
+        normalizeScaleFactor(sy),
+        normalizeScaleFactor(sz)
+      )
       this.rotation = AcGeMathUtil.degToRad(rotDeg)
       this.normal.copy(new AcGeVector3d(nx, ny, nz))
       this.columnCount = columnCount > 0 ? columnCount : 1


### PR DESCRIPTION
# fix(data-model): normalize a zero INSERT scale factor to 1

**Branch:** `fix/dxf-insert-zero-scale`

## Problem

A DXF INSERT whose group 41/42/43 is `0` collapses the block transform to a
singular matrix.

AutoCAD never writes one — the DXF default for all three groups is 1.0 — but 2D
writers routinely emit `43 0` to mean "no Z". `bjnortier/dxf`'s
`arrayed-holes.dxf`, `blocks1.dxf`, `blocks2.dxf`, `array-rotated.dxf`,
`accumulatortest.dxf` and much of LibreCAD's symbol library all do it.

Downstream the zero is destructive rather than merely degenerate. Any renderer
that reconstructs a local TRS from the matrix — `THREE.Matrix4.decompose`, for
example — divides by the zero scale:

```js
const invSZ = 1 / sz          // 1 / 0 = Infinity
_m1.elements[8] *= invSZ      // 0 * Infinity = NaN
quaternion.setFromRotationMatrix(_m1)   // NaN quaternion
```

NaN then spreads into every vertex and bounding box derived from the transform.
In cad-viewer the batch origin became NaN, the layout bounding box became NaN,
zoom-to-extents had nothing finite to frame, and the drawing rendered
**completely blank** even though every entity parsed correctly and the entity
count matched the file exactly.

## Change

Coerce `0` (and any non-finite value) to the spec default of 1 while reading
the INSERT, via a small `normalizeScaleFactor` helper. Non-zero scales,
including negative ones used for mirroring, are untouched.

## Tests

`packages/data-model/__tests__/AcDbBlockReference.spec.ts` gains a three-case
table test: Z zeroed, X and Y zeroed, and none zeroed. Each asserts the
resulting `scaleFactors` and that every element of `blockTransform` stays
finite — the property that keeps a renderer from decomposing it into NaN. The
first two cases fail on `main`, verified by reverting the source fix.

## Validation

`pnpm test` 1100 passed, `pnpm lint` and `pnpm build` clean.

Found by rendering a 2,547-file DXF/DWG corpus in a browser and then walking
the batch data of the drawings that came out empty: their batch origins were
NaN. 11 of the drawings that rendered nothing carry a zero INSERT scale, and
all 11 render after this change.
