### PR TITLE
fix(libredwg-converter): emit wasm as sibling of parser worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ AcDbDatabaseConverterManager.instance.register(
 )
 ```
 
-Deploy `libredwg-parser-worker.js` from `@mlightcad/libredwg-converter`'s `dist/` folder to a public URL (see [example vite config](./packages/example/vite.config.ts)).
+Deploy `libredwg-parser-worker.js` and its sibling `libredwg-web.wasm` from `@mlightcad/libredwg-converter`'s `dist/` folder to the same public directory (see [example vite config](./packages/example/vite.config.ts)).
 
 ### Unregistering a Converter
 
@@ -256,7 +256,7 @@ const dwgConverter = new AcDbLibreDwgConverter({
 })
 ```
 
-Deploy `libredwg-parser-worker.js` from `@mlightcad/libredwg-converter`'s `dist/` folder as a static asset (see [example vite config](./packages/example/vite.config.ts)).
+Deploy `libredwg-parser-worker.js` and its sibling `libredwg-web.wasm` from `@mlightcad/libredwg-converter`'s `dist/` folder as static assets in the same directory (see [example vite config](./packages/example/vite.config.ts)).
 
 **How this limits copyleft propagation**
 
@@ -264,7 +264,7 @@ Deploy `libredwg-parser-worker.js` from `@mlightcad/libredwg-converter`'s `dist/
 | --- | --- | --- |
 | Core SDK (`data-model`, including `AcDbNativeDxfConverter`) | MIT | N/A — no GPL dependency |
 | `libredwg-converter` (main bundle) | GPL | Orchestrates parsing; GPL parser execution stays in worker |
