### PR TITLE
fix(data-model): stop a large $HANDSEED hanging the read forever

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -84,6 +84,29 @@ describe('AcDbDatabase', () => {
     expect(db.generateHandle()).toBe('FFFF')
   })
 
+  it('keeps generating fresh handles past the 2^53 safe-integer limit', () => {
+    // Handles are 64-bit and real drawings use the range: this $HANDSEED comes
+    // from a file in the wild. Held as a double, `value + 1` is a no-op above
+    // 2^53, so the generator repeats one handle and generateUniqueHandle spins
+    // forever the moment that handle is taken — a synchronous hang.
+    const db = new AcDbDatabase()
+    db.initializeHandleSeed('D9B071D01A0CB6A8')
+
+    const first = db.generateHandle()
+    const second = db.generateHandle()
+    expect(first).toBe('D9B071D01A0CB6A8')
+    expect(second).toBe('D9B071D01A0CB6A9')
+    expect(second).not.toBe(first)
+  })
+
+  it('tracks the maximum handle beyond the safe-integer limit', () => {
+    const db = new AcDbDatabase()
+    db.updateMaxHandle('20000000000000')
+    db.updateMaxHandle('1FFFFFFFFFFFFF')
+    // The smaller second value must not lower the ceiling.
+    expect(db.generateHandle()).toBe('20000000000001')
+  })
+
   it('loads multiple fonts in one batch during FONT END', async () => {
     const db = new AcDbDatabase()
     const fileType = 'test-font-load-batch'
@@ -120,11 +143,7 @@ describe('AcDbDatabase', () => {
         fileType
       )
       expect(fontLoader.load).toHaveBeenCalledTimes(1)
-      expect(fontLoader.load).toHaveBeenCalledWith([
-        'arial',
-        'simsun',
-        'hztxt'
-      ])
+      expect(fontLoader.load).toHaveBeenCalledWith(['arial', 'simsun', 'hztxt'])
     } finally {
       manager.unregister(fileType)
     }
@@ -235,7 +254,11 @@ describe('AcDbDatabase', () => {
             stage: string,
             stageStatus: string,
             data?: unknown,
-            taskError?: { error: unknown; task: { name: string }; taskIndex: number }
+            taskError?: {
+              error: unknown
+              task: { name: string }
+              taskIndex: number
+            }
           ) => Promise<void>
         ) => {
           if (progress) {

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -342,6 +342,30 @@ export interface AcDbTables {
 /**
  * Options used to specify default data to create
  */
+/**
+ * Parses a DXF handle (hexadecimal) into a bigint.
+ *
+ * Handles are 64-bit and real drawings use the full range — `$HANDSEED` of
+ * `D9B071D01A0CB6A8` appears in the wild. `parseInt` returns a double there, so
+ * `value + 1` is a no-op above 2^53 and a handle generator built on it repeats
+ * the same handle forever.
+ *
+ * Mirrors `parseInt(handle, 16)` by reading the leading hex run and ignoring
+ * whatever follows.
+ *
+ * @param handle - Handle text from a drawing
+ * @returns The value, or null when the text has no leading hex digits
+ */
+function acdbParseHandleValue(handle: string): bigint | null {
+  const match = /^[0-9A-Fa-f]+/.exec(handle.trim())
+  if (!match) return null
+  try {
+    return BigInt(`0x${match[0]}`)
+  } catch {
+    return null
+  }
+}
+
 export interface AcDbCreateDefaultDataOptions {
   layer?: boolean
   lineType?: boolean
@@ -458,7 +482,7 @@ export class AcDbDatabase extends AcDbObject {
   /** Current space (model space or paper space) */
   private _currentSpace?: AcDbBlockTableRecord
   /** The maximum handle value in the database, used for generating unique object IDs */
-  private _maxHandle: number
+  private _maxHandle: bigint
   /** Global registry of committed object handles across all database-resident objects */
   private _handleRegistry = new Map<AcDbObjectId, AcDbObject>()
   /** Lazily created formatter for lengths, angles, and coordinates */
@@ -562,7 +586,7 @@ export class AcDbDatabase extends AcDbObject {
     this._pdsize = 0
     this._osmode = 0
     this._orthomode = 0
-    this._maxHandle = 0
+    this._maxHandle = BigInt(0)
     this._tables = {
       appIdTable: new AcDbRegAppTable(this),
       blockTable: new AcDbBlockTable(this),
@@ -1042,7 +1066,7 @@ export class AcDbDatabase extends AcDbObject {
    * ```
    */
   generateHandle(): AcDbObjectId {
-    this._maxHandle++
+    this._maxHandle += BigInt(1)
     return this._maxHandle.toString(16).toUpperCase()
   }
 
@@ -1068,9 +1092,9 @@ export class AcDbDatabase extends AcDbObject {
    * @param seed - Hexadecimal handle seed from the drawing header
    */
   initializeHandleSeed(seed: string) {
-    const next = parseInt(seed, 16)
-    if (!isNaN(next) && next > 0) {
-      const baseline = next - 1
+    const next = acdbParseHandleValue(seed)
+    if (next != null && next > BigInt(0)) {
+      const baseline = next - BigInt(1)
       if (baseline > this._maxHandle) {
         this._maxHandle = baseline
       }
@@ -1208,8 +1232,8 @@ export class AcDbDatabase extends AcDbObject {
    * ```
    */
   updateMaxHandle(handle: string): void {
-    const handleValue = parseInt(handle, 16)
-    if (!isNaN(handleValue) && handleValue > this._maxHandle) {
+    const handleValue = acdbParseHandleValue(handle)
+    if (handleValue != null && handleValue > this._maxHandle) {
       this._maxHandle = handleValue
     }
   }
@@ -2274,8 +2298,7 @@ export class AcDbDatabase extends AcDbObject {
           if (options.failOnFontLoadError) {
             throw error
           }
-          const message =
-            error instanceof Error ? error.message : String(error)
+          const message = error instanceof Error ? error.message : String(error)
           console.warn(
             'Failed to load fonts; continuing without them. ' +
               'Check your network or configure a local baseUrl. See ' +


### PR DESCRIPTION
# fix(data-model): stop a large $HANDSEED hanging the read forever

**Branch:** `fix/dxf-handseed-overflow`

## Problem

`_maxHandle` is a `number`, and `generateHandle` increments it:

```ts
generateHandle(): AcDbObjectId {
  this._maxHandle++
  return this._maxHandle.toString(16).toUpperCase()
}

generateUniqueHandle(): AcDbObjectId {
  let handle = this.generateHandle()
  while (this.isHandleTaken(handle)) {
    handle = this.generateHandle()
  }
  return handle
}
```

DXF handles are 64-bit and real drawings use the range.
`dotoritos-kim/dxf-json`'s `sample_A_000217.dxf` carries:

```
9 | $HANDSEED
5 | D9B071D01A0CB6A8
```

That is ~1.57e19, far above `Number.MAX_SAFE_INTEGER` (9.007e15). Incrementing
a double that large **is a no-op**, so `generateHandle` returns the same string
on every call and the `while` loop above never terminates once that handle is
taken.

It is a synchronous loop, so this is worse than a failed open:

- `db.read` never resolves — no error, no rejection
- no timer fires, so a watchdog inside the same context cannot catch it
- in a browser the tab freezes

Reduced to the smallest reproduction, **the HEADER section alone is enough**;
no entities are needed.

## Change

Hold the counter as a `bigint` and parse handles through a shared
`acdbParseHandleValue`, which mirrors `parseInt(handle, 16)` by reading the
leading hex run so existing lenient inputs keep working. Termination is then
provable: the counter always advances and the handle registry is finite.

BigInt *literals* are avoided (`BigInt(0)` rather than `0n`) because the package
targets below ES2020.

## Tests

Two cases in `AcDbDatabase.spec.ts`: consecutive handles past 2^53 must differ
and advance (`D9B071D01A0CB6A8` → `D9B071D01A0CB6A9`), and `updateMaxHandle`
must keep tracking correctly above the limit. Both fail on `main`.

## Validation

`pnpm test` 1099 passed, `pnpm lint` and `pnpm build` clean.

The affected drawing now parses in **175 ms** with 6799 entities, having
previously run for over five minutes without finishing.

Found while scanning a second DXF corpus of 661 files harvested from 42 GitHub
repositories; it was the only file in that set that hung, and it hangs every
consumer of the library, not just a renderer.
