### PR TITLE
fix(data-model): default omitted DXF color to ByLayer instead of CECOLOR

### DIFF
--- a/packages/data-model/__tests__/AcDbDxfPhase3to5.spec.ts
+++ b/packages/data-model/__tests__/AcDbDxfPhase3to5.spec.ts
@@ -481,6 +481,9 @@ describe('DXF Phase 3–5 extensions', () => {
       'SEQEND'
     ].join('\n')
     const db = createWorkingDb()
+    // LibreDWG dwg2dxf often writes $CECOLOR 0 (ByBlock) while omitting
+    // group 62 on ByLayer entities. Import must not copy CECOLOR.
+    db.cecolor.colorIndex = 0
     const filer = AcDbDxfFiler.fromString(snippet, { database: db })
     expect(filer.readItem()?.value).toBe('LINE')
     const line = new AcDbLine(new AcGePoint3d(), new AcGePoint3d(1, 0, 0))
@@ -488,6 +491,11 @@ describe('DXF Phase 3–5 extensions', () => {
     expect(line.objectId).toBe('6EA')
     expect(line.ownerId).toBe('1F')
     expect(line.layer).toBe('3中心线层')
+    expect(line.color.isByLayer).toBe(true)
+    expect(line.color.colorIndex).toBe(256)
+    line.resolveEffectiveProperties()
+    expect(line.color.isByLayer).toBe(true)
+    expect(line.color.colorIndex).toBe(256)
   })
 
   it('reads $CLAYER from HEADER', async () => {

--- a/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
+++ b/packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts
@@ -2685,4 +2685,185 @@ describe('AcDbNativeDxfConverter', () => {
     expect(solid.acisData).toContain('point $-1 1 2 3')
     expect(solid.hasRenderableGeometry).toBe(true)
   })
+
+  it('defaults omitted group 62 to ByLayer even when $CECOLOR is ByBlock', async () => {
+    const dxf = [
+      '0',
+      'SECTION',
+      '2',
+      'HEADER',
+      '9',
+      '$CECOLOR',
+      '62',
+      '0',
+      '0',
+      'ENDSEC',
+      '0',
+      'SECTION',
+      '2',
+      'TABLES',
+      '0',
+      'TABLE',
+      '2',
+      'LAYER',
+      '0',
+      'LAYER',
+      '5',
+      '10',
+      '100',
+      'AcDbSymbolTableRecord',
+      '100',
+      'AcDbLayerTableRecord',
+      '2',
+      'CENTER',
+      '70',
+      '0',
+      '62',
+      '1',
+      '6',
+      'Continuous',
+      '0',
+      'ENDTAB',
+      '0',
+      'ENDSEC',
+      '0',
+      'SECTION',
+      '2',
+      'ENTITIES',
+      '0',
+      'LINE',
+      '5',
+      '55',
+      '102',
+      '{ACAD_REACTORS',
+      '330',
+      '508',
+      '102',
+      '}',
+      '330',
+      '2',
+      '100',
+      'AcDbEntity',
+      '8',
+      'CENTER',
+      '100',
+      'AcDbLine',
+      '10',
+      '0',
+      '20',
+      '0',
+      '30',
+      '0',
+      '11',
+      '10',
+      '21',
+      '0',
+      '31',
+      '0',
+      '0',
+      'LINE',
+      '5',
+      '56',
+      '100',
+      'AcDbEntity',
+      '8',
+      'CENTER',
+      '62',
+      '0',
+      '100',
+      'AcDbLine',
+      '10',
+      '0',
+      '20',
+      '1',
+      '30',
+      '0',
+      '11',
+      '10',
+      '21',
+      '1',
+      '31',
+      '0',
+      '0',
+      'LINE',
+      '5',
+      '57',
+      '100',
+      'AcDbEntity',
+      '8',
+      'CENTER',
+      '62',
+      '3',
+      '100',
+      'AcDbLine',
+      '10',
+      '0',
+      '20',
+      '2',
+      '30',
+      '0',
+      '11',
+      '10',
+      '21',
+      '2',
+      '31',
+      '0',
+      '0',
+      'INSERT',
+      '5',
+      '58',
+      '100',
+      'AcDbEntity',
+      '8',
+      'CENTER',
+      '100',
+      'AcDbBlockReference',
+      '2',
+      'Door',
+      '10',
+      '0',
+      '20',
+      '3',
+      '30',
+      '0',
+      '0',
+      'ENDSEC',
+      '0',
+      'EOF',
+      ''
+    ].join('\n')
+
+    const db = new AcDbDatabase()
+    db.createDefaultData()
+    acdbHostApplicationServices().workingDatabase = db
+
+    const converter = new AcDbNativeDxfConverter()
+    const buffer = new TextEncoder().encode(dxf).buffer
+    await converter.read(buffer, db, { minimumChunkSize: 50 })
+
+    expect(db.cecolor.isByBlock).toBe(true)
+
+    const entities = [...db.tables.blockTable.modelSpace.newIterator()]
+    expect(entities).toHaveLength(4)
+
+    const omitted = entities[0] as AcDbLine
+    expect(omitted).toBeInstanceOf(AcDbLine)
+    expect(omitted.layer).toBe('CENTER')
+    expect(omitted.color.isByLayer).toBe(true)
+    expect(omitted.color.colorIndex).toBe(256)
+    expect(omitted.resolvedColor.colorIndex).toBe(1)
+
+    const byBlock = entities[1] as AcDbLine
+    expect(byBlock.color.isByBlock).toBe(true)
+    expect(byBlock.color.colorIndex).toBe(0)
+
+    const aci = entities[2] as AcDbLine
+    expect(aci.color.isByACI).toBe(true)
+    expect(aci.color.colorIndex).toBe(3)
+
+    const insert = entities[3] as AcDbBlockReference
+    expect(insert).toBeInstanceOf(AcDbBlockReference)
+    expect(insert.color.isByLayer).toBe(true)
+    expect(insert.color.colorIndex).toBe(256)
+  })
 })

--- a/packages/data-model/src/entity/AcDbEntity.ts
+++ b/packages/data-model/src/entity/AcDbEntity.ts
@@ -501,6 +501,13 @@ export abstract class AcDbEntity extends AcDbObject {
       }
     }
 
+    // Omitted group 62 is ByLayer per the DXF spec. Do not leave `_color`
+    // unset: appendEntity copies CECOLOR, which only seeds newly created
+    // entities (LibreDWG dwg2dxf often writes $CECOLOR 0 / ByBlock).
+    if (!this.hasExplicitColor()) {
+      this.setEntityColor(new AcCmColor().setByLayer())
+    }
+
     return this
   }
 


### PR DESCRIPTION
## Summary
- DXF import now treats omitted group 62 as ByLayer, instead of copying ``.
- This matches the DXF spec and avoids LibreDWG dwg2dxf files (`` 0 / ByBlock, no group 62) painting entities ByBlock.
- Adds filer and native converter coverage for omitted, ByBlock, ACI, and INSERT colors.

## Test plan
- [x] `pnpm exec jest packages/data-model/__tests__/AcDbDxfPhase3to5.spec.ts packages/data-model/__tests__/AcDbNativeDxfConverter.spec.ts`
- [ ] Open a LibreDWG `dwg2dxf` drawing whose header `` is 0 and confirm ByLayer entities keep ACI 256 / layer color
- [ ] Confirm entities that explicitly write group 62 = 0 stay ByBlock, and group 62 ACI values are unchanged