-| `libredwg-parser-worker.js` | GPL | Separate bundle; loaded at runtime; communicates via `postMessage` |
+| `libredwg-parser-worker.js` + `libredwg-web.wasm` | GPL | Separate worker + wasm assets; loaded at runtime; communicates via `postMessage` |
 
 When `useWorker: true` is configured and the worker script is deployed separately:
 

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -1,5 +1,9 @@
+import { existsSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+
+const libredwgWasmSrc =
+  './node_modules/@mlightcad/libredwg-converter/dist/libredwg-web.wasm'
 
 export default defineConfig({
   optimizeDeps: {
@@ -19,7 +23,16 @@ export default defineConfig({
         {
           src: './node_modules/@mlightcad/libredwg-converter/dist/*-worker.js',
           dest: 'assets'
-        }
+        },
+        ...(existsSync(libredwgWasmSrc)
+          ? [
+              {
+                // Sibling of libredwg-parser-worker.js (not inlined; see cad-viewer#494).
+                src: libredwgWasmSrc,
+                dest: 'assets'
+              }
+            ]
+          : [])
       ]
     })
   ]

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -1,9 +1,5 @@
-import { existsSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-
-const libredwgWasmSrc =
-  './node_modules/@mlightcad/libredwg-converter/dist/libredwg-web.wasm'
 
 export default defineConfig({
   optimizeDeps: {
@@ -24,15 +20,12 @@ export default defineConfig({
           src: './node_modules/@mlightcad/libredwg-converter/dist/*-worker.js',
           dest: 'assets'
         },
-        ...(existsSync(libredwgWasmSrc)
-          ? [
-              {
-                // Sibling of libredwg-parser-worker.js (not inlined; see cad-viewer#494).
-                src: libredwgWasmSrc,
-                dest: 'assets'
-              }
-            ]
-          : [])
+        {
+          // Sibling of libredwg-parser-worker.js (not inlined; see cad-viewer#494).
+          // Required: missing wasm must fail the copy, not be skipped silently.
+          src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-web.wasm',
+          dest: 'assets'
+        }
       ]
     })
   ]

--- a/packages/libredwg-converter/README.md
+++ b/packages/libredwg-converter/README.md
@@ -39,7 +39,7 @@ const dwgConverter = new AcDbLibreDwgConverter({
 AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, dwgConverter);
 ```
 
-Deploy `libredwg-parser-worker.js` from this package's `dist/` folder to a public URL accessible by your application.
+Deploy both `libredwg-parser-worker.js` and its sibling `libredwg-web.wasm` from this package's `dist/` folder to the same public directory. The worker loads the wasm from next to itself at runtime.
 
 ## API
 

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverterUtil.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverterUtil.ts
@@ -1,6 +1,9 @@
 import { Dwg_File_Type, LibreDwg } from '@mlightcad/libredwg-web'
 
 export async function parseDwg(data: string) {
+  // LibreDwg.create() loads libredwg-web.wasm via the Emscripten glue's
+  // `new URL(..., import.meta.url)`. The worker build emits that wasm as a
+  // sibling of libredwg-parser-worker.js (not inlined).
   const libredwg = await LibreDwg.create()
   if (libredwg == null) {
     throw new Error('libredwg is not loaded!')

--- a/packages/libredwg-converter/verify-build.profile.json
+++ b/packages/libredwg-converter/verify-build.profile.json
@@ -1,10 +1,14 @@
 {
   "main": "dist/libredwg-converter.umd.cjs",
   "worker": "dist/libredwg-parser-worker.js",
+  "wasm": "dist/libredwg-web.wasm",
   "forbiddenInMain": [
     "WebAssembly",
     "wasmBinary",
     "__wasm_call_ctors",
     "HEAP8"
+  ],
+  "forbiddenInWorker": [
+    "data:application/wasm"
   ]
 }

--- a/packages/libredwg-converter/vite.config.worker.ts
+++ b/packages/libredwg-converter/vite.config.worker.ts
@@ -1,6 +1,7 @@
 import strip from 'vite-plugin-strip-comments'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig, PluginOption, Plugin } from 'vite'
+import { resolve } from 'node:path'
 
 /** Linked packages resolve outside node_modules; strip-comments breaks Emscripten glue (`"file://"`). */
 function stripCommentsSafe(...args: Parameters<typeof strip>): Plugin {
@@ -17,6 +18,16 @@ function stripCommentsSafe(...args: Parameters<typeof strip>): Plugin {
   return plugin
 }
 
+/**
+ * Worker build intentionally avoids `build.lib`.
+ *
+ * Vite library mode always inlines assets (ignores assetsInlineLimit), which
+ * turns the ~10 MB LibreDWG wasm into a multi-megabyte `data:` URI inside
+ * `new URL(..., import.meta.url)`. Webpack then feeds that literal to its
+ * resolver and can hang / throw (see mlightcad/cad-viewer#494).
+ *
+ * A normal Rollup entry emits `libredwg-web.wasm` next to the worker instead.
+ */
 export default defineConfig(({ mode }) => {
   const plugins: PluginOption[] = [stripCommentsSafe({ type: 'none' })]
 
@@ -25,6 +36,8 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    // Relative asset URLs so wasm resolves next to the worker wherever it is hosted.
+    base: './',
     esbuild: {
       drop: ['console'],
       legalComments: 'none'
@@ -32,19 +45,21 @@ export default defineConfig(({ mode }) => {
     build: {
       emptyOutDir: false,
       outDir: 'dist',
-      lib: {
-        entry: 'src/AcDbLibreDwgParserWorker.ts',
-        fileName: 'libredwg-parser-worker',
-        formats: ['es']
-      },
-      minify: 'esbuild',
+      // Keep wasm as a sibling file (lib mode would force-inline it).
+      assetsInlineLimit: 0,
       rollupOptions: {
+        input: resolve(__dirname, 'src/AcDbLibreDwgParserWorker.ts'),
         external: [],
         output: {
+          format: 'es',
+          entryFileNames: 'libredwg-parser-worker.js',
+          // Stable names so deploy/copy scripts can find assets next to the worker.
+          assetFileNames: '[name][extname]',
           inlineDynamicImports: true,
           compact: true
         }
-      }
+      },
+      minify: 'esbuild'
     },
     plugins
   }

--- a/tools/verify-build.mjs
+++ b/tools/verify-build.mjs
@@ -102,12 +102,44 @@ function assertWorkerBundle() {
     )
   }
 
+  for (const marker of profile.forbiddenInWorker ?? []) {
+    if (content.includes(marker)) {
+      fail(
+        `${workerLabel} contains forbidden marker "${marker}"; wasm must be a sibling asset, not inlined`
+      )
+    }
+  }
+
   console.log(
     `verify-build (${profileName}): ${workerLabel} ok (${size} bytes, parser present)`
+  )
+}
+
+function assertWasmAsset() {
+  if (!profile.wasm) {
+    return
+  }
+
+  const wasmPath = join(packageDir, profile.wasm)
+  const wasmLabel = basename(profile.wasm)
+  let size
+  try {
+    size = statSync(wasmPath).size
+  } catch {
+    fail(`missing wasm asset: ${wasmPath}`)
+  }
+
+  if (size < 1024 * 1024) {
+    fail(`${wasmLabel} looks too small (${size} bytes); expected LibreDWG wasm`)
+  }
+
+  console.log(
+    `verify-build (${profileName}): ${wasmLabel} ok (${size} bytes)`
   )
 }
 
 assertMainBundle()
 if (!mainOnly) {
   assertWorkerBundle()
+  assertWasmAsset()
 }


### PR DESCRIPTION
## Summary
- Stop using Vite `build.lib` for the LibreDWG parser worker so `libredwg-web.wasm` is emitted as a sibling file instead of a multi-megabyte `data:` URI (avoids Webpack hang/resolve issues; see mlightcad/cad-viewer#494).
- Extend `verify-build` to require the wasm asset and forbid inlined `data:application/wasm` in the worker bundle.
- Update docs and the example Vite static-copy config so worker + wasm are deployed together.

## Test plan
- [ ] `pnpm --filter @mlightcad/libredwg-converter build` succeeds and produces `dist/libredwg-parser-worker.js` + `dist/libredwg-web.wasm`
- [ ] `verify-build` fails if wasm is missing or worker contains `data:application/wasm`
- [ ] Example app copies both assets into `assets/` and DWG parsing via worker still works
- [ ] Confirm worker JS no longer embeds a huge wasm data URI
