### PR TITLE
feat: add directBatchPrimitive for entity geometry batching

### DIFF
--- a/packages/data-model/__tests__/AcDbHatch.spec.ts
+++ b/packages/data-model/__tests__/AcDbHatch.spec.ts
@@ -496,6 +496,52 @@ describe('AcDbHatch', () => {
     expect(multiDraw.entities).toHaveLength(2)
   })
 
+  it('reuses and invalidates cached areasFromLoops across draw and mutations', () => {
+    const hatch = new AcDbHatch()
+    hatch.patternName = HATCH_PATTERN_SOLID
+    hatch.add(createRectLoop(0, 0, 3, 2))
+
+    expect(hatch.directBatchPrimitive).toBe('area')
+    expect(hatch.area).toBeCloseTo(6, 8)
+    expect(hatch.directBatchPrimitive).toBe('area')
+
+    const renderer = {
+      subEntityTraits: {} as Record<string, unknown>,
+      area: jest.fn((area: unknown) => ({ kind: 'area', area })),
+      group: jest.fn((entities: unknown[]) => ({ kind: 'group', entities }))
+    }
+    expect(hatch.subWorldDraw(renderer as never)).toMatchObject({
+      kind: 'area'
+    })
+    expect(renderer.area).toHaveBeenCalledTimes(1)
+    expect(renderer.group).not.toHaveBeenCalled()
+
+    hatch.add(createRectLoop(5, 0, 2, 2))
+    expect(hatch.directBatchPrimitive).toBe(null)
+
+    const multiRenderer = {
+      subEntityTraits: {} as Record<string, unknown>,
+      area: jest.fn((area: unknown) => ({ kind: 'area', area })),
+      group: jest.fn((entities: unknown[]) => ({ kind: 'group', entities }))
+    }
+    const multiDraw = hatch.subWorldDraw(
+      multiRenderer as never
+    ) as unknown as {
+      kind: string
+      entities: unknown[]
+    }
+    expect(multiRenderer.area).toHaveBeenCalledTimes(2)
+    expect(multiRenderer.group).toHaveBeenCalledTimes(1)
+    expect(multiDraw.kind).toBe('group')
+
+    const before = hatch.geometricExtents.clone()
+    hatch.transformBy(new AcGeMatrix3d().makeTranslation(10, 0, 0))
+    const after = hatch.geometricExtents
+    expect(after.min.x).toBeCloseTo(before.min.x + 10, 8)
+    expect(after.max.x).toBeCloseTo(before.max.x + 10, 8)
+    expect(hatch.directBatchPrimitive).toBe(null)
+  })
+
   it('passes gradient hatch settings to graphics traits', () => {
     const hatch = new AcDbHatch()
     hatch.hatchObjectType = AcDbHatchObjectType.GradientObject

--- a/packages/data-model/src/entity/AcDb2dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb2dPolyline.ts
@@ -425,6 +425,15 @@ export class AcDb2dPolyline extends AcDbCurve {
   }
 
   /**
+   * This 2d polyline always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this polyline using the specified renderer.
    *
    * @param renderer - The renderer to use for drawing

--- a/packages/data-model/src/entity/AcDb3dPolyline.ts
+++ b/packages/data-model/src/entity/AcDb3dPolyline.ts
@@ -329,6 +329,15 @@ export class AcDb3dPolyline extends AcDbCurve {
   }
 
   /**
+   * This 3d polyline always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this polyline using the specified renderer.
    *
    * @param renderer - The renderer to use for drawing

--- a/packages/data-model/src/entity/AcDbArc.ts
+++ b/packages/data-model/src/entity/AcDbArc.ts
@@ -600,6 +600,15 @@ export class AcDbArc extends AcDbCurve {
   }
 
   /**
+   * This arc always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this arc using the specified renderer.
    *
    * This method renders the arc as a circular arc using the arc's

--- a/packages/data-model/src/entity/AcDbCircle.ts
+++ b/packages/data-model/src/entity/AcDbCircle.ts
@@ -439,6 +439,15 @@ export class AcDbCircle extends AcDbCurve {
   }
 
   /**
+   * This circle always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this circle using the specified renderer.
    *
    * This method renders the circle as a circular arc using the circle's

--- a/packages/data-model/src/entity/AcDbEllipse.ts
+++ b/packages/data-model/src/entity/AcDbEllipse.ts
@@ -581,6 +581,15 @@ export class AcDbEllipse extends AcDbCurve {
   }
 
   /**
+   * This ellipse always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this ellipse using the specified renderer.
    *
    * This method renders the ellipse as an elliptical arc using the ellipse's

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -6,6 +6,7 @@ import {
   AcGeVector3dLike
 } from '@mlightcad/geometry-engine'
 import {
+  AcGiDirectBatchPrimitive,
   AcGiEntity,
   AcGiLineStyle,
   AcGiLineWeight,
@@ -732,6 +733,21 @@ export abstract class AcDbEntity extends AcDbObject {
     renderer: AcGiRenderer,
     delay?: boolean
   ): AcGiEntity | undefined
+
+  /**
+   * The batchable primitive kind emitted by {@link subWorldDraw}, when this entity
+   * is eligible for direct geometry batching without an intermediate drawable tree.
+   *
+   * Default `null`: not eligible. Simple entities override to return the expected
+   * primitive kind (`lineStrip`, `point`, `area`, …). Renderers should still treat
+   * capture misses (wide polyline → `area` instead of `lines`, multi-draw, etc.)
+   * as a fallback to the legacy path.
+   *
+   * @internal
+   */
+  get directBatchPrimitive(): AcGiDirectBatchPrimitive | null {
+    return null
+  }
 
   /**
    * Called by cad application when it wants the entity to draw itself in WCS (World Coordinate

--- a/packages/data-model/src/entity/AcDbFace.ts
+++ b/packages/data-model/src/entity/AcDbFace.ts
@@ -253,6 +253,15 @@ export class AcDbFace extends AcDbEntity {
   }
 
   /**
+   * This face always draws as a single `lineSegments` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineSegments' as const
+  }
+
+  /**
    * Draws this face using the specified renderer.
    *
    * This method renders the face as a filled area using the face's

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -181,6 +181,11 @@ export class AcDbHatch extends AcDbEntity {
 
   /** The underlying geometric area object */
   private _geo: AcGeArea2d
+  /**
+   * Cached result of {@link buildAreasFromLoops}. Cleared when loops change
+   * (`add`, `transformBy`, grip edits).
+   */
+  private _areasFromLoopsCache: AcGeArea2d[] | null = null
   /** The flag to indicate whether the hatch object is configured for solid fill */
   private _isSolidFill: boolean
   /** The elevation (Z-coordinate) of the hatch plane */
@@ -942,12 +947,27 @@ export class AcDbHatch extends AcDbEntity {
    */
   add(loop: AcGeLoop2dType) {
     this._geo.add(loop)
+    this.invalidateAreasFromLoopsCache()
+  }
+
+  private invalidateAreasFromLoopsCache() {
+    this._areasFromLoopsCache = null
   }
 
   private buildAreasFromLoops() {
+    if (this._areasFromLoopsCache != null) {
+      return this._areasFromLoopsCache
+    }
+
     const loops = this._geo.loops
-    if (loops.length === 0) return []
-    if (loops.length === 1) return [this._geo]
+    if (loops.length === 0) {
+      this._areasFromLoopsCache = []
+      return this._areasFromLoopsCache
+    }
+    if (loops.length === 1) {
+      this._areasFromLoopsCache = [this._geo]
+      return this._areasFromLoopsCache
+    }
 
     const hierarchy = this._geo.buildHierarchy()
     const areas: AcGeArea2d[] = []
@@ -968,7 +988,8 @@ export class AcDbHatch extends AcDbEntity {
 
     hierarchy.children.forEach(child => visit(child, 0))
 
-    return areas.length > 0 ? areas : [this._geo]
+    this._areasFromLoopsCache = areas.length > 0 ? areas : [this._geo]
+    return this._areasFromLoopsCache
   }
 
   private getCalculatedAreaValue(): number {
@@ -1158,6 +1179,7 @@ export class AcDbHatch extends AcDbEntity {
     acdbForEachGripIndex(indices, index => {
       this.moveBoundaryGripPointAt(index, offset)
     })
+    this.invalidateAreasFromLoopsCache()
     return this
   }
 
@@ -1666,6 +1688,7 @@ export class AcDbHatch extends AcDbEntity {
       1
     )
     this._geo.transform(matrix2d)
+    this.invalidateAreasFromLoopsCache()
     this._elevation = new AcGePoint3d(0, 0, this._elevation).applyMatrix4(
       matrix
     ).z

--- a/packages/data-model/src/entity/AcDbHatch.ts
+++ b/packages/data-model/src/entity/AcDbHatch.ts
@@ -1598,6 +1598,23 @@ export class AcDbHatch extends AcDbEntity {
   }
 
   /**
+   * Solid (non-gradient) hatches that draw as a single `area` call.
+   * Multi-loop hatches that become a `group` of areas stay on the legacy path.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    if (!this.isSolidFill || this.isGradient) {
+      return null
+    }
+    const areas = this.buildAreasFromLoops()
+    if (areas.length > 1) {
+      return null
+    }
+    return 'area' as const
+  }
+
+  /**
    * @inheritdoc
    */
   subWorldDraw(renderer: AcGiRenderer) {

--- a/packages/data-model/src/entity/AcDbLeader.ts
+++ b/packages/data-model/src/entity/AcDbLeader.ts
@@ -530,6 +530,15 @@ export class AcDbLeader extends AcDbCurve {
   }
 
   /**
+   * This leader always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * @inheritdoc
    */
   subWorldDraw(renderer: AcGiRenderer) {

--- a/packages/data-model/src/entity/AcDbLine.ts
+++ b/packages/data-model/src/entity/AcDbLine.ts
@@ -419,6 +419,15 @@ export class AcDbLine extends AcDbCurve {
   }
 
   /**
+   * This line always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this line using the specified renderer.
    *
    * This method renders the line as a series of connected line segments

--- a/packages/data-model/src/entity/AcDbPoint.ts
+++ b/packages/data-model/src/entity/AcDbPoint.ts
@@ -268,6 +268,17 @@ export class AcDbPoint extends AcDbEntity {
   }
 
   /**
+   * Only the simple PDMODE dot (0) is a single `THREE.Points` drawable.
+   * Other modes emit symbol LineSegments and stay on the legacy path.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    const mode = this.database?.pdmode ?? 0
+    return mode === 0 ? ('point' as const) : null
+  }
+
+  /**
    * Draws this point using the specified renderer.
    *
    * This method renders the point using the point's current style properties,

--- a/packages/data-model/src/entity/AcDbPolyline.ts
+++ b/packages/data-model/src/entity/AcDbPolyline.ts
@@ -626,6 +626,15 @@ export class AcDbPolyline extends AcDbCurve {
   }
 
   /**
+   * Thin centerline → `lineStrip`; any renderable width → solid `area`.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return this.hasRenderableWidth() ? ('area' as const) : ('lineStrip' as const)
+  }
+
+  /**
    * Draws this polyline using the specified renderer.
    *
    * This method renders the polyline as a series of connected line segments
@@ -896,6 +905,22 @@ export class AcDbPolyline extends AcDbCurve {
 
     // Default LWPOLYLINE width is 0; omit group 43 unless there is actual width.
     return common != null && common !== 0 ? common : undefined
+  }
+
+  /**
+   * True when any vertex carries a start/end width above the render epsilon.
+   * Matches the width gate used by {@link createWidthProfile}.
+   */
+  private hasRenderableWidth(): boolean {
+    const vertices = this._geo.vertices
+    for (let i = 0; i < vertices.length; i++) {
+      const startWidth = Math.max(0, vertices[i].startWidth ?? 0)
+      const endWidth = Math.max(0, vertices[i].endWidth ?? 0)
+      if (startWidth > WIDTH_EPSILON || endWidth > WIDTH_EPSILON) {
+        return true
+      }
+    }
+    return false
   }
 
   /**

--- a/packages/data-model/src/entity/AcDbRay.ts
+++ b/packages/data-model/src/entity/AcDbRay.ts
@@ -343,6 +343,15 @@ export class AcDbRay extends AcDbCurve {
   }
 
   /**
+   * This ray always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this ray using the specified renderer.
    *
    * This method renders the ray as a line segment extending from the base point

--- a/packages/data-model/src/entity/AcDbSpline.ts
+++ b/packages/data-model/src/entity/AcDbSpline.ts
@@ -573,6 +573,15 @@ export class AcDbSpline extends AcDbCurve {
   }
 
   /**
+   * This spline always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this spline using the specified renderer.
    *
    * This method renders the spline as a series of connected line segments

--- a/packages/data-model/src/entity/AcDbTrace.ts
+++ b/packages/data-model/src/entity/AcDbTrace.ts
@@ -313,6 +313,15 @@ export class AcDbTrace extends AcDbCurve {
   }
 
   /**
+   * This trace always draws as a single `area` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'area' as const
+  }
+
+  /**
    * Draws this trace using the specified renderer.
    *
    * This method renders the trace as a filled area using the trace's

--- a/packages/data-model/src/entity/AcDbXline.ts
+++ b/packages/data-model/src/entity/AcDbXline.ts
@@ -331,6 +331,15 @@ export class AcDbXline extends AcDbCurve {
   }
 
   /**
+   * This xline always draws as a single `lineStrip` primitive.
+   *
+   * @internal
+   */
+  override get directBatchPrimitive() {
+    return 'lineStrip' as const
+  }
+
+  /**
    * Draws this xline using the specified renderer.
    *
    * This method renders the xline as a line segment extending from the base point

--- a/packages/graphic-interface/src/AcGiDirectBatchPrimitive.ts
+++ b/packages/graphic-interface/src/AcGiDirectBatchPrimitive.ts
@@ -1,0 +1,18 @@
+/**
+ * Primitive kinds that a renderer may capture from a single {@link AcGiRenderer}
+ * draw call and append into a batch without an intermediate scene-graph entity.
+ *
+ * Entities advertise support via the
+ * {@link import('@mlightcad/data-model').AcDbEntity.directBatchPrimitive} accessor.
+ *
+ * @internal
+ */
+export type AcGiDirectBatchPrimitive =
+  /** `lines` / `circularArc` / `ellipticalArc` (tessellated to a point strip). */
+  | 'lineStrip'
+  /** `lineSegments` (indexed `gl.LINES`). */
+  | 'lineSegments'
+  /** `point` with a simple Points drawable (no symbol LineSegments). */
+  | 'point'
+  /** `area` solid fill (single area call, not a group of areas). */
+  | 'area'

--- a/packages/graphic-interface/src/index.ts
+++ b/packages/graphic-interface/src/index.ts
@@ -27,6 +27,7 @@ export {
   acgiResolveSubEntityTraitsRgbFromBackground
 } from './AcGiContext'
 export type { AcGiContextOptions } from './AcGiContext'
+export type { AcGiDirectBatchPrimitive } from './AcGiDirectBatchPrimitive'
 export type { AcGiFontMapping, AcGiRenderer } from './AcGiRenderer'
 export type { AcGiShapeData } from './AcGiShapeData'
 export type { AcGiStyleType } from './AcGiStyleType'

--- a/typedoc.base.jsonc
+++ b/typedoc.base.jsonc
@@ -5,5 +5,6 @@
     // advanced method in the readme.
 
     "$schema": "https://typedoc.org/schema.json",
-    "includeVersion": true
+    "includeVersion": true,
+    "excludeInternal": true
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,7 +10,8 @@
     ],
     "excludeExternals": true,
     "excludePrivate": true,
-    "excludeProtected": false
+    "excludeProtected": false,
+    "excludeInternal": true
 
     // In TypeDoc 0.26 it is possible to specify options which should be inherited
     // by packages here, instead of in a separate file which is extended by each


### PR DESCRIPTION
## Summary
- Add `AcGiDirectBatchPrimitive` and `AcDbEntity.directBatchPrimitive` so renderers can skip the intermediate drawable tree for simple single-primitive entities.
- Override eligibility on common curve/area/point entities (line strips, areas, points, faces), with Hatch/Polyline/Point returning `null` when draw would not be a single matching primitive.
- Set TypeDoc `excludeInternal: true` so these `@internal` batching hooks stay out of public docs.

## Test plan
- [ ] Confirm TypeScript build for `data-model` and `graphic-interface` packages
- [ ] Smoke-render drawings with lines, arcs, circles, polylines (thin + width), solid hatches (single vs multi-loop), points (PDMODE 0 vs other), and faces
- [ ] Verify renderer fallback still works when advertised kind does not match captured draw (e.g. wide polyline area miss)
- [ ] Regenerate docs and confirm `directBatchPrimitive` / `AcGiDirectBatchPrimitive` are excluded