### PR TITLE
fix: correct OCS transforms for non-default extrusions

### DIFF
--- a/packages/data-model/__tests__/AcDbArc.spec.ts
+++ b/packages/data-model/__tests__/AcDbArc.spec.ts
@@ -322,6 +322,61 @@ describe('AcDbArc', () => {
     expect(arc.endAngle).toBeCloseTo(Math.PI / 2)
   })
 
+  it('syncs OCS refVec when dxfIn reads a -Z extrusion ARC', () => {
+    createWorkingDb()
+    // OCS center (1,2,0), r=4, angles 0°→90°, extrusion (0,0,-1)
+    // WCS center = (-1,2,0); start = (-5,2,0); end = (-1,6,0)
+    const dxf = [
+      '0',
+      'ARC',
+      '5',
+      'BB',
+      '100',
+      'AcDbEntity',
+      '8',
+      '0',
+      '100',
+      'AcDbCircle',
+      '10',
+      '1',
+      '20',
+      '2',
+      '30',
+      '0',
+      '40',
+      '4',
+      '210',
+      '0',
+      '220',
+      '0',
+      '230',
+      '-1',
+      '100',
+      'AcDbArc',
+      '50',
+      '0',
+      '51',
+      '90',
+      '0',
+      'EOF'
+    ].join('\n')
+
+    const filer = AcDbDxfFiler.fromString(dxf)
+    expect(filer.readItem()?.value).toBe('ARC')
+
+    // Factory path mirrors AcDbDxfEntityFactory: default +Z refVec before dxfIn.
+    const arc = new AcDbArc(new AcGePoint3d(), 1, 0, Math.PI / 2)
+    arc.dxfIn(filer)
+
+    expect(arc.normal.z).toBeCloseTo(-1, 8)
+    expect(arc.center.x).toBeCloseTo(-1, 8)
+    expect(arc.center.y).toBeCloseTo(2, 8)
+    expect(arc.startPoint.x).toBeCloseTo(-5, 8)
+    expect(arc.startPoint.y).toBeCloseTo(2, 8)
+    expect(arc.endPoint.x).toBeCloseTo(-1, 8)
+    expect(arc.endPoint.y).toBeCloseTo(6, 8)
+  })
+
   it('writes ARC center and angles in OCS for non-default extrusion', () => {
     createWorkingDb()
     const arc = new AcDbArc(

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -249,7 +249,7 @@ export class AcDbArc extends AcDbCurve {
    * ```
    */
   set normal(value: AcGeVector3dLike) {
-    this._geo.normal = value
+    this.setNormalAndRefVec(value)
   }
 
   /**
@@ -731,11 +731,19 @@ export class AcDbArc extends AcDbCurve {
     nz: number
   ) {
     const normal = new AcGeVector3d(nx, ny, nz)
-    this.normal.copy(normal)
-    this.center = acgeTransformOcsPointToWcs({ x, y, z }, normal)
+    // DXF arcs are created with a default +Z normal/refVec, then filled via
+    // dxfIn. Sync refVec with the OCS X axis or -Z extrusions tessellate on
+    // the mirrored side of the center (messy chords for large-radius fillets).
+    this.setNormalAndRefVec(normal)
+    this.center = acgeTransformOcsPointToWcs({ x, y, z }, this.normal)
     this.radius = radius
     this.startAngle = AcGeMathUtil.degToRad(startDeg)
     this.endAngle = AcGeMathUtil.degToRad(endDeg)
+  }
+
+  private setNormalAndRefVec(normal: AcGeVector3dLike) {
+    this._geo.normal = normal
+    this._geo.refVec = acgeGetOcsReferenceVector(this._geo.normal)
   }
 
   override getOffsetCurves(offsetDist: number): AcDbCurve[] {

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -531,8 +531,11 @@ export class AcDbCircle extends AcDbCurve {
     nz: number
   ) {
     const normal = new AcGeVector3d(nx, ny, nz)
-    this.normal.copy(normal)
-    this.center = acgeTransformOcsPointToWcs({ x, y, z }, normal)
+    // Keep OCS reference vector in sync when dxfIn replaces the default +Z
+    // normal from the entity factory (same issue as {@link AcDbArc}).
+    this._geo.normal = normal
+    this._geo.refVec = acgeGetOcsReferenceVector(this._geo.normal)
+    this.center = acgeTransformOcsPointToWcs({ x, y, z }, this.normal)
     this.radius = radius
   }
 

--- a/packages/geometry-engine/__tests__/AcGeOcsUtil.spec.ts
+++ b/packages/geometry-engine/__tests__/AcGeOcsUtil.spec.ts
@@ -29,4 +29,18 @@ describe('AcGeOcsUtil', () => {
     expect(acgeGetOcsAngle(center, start, normal)).toBeCloseTo(0, 8)
     expect(acgeGetOcsAngle(center, end, normal)).toBeCloseTo(Math.PI / 2, 8)
   })
+
+  it('maps OCS→WCS correctly for a non-axis-aligned extrusion', () => {
+    const normal = { x: 0, y: 1, z: 0 }
+    // Arbitrary Axis: Ax = Wz × N = (-1,0,0), Ay = N × Ax = (0,0,1)
+    const wcs = acgeTransformOcsPointToWcs({ x: 1, y: 2, z: 3 }, normal)
+    expect(wcs.x).toBeCloseTo(-1, 8)
+    expect(wcs.y).toBeCloseTo(3, 8)
+    expect(wcs.z).toBeCloseTo(2, 8)
+
+    const back = acgeTransformWcsPointToOcs(wcs, normal)
+    expect(back.x).toBeCloseTo(1, 8)
+    expect(back.y).toBeCloseTo(2, 8)
+    expect(back.z).toBeCloseTo(3, 8)
+  })
 })

--- a/packages/geometry-engine/src/math/AcGeMatrix3d.ts
+++ b/packages/geometry-engine/src/math/AcGeMatrix3d.ts
@@ -279,24 +279,10 @@ export class AcGeMatrix3d {
         xAxis.crossVectors(AcGeVector3d.Z_AXIS, normal).normalize()
       }
       const yAxis = normal.clone().cross(xAxis).normalize()
-      this.set(
-        xAxis.x,
-        xAxis.y,
-        xAxis.z,
-        0,
-        yAxis.x,
-        yAxis.y,
-        yAxis.z,
-        0,
-        normal.x,
-        normal.y,
-        normal.z,
-        0,
-        0,
-        0,
-        0,
-        1
-      )
+      // Columns must be the OCS basis vectors (same layout as {@link makeBasis}).
+      // Passing axes as rows produced the transpose and broke OCS↔WCS for
+      // non-axis-aligned extrusions.
+      this.makeBasis(xAxis, yAxis, normal)
     } else {
       this.identity()
     }


### PR DESCRIPTION
## Summary
- Fix `AcGeMatrix3d.setFromExtrusionDirection` to build the OCS basis via `makeBasis` (columns) instead of a transposed row layout that broke OCS↔WCS for non-axis-aligned extrusions.
- Sync ARC/CIRCLE OCS `refVec` when `dxfIn` replaces the factory default +Z normal, so -Z extrusions no longer tessellate on the mirrored side of the center.
- Add regression tests for -Z ARC `dxfIn` and non-axis-aligned OCS point mapping.

## Test plan
- [x] `pnpm test -- packages/geometry-engine/__tests__/AcGeOcsUtil.spec.ts packages/data-model/__tests__/AcDbArc.spec.ts`
- [ ] Spot-check a DXF with -Z extrusion arcs/fillets for mirrored chords
- [ ] Spot-check a drawing with tilted (non-axis-aligned) extrusion circles/arcs for correct placement