### PR TITLE
fix(libredwg-converter): stream large block entities when collecting fonts

### DIFF
--- a/packages/data-model/src/converter/AcDbFontNameCollector.ts
+++ b/packages/data-model/src/converter/AcDbFontNameCollector.ts
@@ -30,11 +30,13 @@ export type AcDbFontNameCollectorEntityFontInfo = {
 
 /**
  * Entity collections accepted by {@link AcDbFontNameCollector.collect}.
- * Arrays match LibreDwg-style models; maps match handle→entity stores.
+ * Arrays match LibreDwg-style models; maps match handle→entity stores;
+ * arbitrary iterables avoid materializing a single giant entity array.
  */
 export type AcDbFontNameCollectorEntities<TEntity> =
   | readonly TEntity[]
   | Map<number, TEntity>
+  | Iterable<TEntity>
 
 /** Callbacks that map a host-specific entity model to collector input. */
 export type AcDbFontNameCollectorAdapter<TEntity> = {
@@ -149,10 +151,9 @@ export class AcDbFontNameCollector {
 
   private static iterateEntities<TEntity>(
     entities: AcDbFontNameCollectorEntities<TEntity>
-  ): IterableIterator<TEntity> {
-    return entities instanceof Map
-      ? entities.values()
-      : entities[Symbol.iterator]()
+  ): Iterable<TEntity> {
+    // Maps iterate as [key, value] pairs; walk values only.
+    return entities instanceof Map ? entities.values() : entities
   }
 
   /**

--- a/packages/data-model/src/converter/AcDbFontNameCollector.ts
+++ b/packages/data-model/src/converter/AcDbFontNameCollector.ts
@@ -80,7 +80,8 @@ export class AcDbFontNameCollector {
   /**
    * Walks entities and returns all normalized font names referenced by the drawing.
    *
-   * @param entities - Entity array, or a handle→entity map (`Map` values are walked).
+   * @param entities - Entity array, handle→entity map (`Map` values are walked),
+   *   or any iterable of entities (avoids materializing a single giant array).
    */
   collect<TEntity>(
     entities: AcDbFontNameCollectorEntities<TEntity>,

--- a/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
@@ -159,6 +159,49 @@ describe('AcDbLibreDwgConverter', () => {
     expect(fonts).not.toContain('italic')
   })
 
+  it('does not throw when a BLOCK_RECORD has more entities than apply arg limits', () => {
+    // Engines typically fail around ~65k–125k args for Function.prototype.apply /
+    // array spread used as push(...entities). Use well above that.
+    const LARGE = 150_000
+    const entities = new Array(LARGE)
+    for (let i = 0; i < LARGE; i++) {
+      entities[i] = { type: 'LINE' }
+    }
+    entities[0] = { type: 'TEXT', styleName: 'Romans' }
+    entities[LARGE - 1] = {
+      type: 'MTEXT',
+      styleName: 'Romans',
+      text: '{\\fCustom|b0;Hi}'
+    }
+
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+    const fonts = converter.getFontsPublic({
+      header: { TEXTSTYLE: 'Standard' },
+      tables: {
+        STYLE: {
+          entries: [
+            {
+              name: 'Standard',
+              font: 'txt.shx',
+              standardFlag: 0
+            },
+            {
+              name: 'Romans',
+              font: 'romans.shx',
+              standardFlag: 0
+            }
+          ]
+        },
+        BLOCK_RECORD: {
+          entries: [{ name: 'DENSE', entities }]
+        }
+      },
+      entities: []
+    })
+
+    expect(fonts).toEqual(expect.arrayContaining(['romans', 'custom']))
+  })
+
   it('collects fonts from tolerance entities via dim style text style and inline fonts', () => {
     const converter = new TestLibreDwgConverter({ useWorker: false })
     const fonts = converter.getFontsPublic({

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -120,10 +120,21 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       )
     }
 
-    const rootEntities: DwgEntity[] = [...(dwg.entities ?? [])]
-    for (const btr of dwg.tables.BLOCK_RECORD.entries) {
-      if (btr.entities?.length) {
-        rootEntities.push(...btr.entities)
+    // Do not build one giant array with push(...entities) / Array spread —
+    // engines limit Function.prototype.apply argument counts, and large
+    // BLOCK_RECORD entity lists (dense hatches, arrays) can throw
+    // RangeError: Maximum call stack size exceeded. Stream instead.
+    const rootEntities: Iterable<DwgEntity> = {
+      *[Symbol.iterator](): IterableIterator<DwgEntity> {
+        const modelEntities = dwg.entities
+        if (modelEntities?.length) {
+          yield* modelEntities
+        }
+        for (const btr of dwg.tables.BLOCK_RECORD.entries) {
+          if (btr.entities?.length) {
+            yield* btr.entities
+          }
+        }
       }
     }
 
@@ -848,7 +859,11 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
 
     const result: DwgEntity[] = []
     for (const type of order) {
-      result.push(...groups[type])
+      // Avoid push(...group): large same-type groups hit apply arg limits.
+      const group = groups[type]
+      for (let i = 0; i < group.length; i++) {
+        result.push(group[i])
+      }
     }
     return result
   }


### PR DESCRIPTION
## Summary
- Avoid building one giant entity array with `push(...entities)` / array spread when collecting fonts — large `BLOCK_RECORD` lists hit engine `Function.prototype.apply` argument limits and throw `RangeError: Maximum call stack size exceeded`.
- Stream model-space and block entities via an `Iterable`, and teach `AcDbFontNameCollector` to accept arbitrary iterables (still special-casing `Map` values).
- Replace `push(...group)` in `groupAndFlattenByType` with an indexed loop for the same apply-limit reason; add a regression test with 150k entities in one block.

## Test plan
- [ ] `nx test libredwg-converter` (or package test script) — confirm new large-block font-collect case passes
- [ ] Spot-check font preload on a dense DWG (large hatch/array block) that previously crashed during `getFonts`
- [ ] Confirm normal small drawings still collect the expected font set