### PR TITLE
fix(data-model): tolerate missing LibreDWG symbol/table names

### DIFF
--- a/packages/data-model/__tests__/AcDbSymbolTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbSymbolTable.spec.ts
@@ -95,6 +95,18 @@ describe('AcDbSymbolTable', () => {
     expect(table.hasId('unnamed-id')).toBe(false)
   })
 
+  it('treats undefined/null names as missing in getAt/has/remove', () => {
+    const db = setupWorkingDatabase()
+    const table = new AcDbSymbolTable<AcDbSymbolTableRecord>(db)
+    table.add(new AcDbSymbolTableRecord({ name: 'A' }))
+
+    expect(table.getAt(undefined as unknown as string)).toBeUndefined()
+    expect(table.getAt(null as unknown as string)).toBeUndefined()
+    expect(table.has(undefined as unknown as string)).toBe(false)
+    expect(table.remove(undefined as unknown as string)).toBe(false)
+    expect(table.getAt('A')?.name).toBe('A')
+  })
+
   it('applies normalized names when subclass overrides normalizeName', () => {
     const db = new AcDbDatabase()
     const table = new LowercaseSymbolTable(db)

--- a/packages/data-model/__tests__/AcDbTable.spec.ts
+++ b/packages/data-model/__tests__/AcDbTable.spec.ts
@@ -268,6 +268,66 @@ describe('AcDbTable', () => {
     expect(renderer.lineSegments).not.toHaveBeenCalled()
   })
 
+  it('resolves anonymous table block by owningBlockRecordId when name is missing', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const block = new AcDbBlockTableRecord()
+    block.name = '*T_MISSING_NAME'
+    block.objectId = 'BTR_TABLE_ANON'
+    db.tables.blockTable.add(block)
+
+    const mtext = new AcDbMText()
+    mtext.contents = 'FROM_OWNING_BTR'
+    mtext.height = 3
+    block.appendEntity(mtext)
+
+    // LibreDWG can omit ldata.name while still providing block_header handle.
+    const table = new AcDbTable(undefined as unknown as string, 1, 1)
+    table.owningBlockRecordId = 'BTR_TABLE_ANON'
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(9)
+    table.setUniformColumnWidth(20)
+    table.setCell(0, {
+      text: 'CELL_FALLBACK',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      cellType: 1,
+      textHeight: 2
+    })
+
+    expect(table.blockName).toBe('')
+    expect(table.blockTableRecord).toBe(block)
+    expect(() =>
+      table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).not.toThrow()
+
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    const mtextCall = renderer.mtext.mock.calls[0] as unknown[]
+    expect((mtextCall[0] as { text: string }).text).toBe('FROM_OWNING_BTR')
+    expect(renderer.lineSegments).not.toHaveBeenCalled()
+  })
+
+  it('draws cell geometry when both block name and owningBlockRecordId are missing', () => {
+    const db = setWorkingDb()
+    const renderer = createRenderer()
+    const table = new AcDbTable(undefined as unknown as string, 1, 1)
+    db.tables.blockTable.modelSpace.appendEntity(table)
+    table.setUniformRowHeight(10)
+    table.setUniformColumnWidth(20)
+    table.setCell(0, {
+      text: 'CELL_ONLY',
+      attachmentPoint: AcGiMTextAttachmentPoint.MiddleCenter,
+      textStyle: 'Standard',
+      cellType: 1,
+      textHeight: 2
+    })
+
+    expect(() =>
+      table.subWorldDraw(renderer as unknown as AcGiRenderer<AcGiEntity>)
+    ).not.toThrow()
+    expect(renderer.mtext).toHaveBeenCalledTimes(1)
+    expect(renderer.lineSegments).toHaveBeenCalledTimes(1)
+  })
+
   it('renders an anonymous table block when cell content is unavailable', () => {
     const db = setWorkingDb()
     const renderer = createRenderer()

--- a/packages/data-model/src/database/AcDbBlockTable.ts
+++ b/packages/data-model/src/database/AcDbBlockTable.ts
@@ -128,7 +128,10 @@ export class AcDbBlockTable extends AcDbSymbolTable<AcDbBlockTableRecord> {
    * @returns The normalized block table record name.
    */
   protected normalizeName(name: string) {
-    const trimmed = name.trim()
+    const trimmed = (name ?? '').trim()
+    if (!trimmed) {
+      return ''
+    }
     if (AcDbBlockTableRecord.isModelSapceName(trimmed)) {
       return AcDbBlockTableRecord.MODEL_SPACE_NAME
     }

--- a/packages/data-model/src/database/AcDbSymbolTable.ts
+++ b/packages/data-model/src/database/AcDbSymbolTable.ts
@@ -347,7 +347,9 @@ export class AcDbSymbolTable<
    * @returns The normalized symbol table record name.
    */
   protected normalizeName(name: string) {
-    return name.trim().toUpperCase()
+    // LibreDWG / partial DXF can omit symbol names; treat missing as empty
+    // so getAt/has/remove return "not found" instead of throwing on `.trim()`.
+    return (name ?? '').trim().toUpperCase()
   }
 
   /**

--- a/packages/data-model/src/database/AcDbViewportTable.ts
+++ b/packages/data-model/src/database/AcDbViewportTable.ts
@@ -45,7 +45,10 @@ export class AcDbViewportTable extends AcDbSymbolTable<AcDbViewportTableRecord> 
    * @returns The normalized viewport table record name.
    */
   protected normalizeName(name: string) {
-    const trimmed = name.trim()
+    const trimmed = (name ?? '').trim()
+    if (!trimmed) {
+      return ''
+    }
     if (AcDbViewportTableRecord.isActiveVportName(trimmed)) {
       return ACTIVE_VPORT_NAME
     }

--- a/packages/data-model/src/entity/AcDbBlockReference.ts
+++ b/packages/data-model/src/entity/AcDbBlockReference.ts
@@ -92,7 +92,7 @@ export class AcDbBlockReference extends AcDbEntity {
    */
   constructor(blockName: string) {
     super()
-    this._blockName = blockName
+    this._blockName = blockName ?? ''
     this._position = new AcGePoint3d()
     this._rotation = 0.0
     this._normal = new AcGeVector3d(0, 0, 1)
@@ -289,6 +289,10 @@ export class AcDbBlockReference extends AcDbEntity {
    * ```
    */
   get blockTableRecord() {
+    // Missing block names must not throw when looking up the BTR.
+    if (!this._blockName) {
+      return undefined
+    }
     return this.database.tables.blockTable.getAt(this._blockName)
   }
 

--- a/packages/data-model/src/entity/AcDbTable.ts
+++ b/packages/data-model/src/entity/AcDbTable.ts
@@ -189,13 +189,35 @@ export class AcDbTable extends AcDbBlockReference {
    * @param numColumns - The number of columns in the table
    */
   constructor(name: string, numRows: number, numColumns: number) {
-    super(name)
+    super(name ?? '')
     this._attachmentPoint = AcGiMTextAttachmentPoint.TopLeft
     this._numColumns = numColumns
     this._numRows = numRows
     this._columnWidth = new Array<number>(numColumns)
     this._rowHeight = new Array<number>(numRows)
     this._cells = new Array<AcDbTableCell>(numRows * numColumns)
+  }
+
+  /**
+   * Resolves the anonymous table block used for rendering.
+   *
+   * LibreDWG sometimes omits the block name (`ldata.name`) while still providing
+   * the hard-pointer block record handle. Prefer name lookup, then fall back to
+   * {@link owningBlockRecordId}.
+   */
+  override get blockTableRecord(): AcDbBlockTableRecord | undefined {
+    const blockName = this.blockName
+    if (blockName) {
+      const byName = this.database.tables.blockTable.getAt(blockName)
+      if (byName) {
+        return byName
+      }
+    }
+    const owningId = this.owningBlockRecordId
+    if (!owningId) {
+      return undefined
+    }
+    return this.database.tables.blockTable.getIdAt(owningId)
   }
 
   /**

--- a/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
+++ b/packages/libredwg-converter/src/AcDbEntitiyConverter.ts
@@ -646,7 +646,7 @@ export class AcDbEntityConverter {
 
   private convertTable(table: DwgTableEntity) {
     const dbEntity = new AcDbTable(
-      table.name,
+      table.name ?? '',
       table.rowCount,
       table.columnCount
     )


### PR DESCRIPTION
## Summary
- Guard symbol-table name normalization and block-reference lookups against omitted/null names from LibreDWG so lookups return not-found instead of throwing on `.trim()`.
- Let `AcDbTable` fall back to `owningBlockRecordId` when the anonymous table block name is missing, while still drawing cell geometry if neither name nor owner id is available.
- Add regression tests for the null-name symbol-table path and both table rendering fallbacks.

## Test plan
- [ ] Run `packages/data-model` tests (`AcDbSymbolTable.spec.ts`, `AcDbTable.spec.ts`)
- [ ] Open a DWG with TABLE entities where LibreDWG omits `ldata.name` but provides `blockRecordHandle` and confirm anonymous table content renders
- [ ] Confirm tables with neither name nor owning block still draw cell text/borders without throwing

Made with [Cursor](https://cursor.com)