### PR TITLE
perf(data-model): skip font collection when no fontLoader is provided

### DIFF
--- a/packages/data-model/__tests__/AcDbDatabase.spec.ts
+++ b/packages/data-model/__tests__/AcDbDatabase.spec.ts
@@ -96,16 +96,23 @@ describe('AcDbDatabase', () => {
         async (
           _data: ArrayBuffer,
           _db: AcDbDatabase,
-          _minimumChunkSize: number,
-          progress?: (
-            percentage: number,
-            stage: string,
-            stageStatus: string,
-            data?: unknown
-          ) => Promise<void>
+          options?: {
+            collectFonts?: boolean
+            progress?: (
+              percentage: number,
+              stage: string,
+              stageStatus: string,
+              data?: unknown
+            ) => Promise<void>
+          }
         ) => {
-          if (progress) {
-            await progress(5, 'FONT', 'END', ['arial', 'simsun', 'hztxt'])
+          expect(options?.collectFonts).toBe(true)
+          if (options?.progress) {
+            await options.progress(5, 'FONT', 'END', [
+              'arial',
+              'simsun',
+              'hztxt'
+            ])
           }
         }
       )
@@ -130,6 +137,27 @@ describe('AcDbDatabase', () => {
     }
   })
 
+  it('skips font collection when fontLoader is not provided', async () => {
+    const db = new AcDbDatabase()
+    const fileType = 'test-skip-font-collection'
+    const converter = {
+      read: jest.fn(async () => undefined)
+    }
+    const manager = AcDbDatabaseConverterManager.instance
+    manager.register(fileType, converter as never)
+
+    try {
+      await db.read(new ArrayBuffer(0), { readOnly: true }, fileType)
+      expect(converter.read).toHaveBeenCalledWith(
+        expect.any(ArrayBuffer),
+        db,
+        expect.objectContaining({ collectFonts: false })
+      )
+    } finally {
+      manager.unregister(fileType)
+    }
+  })
+
   it('continues reading when font loading fails by default', async () => {
     const db = new AcDbDatabase()
     const fileType = 'test-font-load'
@@ -142,16 +170,17 @@ describe('AcDbDatabase', () => {
         async (
           _data: ArrayBuffer,
           _db: AcDbDatabase,
-          _minimumChunkSize: number,
-          progress?: (
-            percentage: number,
-            stage: string,
-            stageStatus: string,
-            data?: unknown
-          ) => Promise<void>
+          options?: {
+            progress?: (
+              percentage: number,
+              stage: string,
+              stageStatus: string,
+              data?: unknown
+            ) => Promise<void>
+          }
         ) => {
-          if (progress) {
-            await progress(5, 'FONT', 'END', ['arial'])
+          if (options?.progress) {
+            await options.progress(5, 'FONT', 'END', ['arial'])
           }
         }
       )
@@ -186,16 +215,17 @@ describe('AcDbDatabase', () => {
         async (
           _data: ArrayBuffer,
           _db: AcDbDatabase,
-          _minimumChunkSize: number,
-          progress?: (
-            percentage: number,
-            stage: string,
-            stageStatus: string,
-            data?: unknown
-          ) => Promise<void>
+          options?: {
+            progress?: (
+              percentage: number,
+              stage: string,
+              stageStatus: string,
+              data?: unknown
+            ) => Promise<void>
+          }
         ) => {
-          if (progress) {
-            await progress(5, 'FONT', 'END', ['arial'])
+          if (options?.progress) {
+            await options.progress(5, 'FONT', 'END', ['arial'])
           }
         }
       )
@@ -229,17 +259,22 @@ describe('AcDbDatabase', () => {
         async (
           _data: ArrayBuffer,
           _db: AcDbDatabase,
-          _minimumChunkSize: number,
-          progress?: (
-            percentage: number,
-            stage: string,
-            stageStatus: string,
-            data?: unknown,
-            taskError?: { error: unknown; task: { name: string }; taskIndex: number }
-          ) => Promise<void>
+          options?: {
+            progress?: (
+              percentage: number,
+              stage: string,
+              stageStatus: string,
+              data?: unknown,
+              taskError?: {
+                error: unknown
+                task: { name: string }
+                taskIndex: number
+              }
+            ) => Promise<void>
+          }
         ) => {
-          if (progress) {
-            await progress(5, 'PARSE', 'ERROR', undefined, {
+          if (options?.progress) {
+            await options.progress(5, 'PARSE', 'ERROR', undefined, {
               error: oomError,
               task: { name: 'PARSE' },
               taskIndex: 1

--- a/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
@@ -436,7 +436,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     expect(db.version.name).toBe('AC1032')
     expect(db.insunits).toBe(4)
@@ -836,7 +836,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     expect(db.classes).toHaveLength(1)
     expect(db.classes[0].name).toBe('ACDBDICTIONARYWDFLT')
@@ -935,7 +935,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const xref = db.tables.blockTable.getAt('xref1')
     expect(xref).toBeDefined()
@@ -1483,7 +1483,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const modelLayout = db.objects.layout.getAt('Model')
     expect(modelLayout).toBeDefined()
@@ -2015,7 +2015,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const model = [...db.tables.blockTable.modelSpace.newIterator()]
     const text = model.find(e => e instanceof AcDbText) as AcDbText | undefined
@@ -2129,7 +2129,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const dim = [...db.tables.blockTable.modelSpace.newIterator()].find(
       e => e instanceof AcDbRotatedDimension
@@ -2236,13 +2236,13 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50, async (_pct, stage, status, data) => {
+    await converter.read(buffer, db, { minimumChunkSize: 50, progress: async (_pct, stage, status, data) => {
       stages.push(`${stage}:${status}`)
       if (stage === 'FONT' && status === 'END') {
         expect(Array.isArray(data)).toBe(true)
         expect(data as string[]).toEqual(expect.arrayContaining(['simsun']))
       }
-    })
+    }})
 
     expect(stages.filter(s => !s.endsWith(':IN-PROGRESS'))).toEqual([
       'START:START',
@@ -2403,15 +2403,109 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50, async (_pct, stage, status, data) => {
+    await converter.read(buffer, db, { minimumChunkSize: 50, progress: async (_pct, stage, status, data) => {
       if (stage === 'FONT' && status === 'END') {
         fonts = data as string[]
       }
-    })
+    }})
 
     expect(fonts).toEqual(
       expect.arrayContaining(['arial', 'custom', 'inline', 'gdt.shx'])
     )
+  })
+
+  it('returns empty fonts when collectFonts is false', async () => {
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'TABLES',
+      '0',
+      'TABLE',
+      '2',
+      'STYLE',
+      '0',
+      'STYLE',
+      '5',
+      '61',
+      '100',
+      'AcDbSymbolTableRecord',
+      '100',
+      'AcDbTextStyleTableRecord',
+      '2',
+      'Standard',
+      '70',
+      '0',
+      '40',
+      '0.0',
+      '41',
+      '1.0',
+      '50',
+      '0.0',
+      '71',
+      '0',
+      '42',
+      '0.2',
+      '3',
+      'Arial.ttf',
+      '4',
+      '',
+      '0',
+      'ENDTAB',
+      '0',
+      'ENDSEC',
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      '0',
+      'MTEXT',
+      '5',
+      'A1',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbMText',
+      '10',
+      '0.0',
+      '20',
+      '0.0',
+      '30',
+      '0.0',
+      '40',
+      '2.5',
+      '1',
+      '{\\fCustom|b0|i0|c0|p34;Hello}',
+      '7',
+      'Standard',
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF'
+    ].join('\n')
+
+    let fonts: string[] | undefined
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const converter = new AcDbNativeDxfConverter()
+    const buffer = new TextEncoder().encode(dxf).buffer
+    await converter.read(buffer, db, {
+      minimumChunkSize: 50,
+      collectFonts: false,
+      progress: async (_pct, stage, status, data) => {
+        if (stage === 'FONT' && status === 'END') {
+          fonts = data as string[]
+        }
+      }
+    })
+
+    expect(fonts).toEqual([])
+    // STYLE table is still populated; only font-name collection is skipped.
+    expect(db.tables.textStyleTable.getAt('Standard')?.fileName).toBe('Arial')
   })
 
   it('emits PARSE IN-PROGRESS while streaming entities', async () => {
@@ -2457,10 +2551,10 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(lines.join('\n')).buffer
-    await converter.read(buffer, db, 5, async (pct, stage, status) => {
+    await converter.read(buffer, db, { minimumChunkSize: 5, progress: async (pct, stage, status) => {
       stages.push(`${stage}:${status}`)
       percentages.push(pct)
-    })
+    }})
 
     expect(stages).toContain('PARSE:IN-PROGRESS')
     expect(stages).toContain('ENTITY:IN-PROGRESS')
@@ -2565,7 +2659,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const inserts = [...db.tables.blockTable.modelSpace.newIterator()].filter(
       e => e instanceof AcDbBlockReference
@@ -2698,7 +2792,7 @@ describe('AcDbNativeDxfConverter', () => {
 
     const converter = new AcDbNativeDxfConverter()
     const buffer = new TextEncoder().encode(dxf).buffer
-    await converter.read(buffer, db, 50)
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
 
     const paper = db.tables.blockTable.getAt('*Paper_Space')!
     const lines = [...paper.newIterator()].filter(e => e instanceof AcDbLine)
@@ -2786,7 +2880,7 @@ describe('AcDbNativeDxfConverter', () => {
     const converter = new AcDbNativeDxfConverter()
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db
-    await converter.read(new TextEncoder().encode(dxf).buffer, db, 50)
+    await converter.read(new TextEncoder().encode(dxf).buffer, db, { minimumChunkSize: 50 })
 
     const solids = [...db.tables.blockTable.modelSpace.newIterator()].filter(
       e => e instanceof AcDb3dSolid
@@ -2834,7 +2928,7 @@ describe('AcDbNativeDxfConverter', () => {
     const converter = new AcDbNativeDxfConverter()
     const db = new AcDbDatabase()
     acdbHostApplicationServices().workingDatabase = db
-    await converter.read(new TextEncoder().encode(dxf).buffer, db, 50)
+    await converter.read(new TextEncoder().encode(dxf).buffer, db, { minimumChunkSize: 50 })
 
     const solid = [...db.tables.blockTable.modelSpace.newIterator()].find(
       e => e instanceof AcDb3dSolid

--- a/packages/data-model/src/database/AcDbDatabase.ts
+++ b/packages/data-model/src/database/AcDbDatabase.ts
@@ -254,6 +254,9 @@ export interface AcDbOpenDatabaseOptions {
    * in the drawing database. By default, font load failures are logged and
    * parsing continues without the missing fonts. Set {@link failOnFontLoadError}
    * to `true` to abort the read when font loading fails.
+   *
+   * When omitted, the converter skips collecting font names during parse,
+   * which can reduce open time when fonts will not be loaded.
    */
   fontLoader?: AcDbFontLoader
 
@@ -2215,14 +2218,14 @@ export class AcDbDatabase extends AcDbObject {
     acdbAssignWorkingDatabase(this)
 
     try {
-      await converter.read(
-        data,
-        this,
-        (options && options.minimumChunkSize) || 10,
-        this.createConversionProgressHandler(options),
-        options?.timeout,
-        options?.sysVars
-      )
+      await converter.read(data, this, {
+        minimumChunkSize: (options && options.minimumChunkSize) || 10,
+        progress: this.createConversionProgressHandler(options),
+        timeout: options?.timeout,
+        sysVars: options?.sysVars,
+        // Skip font collection when nothing will load them — saves parse time.
+        collectFonts: options?.fontLoader != null
+      })
     } catch (error) {
       const openError = AcDbOpenDatabaseError.from(error)
       this._lastOpenError = openError
@@ -2503,12 +2506,10 @@ export class AcDbDatabase extends AcDbObject {
    */
   async regen() {
     const converter = new AcDbRegenerator(this)
-    await converter.read(
-      null as unknown as ArrayBuffer,
-      this,
-      500,
-      this.createConversionProgressHandler()
-    )
+    await converter.read(null as unknown as ArrayBuffer, this, {
+      minimumChunkSize: 500,
+      progress: this.createConversionProgressHandler()
+    })
   }
 
   /**

--- a/packages/data-model/src/database/AcDbDatabaseConverter.ts
+++ b/packages/data-model/src/database/AcDbDatabaseConverter.ts
@@ -134,6 +134,42 @@ export type AcDbConversionProgressCallback = (
 ) => Promise<void>
 
 /**
+ * Options for {@link AcDbDatabaseConverter.read}.
+ *
+ * Keeps the converter read API extensible without growing positional arguments.
+ */
+export interface AcDbDatabaseConverterReadOptions {
+  /**
+   * Minimum number of items in one processing chunk.
+   *
+   * Defaults to converter-specific behavior when omitted.
+   */
+  minimumChunkSize?: number
+
+  /**
+   * Optional progress callback invoked as conversion stages advance.
+   */
+  progress?: AcDbConversionProgressCallback
+
+  /**
+   * Timeout for parser web worker operations in milliseconds.
+   */
+  timeout?: number
+
+  /**
+   * System variables to override in the database after HEADER is processed.
+   */
+  sysVars?: Record<string, number | boolean | string>
+
+  /**
+   * When `true` (default), collect font names referenced by the drawing and
+   * report them on the FONT stage. When `false`, skip font collection and
+   * report an empty fonts list — useful when no font loader will load them.
+   */
+  collectFonts?: boolean
+}
+
+/**
  * Interface defining the data for a conversion task.
  *
  * @template TIn - The input type for the task
@@ -388,21 +424,23 @@ export abstract class AcDbDatabaseConverter<TModel = unknown> {
    *
    * @param data - The input data to convert
    * @param db - The database to populate with converted data
-   * @param minimumChunkSize - Minimum chunk size for batch processing
-   * @param progress - Optional progress callback
-   * @param timeout - Optional timeout for parser web worker operations in milliseconds
-   * @param sysVars - Optional system variables to override in the database
+   * @param options - Optional read options (chunk size, progress, fonts, etc.)
    * @returns Promise that resolves when conversion is complete
    *
    */
   async read(
     data: ArrayBuffer,
     db: AcDbDatabase,
-    minimumChunkSize: number,
-    progress?: AcDbConversionProgressCallback,
-    timeout?: number,
-    sysVars?: Record<string, number | boolean | string>
+    options: AcDbDatabaseConverterReadOptions = {}
   ) {
+    const {
+      minimumChunkSize = 10,
+      progress,
+      timeout,
+      sysVars,
+      collectFonts = true
+    } = options
+
     const loadDbTimeEntry: AcCmPerformanceEntry<AcDbConvertDatabasePerformanceData> =
       {
         name: PERFORMANCE_ENTRY_NAME,
@@ -459,7 +497,7 @@ export abstract class AcDbDatabaseConverter<TModel = unknown> {
           step: 5,
           progress: percentage,
           task: async (data: { model: TModel }) => {
-            const fonts = this.getFonts(data.model)
+            const fonts = collectFonts ? this.getFonts(data.model) : []
             return { model: data.model, data: fonts }
           }
         },

--- a/packages/data-model/src/database/AcDbDatabaseConverterManager.ts
+++ b/packages/data-model/src/database/AcDbDatabaseConverterManager.ts
@@ -51,7 +51,7 @@ export interface AcDbDatabaseConverterManagerEventArgs {
  * const manager = AcDbDatabaseConverterManager.instance;
  * const converter = manager.get(AcDbFileType.DXF);
  * if (converter) {
- *   await converter.read(dxfData, database, 100);
+ *   await converter.read(dxfData, database, { minimumChunkSize: 100 });
  * }
  * ```
  */
@@ -172,7 +172,7 @@ export class AcDbDatabaseConverterManager {
    * ```typescript
    * const converter = manager.get(AcDbFileType.DXF);
    * if (converter) {
-   *   await converter.read(dxfData, database, 100);
+   *   await converter.read(dxfData, database, { minimumChunkSize: 100 });
    * }
    * ```
    */

--- a/packages/data-model/src/database/index.ts
+++ b/packages/data-model/src/database/index.ts
@@ -29,6 +29,7 @@ export type {
   AcDbConversionStage,
   AcDbConvertDatabasePerformanceData,
   AcDbDatabaseConverterConfig,
+  AcDbDatabaseConverterReadOptions,
   AcDbParsingTaskResult,
   AcDbParsingTaskStats,
   AcDbStageStatus

--- a/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
+++ b/packages/data-model/src/dxf/AcDbDxfDocumentReader.ts
@@ -56,6 +56,12 @@ export interface AcDbDxfDocumentReaderOptions {
   onProgress?: (ratio: number) => void | Promise<void>
   /** Total DXF byte length for {@link onProgress}. */
   totalBytes?: number
+  /**
+   * When `true` (default), collect font names from STYLE records and inline
+   * text overrides. When `false`, skip collection and return an empty fonts
+   * list from {@link AcDbDxfDocumentReader.read}.
+   */
+  collectFonts?: boolean
 }
 
 export interface AcDbDxfDocumentReaderResult {
@@ -900,6 +906,7 @@ export class AcDbDxfDocumentReader {
    * need to pick up inline overrides that are not in the style table.
    */
   private collectFontFromStyleRecord(record: AcDbTextStyleTableRecord) {
+    if (this._options.collectFonts === false) return
     if (record.fileName) {
       const normalized = AcDbFontNameCollector.normalizeFontFileName(
         record.fileName
@@ -926,6 +933,7 @@ export class AcDbDxfDocumentReader {
    * this only covers `\f` / `\F` overrides in MTEXT, MLEADER, and TOLERANCE.
    */
   private collectInlineFontsFromEntity(entity: AcDbEntity) {
+    if (this._options.collectFonts === false) return
     const formattedText = this.getEntityFormattedTextForFonts(entity)
     if (!formattedText) return
     for (const font of AcDbFontNameCollector.collectInlineMTextFonts(

--- a/packages/data-model/src/dxf/AcDbNativeDxfConverter.ts
+++ b/packages/data-model/src/dxf/AcDbNativeDxfConverter.ts
@@ -9,7 +9,8 @@ import type { AcDbDatabase } from '../database/AcDbDatabase'
 import {
   type AcDbConversionProgressCallback,
   AcDbDatabaseConverter,
-  type AcDbDatabaseConverterConfig
+  type AcDbDatabaseConverterConfig,
+  type AcDbDatabaseConverterReadOptions
 } from '../database/AcDbDatabaseConverter'
 import { AcDbDxfDocumentReader } from './AcDbDxfDocumentReader'
 
@@ -53,11 +54,14 @@ export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
   override async read(
     data: ArrayBuffer,
     db: AcDbDatabase,
-    minimumChunkSize: number,
-    progress?: AcDbConversionProgressCallback,
-    _timeout?: number,
-    _sysVars?: Record<string, number | boolean | string>
+    options: AcDbDatabaseConverterReadOptions = {}
   ) {
+    const {
+      minimumChunkSize = 10,
+      progress,
+      collectFonts = true
+    } = options
+
     this.progress = progress
 
     const emit = async (
@@ -88,6 +92,7 @@ export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
         entityBatchSize: Math.max(1, minimumChunkSize || 200),
         yieldBudgetMs: ACCM_DEFAULT_UI_YIELD_BUDGET_MS,
         totalBytes,
+        collectFonts,
         onProgress: async ratio => {
           const pct = Math.min(
             PARSE_END_PCT - 1,
@@ -107,7 +112,12 @@ export class AcDbNativeDxfConverter extends AcDbDatabaseConverter<null> {
 
       // Same FONT contract as AcDbDxfConverter / AcDbDatabaseConverter.
       await emit(FONT_START_PCT, 'FONT', 'START')
-      await emit(FONT_END_PCT, 'FONT', 'END', result.fonts)
+      await emit(
+        FONT_END_PCT,
+        'FONT',
+        'END',
+        collectFonts ? result.fonts : []
+      )
 
       await emit(ENTITY_START_PCT, 'ENTITY', 'START')
       const chunkSize = Math.max(1, minimumChunkSize || 200)

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -127,6 +127,7 @@ export type {
   AcDbConverterType,
   AcDbCreateDefaultDataOptions,
   AcDbDatabaseConverterConfig,
+  AcDbDatabaseConverterReadOptions,
   AcDbDatabaseConverterManagerEventArgs,
   AcDbDictObjectEventArgs,
   AcDbDimStyleTableRecordAttrs,


### PR DESCRIPTION
## Summary
- Collapse `AcDbDatabaseConverter.read` positional args into `AcDbDatabaseConverterReadOptions` so new flags stay extensible.
- Add `collectFonts` and automatically set it from `fontLoader != null` in `AcDbDatabase.read`, skipping STYLE/inline font-name scanning when nothing will load fonts.
- Wire the option through the native DXF reader/converter and cover it with unit tests.

## Test plan
- [x] `pnpm test -- --testPathPattern='packages/data-model/__tests__/(AcDbDatabase|AcDbNativeDxfConverter)' --no-coverage`
- [x] `pnpm --filter @mlightcad/data-model exec tsc --noEmit`
- [ ] Smoke-open a DXF with and without `fontLoader` and confirm FONT stage behavior (fonts list empty when omitted; fonts still load when provided)