### PR TITLE
fix(data-model): skip write-access checks on detached symbol records

### DIFF
--- a/packages/data-model/__tests__/AcDbSymbolTableRecordWriteAccess.spec.ts
+++ b/packages/data-model/__tests__/AcDbSymbolTableRecordWriteAccess.spec.ts
@@ -1,6 +1,7 @@
 import { AcCmColor } from '@mlightcad/common'
 
 import { AcDbOpenMode } from '../src/base'
+import { acdbHostApplicationServices } from '../src/base/AcDbHostApplicationServices'
 import {
   AcDbDatabase,
   AcDbLayerModifiedEventArgs
@@ -11,6 +12,7 @@ import {
   LAYER_TABLE_RECORD_DIFF_ATTR_KEYS
 } from '../src/database/AcDbLayerTableRecord'
 import { AcDbTextStyleTableRecord } from '../src/database/AcDbTextStyleTableRecord'
+import { AcDbViewportTableRecord } from '../src/database/AcDbViewportTableRecord'
 
 describe('AcDbSymbolTableRecord write access', () => {
   it('derives layer diff keys from default attrs plus name', () => {
@@ -49,6 +51,27 @@ describe('AcDbSymbolTableRecord write access', () => {
 
     db.tables.layerTable.add(layer)
     expect(layer.isOff).toBe(true)
+  })
+
+  it('allows mutating an unbound record after a real handle without a working database', () => {
+    const services = acdbHostApplicationServices() as unknown as {
+      _workingDatabase: AcDbDatabase | null
+    }
+    const previousDb = services._workingDatabase
+    services._workingDatabase = null
+    try {
+      const record = new AcDbViewportTableRecord()
+      record.objectId = '1A2B'
+      expect(record.isTemp).toBe(false)
+      expect(() => {
+        record.standardFlag = 1
+        record.circleSides = 200
+      }).not.toThrow()
+      expect(record.standardFlag).toBe(1)
+      expect(record.circleSides).toBe(200)
+    } finally {
+      services._workingDatabase = previousDb
+    }
   })
 
   it('dispatches layerModified on commit, not during editing', () => {

--- a/packages/data-model/src/base/AcDbObject.ts
+++ b/packages/data-model/src/base/AcDbObject.ts
@@ -371,6 +371,17 @@ export class AcDbObject<ATTRS extends AcDbObjectAttrs = AcDbObjectAttrs> {
   }
 
   /**
+   * Database this object has been added to, or `undefined` if it is still detached.
+   *
+   * Unlike {@link database}, this does not fall back to the host working database.
+   * DWG/DXF import assigns real handles before `add()`; write-access checks must
+   * not consult a possibly-unset or second-copy working-database singleton.
+   */
+  protected get residentDatabase(): AcDbDatabase | undefined {
+    return this._database
+  }
+
+  /**
    * Associates this object with a database. Subclasses may override {@link database}
    * and call this helper to avoid `super` setter restrictions.
    */

--- a/packages/data-model/src/database/AcDbSymbolTableRecord.ts
+++ b/packages/data-model/src/database/AcDbSymbolTableRecord.ts
@@ -91,7 +91,11 @@ export class AcDbSymbolTableRecord<
   /**
    * Ensures this record may be modified.
    *
-   * Temporary records and undo/redo replay are exempt from the open-for-write check.
+   * Temporary records, still-detached records (real handle assigned but not yet
+   * added to a table), and undo/redo replay are exempt from the open-for-write
+   * check. Do not use {@link database} here: that getter falls back to the host
+   * working database and throws when it is unset or belongs to another data-model
+   * copy (Vite + peer `dwg-converter`).
    *
    * @throws Error when an existing record is modified without being opened for write
    */
@@ -100,7 +104,7 @@ export class AcDbSymbolTableRecord<
       return
     }
 
-    const db = this.database
+    const db = this.residentDatabase
     if (!db) {
       return
     }

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -2,13 +2,20 @@ import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
+  resolve: {
+    dedupe: ['@mlightcad/data-model']
+  },
   optimizeDeps: {
-    // Do not prebundle GPL converters: Vite would inline @mlightcad/data-model
+    // Do not prebundle converters: Vite would inline @mlightcad/data-model
     // into the optimized chunk, creating a second HostApplicationServices /
     // workingDatabase singleton. The app then sets workingDatabase on one copy
     // while converter-created entities read the other →
     // "The current working database must be set before using it!".
-    exclude: ['@mlightcad/libredwg-converter', '@mlightcad/data-model']
+    exclude: [
+      '@mlightcad/libredwg-converter',
+      '@mlight-cad/dwg-converter',
+      '@mlightcad/data-model'
+    ]
   },
   build: {
     outDir: 'dist'

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -231,7 +231,6 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     const viewports = model.tables.VPORT.entries
     viewports.forEach(item => {
       const record = new AcDbViewportTableRecord()
-      this.processCommonTableEntryAttrs(item, record)
       if (item.circleSides) {
         record.circleSides = item.circleSides
       }
@@ -341,6 +340,9 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       if (item.ambientColor) {
         record.gsView.ambientColor = item.ambientColor
       }
+      // Assign the DWG handle last so VPORT setters do not hit assertOpenForWrite
+      // on an unbound non-TEMP record (working-database singleton).
+      this.processCommonTableEntryAttrs(item, record)
       db.tables.viewportTable.add(record)
     })
   }


### PR DESCRIPTION
## Summary
- Add `residentDatabase` so write-access checks do not fall back to the host working-database singleton during DWG/DXF import.
- Assign VPORT handles last in LibreDWG conversion so setters do not hit `assertOpenForWrite` on an unbound non-TEMP record.
- Dedupe `@mlightcad/data-model` in the example Vite config and exclude `@mlight-cad/dwg-converter` from prebundling to avoid a second HostApplicationServices copy.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbSymbolTableRecordWriteAccess.spec.ts`
- [ ] Open a DWG with VPORT table entries and confirm import no longer throws on unbound symbol write-access
- [ ] Confirm example app with `@mlight-cad/dwg-converter` no longer reports an unset working database after `workingDatabase` is assigned
