### PR TITLE
feat(data-model): classify DWG converter license failures

### DIFF
--- a/packages/data-model/__tests__/AcDbOpenDatabaseError.spec.ts
+++ b/packages/data-model/__tests__/AcDbOpenDatabaseError.spec.ts
@@ -21,6 +21,40 @@ describe('AcDbOpenDatabaseError', () => {
     expect(error.stage).toBe('PARSE')
   })
 
+  it('classifies structured license errors from thrown values', () => {
+    const expired = new Error(
+      'Your 30-day evaluation of @mlight-cad/dwg-converter has expired. Contact MLightCAD to obtain a license key.'
+    )
+    expired.name = 'DwgConverterLicenseError'
+    ;(expired as Error & { code: string }).code = 'license_expired'
+
+    const openError = AcDbOpenDatabaseError.from(expired, 'PARSE')
+    expect(openError.code).toBe('license_expired')
+    expect(openError.cause).toBe(expired)
+    expect(AcDbOpenDatabaseError.isLicenseErrorCode(openError.code)).toBe(true)
+
+    const invalid = new Error(
+      'Invalid @mlight-cad/dwg-converter license key. Check the key or contact MLightCAD support.'
+    )
+    invalid.name = 'DwgConverterLicenseError'
+    ;(invalid as Error & { code: string }).code = 'license_invalid'
+
+    expect(AcDbOpenDatabaseError.from(invalid).code).toBe('license_invalid')
+  })
+
+  it('classifies license failures from message markers', () => {
+    expect(
+      AcDbOpenDatabaseError.classifyWorkerErrorMessage(
+        'Your 30-day evaluation of @mlight-cad/dwg-converter has expired. Contact MLightCAD to obtain a license key.'
+      )
+    ).toBe('license_expired')
+    expect(
+      AcDbOpenDatabaseError.classifyWorkerErrorMessage(
+        'Invalid @mlight-cad/dwg-converter license key. Check the key or contact MLightCAD support.'
+      )
+    ).toBe('license_invalid')
+  })
+
   it('throws typed parse failures from worker results', () => {
     expect(() =>
       AcDbOpenDatabaseError.throwOnWorkerParseFailure({
@@ -43,6 +77,34 @@ describe('AcDbOpenDatabaseError', () => {
     } catch (error) {
       expect((error as AcDbOpenDatabaseError).code).toBe('worker_oom')
       expect((error as AcDbOpenDatabaseError).name).toBe('AcDbOpenDatabaseError')
+    }
+  })
+
+  it('maps worker license error codes through parse failures', () => {
+    try {
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure({
+        success: false,
+        error:
+          'Your 30-day evaluation of @mlight-cad/dwg-converter has expired. Contact MLightCAD to obtain a license key.',
+        errorCode: 'license_expired',
+        duration: 1
+      })
+      fail('expected throw')
+    } catch (error) {
+      expect((error as AcDbOpenDatabaseError).code).toBe('license_expired')
+    }
+
+    try {
+      AcDbOpenDatabaseError.throwOnWorkerParseFailure({
+        success: false,
+        error:
+          'Invalid @mlight-cad/dwg-converter license key. Check the key or contact MLightCAD support.',
+        errorCode: 'license_invalid',
+        duration: 1
+      })
+      fail('expected throw')
+    } catch (error) {
+      expect((error as AcDbOpenDatabaseError).code).toBe('license_invalid')
     }
   })
 })

--- a/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
+++ b/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
@@ -7,9 +7,9 @@
 
 import {
   ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME,
-  classifyDwgConverterLicenseMessage,
-  classifyDwgConverterLicenseMessageOrInvalid,
-  isDwgConverterLicenseCode
+  acdbClassifyDwgConverterLicenseMessage,
+  acdbClassifyDwgConverterLicenseMessageOrInvalid,
+  acdbIsDwgConverterLicenseCode
 } from './AcDbDwgConverterLicense'
 
 /** Message sent from the main thread to a worker task. */
@@ -127,15 +127,15 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
   ): AcDbWorkerErrorCode {
     if (error instanceof Error) {
       const code = (error as { code?: unknown }).code
-      if (isDwgConverterLicenseCode(code)) {
+      if (acdbIsDwgConverterLicenseCode(code)) {
         return code
       }
       if (error.name === ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME) {
-        return classifyDwgConverterLicenseMessageOrInvalid(message)
+        return acdbClassifyDwgConverterLicenseMessageOrInvalid(message)
       }
     }
 
-    const licenseCode = classifyDwgConverterLicenseMessage(message)
+    const licenseCode = acdbClassifyDwgConverterLicenseMessage(message)
     if (licenseCode) {
       return licenseCode
     }

--- a/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
+++ b/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
@@ -5,6 +5,13 @@
 
 /// <reference lib="webworker" />
 
+import {
+  ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME,
+  classifyDwgConverterLicenseMessage,
+  classifyDwgConverterLicenseMessageOrInvalid,
+  isDwgConverterLicenseCode
+} from './AcDbDwgConverterLicense'
+
 /** Message sent from the main thread to a worker task. */
 export interface AcDbWorkerMessage<TInput = unknown> {
   /** Unique task identifier used to correlate the response. */
@@ -120,15 +127,15 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
   ): AcDbWorkerErrorCode {
     if (error instanceof Error) {
       const code = (error as { code?: unknown }).code
-      if (code === 'license_expired' || code === 'license_invalid') {
+      if (isDwgConverterLicenseCode(code)) {
         return code
       }
-      if (error.name === 'DwgConverterLicenseError') {
-        return this.classifyLicenseMessage(message)
+      if (error.name === ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME) {
+        return classifyDwgConverterLicenseMessageOrInvalid(message)
       }
     }
 
-    const licenseCode = this.classifyLicenseMessageFromText(message)
+    const licenseCode = classifyDwgConverterLicenseMessage(message)
     if (licenseCode) {
       return licenseCode
     }
@@ -148,25 +155,6 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
       return 'worker_oom'
     }
     return 'worker_error'
-  }
-
-  private classifyLicenseMessage(
-    message: string
-  ): 'license_expired' | 'license_invalid' {
-    return this.classifyLicenseMessageFromText(message) ?? 'license_invalid'
-  }
-
-  private classifyLicenseMessageFromText(
-    message: string
-  ): 'license_expired' | 'license_invalid' | undefined {
-    const lower = message.toLowerCase()
-    if (lower.includes('evaluation of @mlight-cad/dwg-converter has expired')) {
-      return 'license_expired'
-    }
-    if (lower.includes('invalid @mlight-cad/dwg-converter license key')) {
-      return 'license_invalid'
-    }
-    return undefined
   }
 
   /**

--- a/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
+++ b/packages/data-model/src/converter/worker/AcDbBaseWorker.ts
@@ -19,11 +19,15 @@ export interface AcDbWorkerMessage<TInput = unknown> {
  * - `worker_oom` — postMessage failed due to memory or clone limits
  * - `worker_timeout` — task exceeded the configured timeout (main thread)
  * - `worker_error` — generic worker or postMessage failure
+ * - `license_expired` — DWG converter evaluation period has ended
+ * - `license_invalid` — DWG converter license key is missing, malformed, expired, or invalid
  */
 export type AcDbWorkerErrorCode =
   | 'worker_oom'
   | 'worker_timeout'
   | 'worker_error'
+  | 'license_expired'
+  | 'license_invalid'
 
 /** Response posted back to the main thread after a worker task completes. */
 export interface AcDbWorkerResponse<TOutput = unknown> {
@@ -59,11 +63,14 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
         const result = await this.executeTask(input)
         this.sendResponse(id, true, result)
       } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error)
         this.sendResponse(
           id,
           false,
           undefined,
-          error instanceof Error ? error.message : String(error)
+          message,
+          this.classifyTaskError(error, message)
         )
       }
     }
@@ -102,6 +109,34 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
   }
 
   /**
+   * Map a thrown worker task error to a structured error code.
+   *
+   * Prefers a structured `code` on the error (for example license failures),
+   * then the error name, then message heuristics.
+   */
+  private classifyTaskError(
+    error: unknown,
+    message: string
+  ): AcDbWorkerErrorCode {
+    if (error instanceof Error) {
+      const code = (error as { code?: unknown }).code
+      if (code === 'license_expired' || code === 'license_invalid') {
+        return code
+      }
+      if (error.name === 'DwgConverterLicenseError') {
+        return this.classifyLicenseMessage(message)
+      }
+    }
+
+    const licenseCode = this.classifyLicenseMessageFromText(message)
+    if (licenseCode) {
+      return licenseCode
+    }
+
+    return this.classifyPostMessageError(message)
+  }
+
+  /**
    * Map a postMessage failure message to a structured error code.
    */
   private classifyPostMessageError(message: string): AcDbWorkerErrorCode {
@@ -113,6 +148,25 @@ export abstract class AcDbBaseWorker<TInput = unknown, TOutput = unknown> {
       return 'worker_oom'
     }
     return 'worker_error'
+  }
+
+  private classifyLicenseMessage(
+    message: string
+  ): 'license_expired' | 'license_invalid' {
+    return this.classifyLicenseMessageFromText(message) ?? 'license_invalid'
+  }
+
+  private classifyLicenseMessageFromText(
+    message: string
+  ): 'license_expired' | 'license_invalid' | undefined {
+    const lower = message.toLowerCase()
+    if (lower.includes('evaluation of @mlight-cad/dwg-converter has expired')) {
+      return 'license_expired'
+    }
+    if (lower.includes('invalid @mlight-cad/dwg-converter license key')) {
+      return 'license_invalid'
+    }
+    return undefined
   }
 
   /**

--- a/packages/data-model/src/converter/worker/AcDbDwgConverterLicense.ts
+++ b/packages/data-model/src/converter/worker/AcDbDwgConverterLicense.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared helpers for classifying `@mlight-cad/dwg-converter` license failures.
+ *
+ * Markers are kept in sync with the converter's user-facing license messages.
+ */
+
+/** Error name thrown by `@mlight-cad/dwg-converter` for license failures. */
+export const ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME =
+  'DwgConverterLicenseError'
+
+/** Machine-readable license failure codes shared by worker and open-database errors. */
+export type AcDbDwgConverterLicenseCode =
+  | 'license_expired'
+  | 'license_invalid'
+
+const LICENSE_EXPIRED_MARKERS = [
+  'evaluation of @mlight-cad/dwg-converter has expired'
+] as const
+
+const LICENSE_INVALID_MARKERS = [
+  'invalid @mlight-cad/dwg-converter license key'
+] as const
+
+/**
+ * Returns `true` when {@link code} is a DWG converter license failure code.
+ */
+export function isDwgConverterLicenseCode(
+  code: unknown
+): code is AcDbDwgConverterLicenseCode {
+  return code === 'license_expired' || code === 'license_invalid'
+}
+
+/**
+ * Classifies a license failure message into expired vs invalid.
+ *
+ * @returns The matching license code, or `undefined` when no marker matches
+ */
+export function classifyDwgConverterLicenseMessage(
+  message: string
+): AcDbDwgConverterLicenseCode | undefined {
+  const lower = message.toLowerCase()
+  if (LICENSE_EXPIRED_MARKERS.some(marker => lower.includes(marker))) {
+    return 'license_expired'
+  }
+  if (LICENSE_INVALID_MARKERS.some(marker => lower.includes(marker))) {
+    return 'license_invalid'
+  }
+  return undefined
+}
+
+/**
+ * Classifies a known license error message, defaulting unknown text to invalid.
+ */
+export function classifyDwgConverterLicenseMessageOrInvalid(
+  message: string
+): AcDbDwgConverterLicenseCode {
+  return classifyDwgConverterLicenseMessage(message) ?? 'license_invalid'
+}

--- a/packages/data-model/src/converter/worker/AcDbDwgConverterLicense.ts
+++ b/packages/data-model/src/converter/worker/AcDbDwgConverterLicense.ts
@@ -24,7 +24,7 @@ const LICENSE_INVALID_MARKERS = [
 /**
  * Returns `true` when {@link code} is a DWG converter license failure code.
  */
-export function isDwgConverterLicenseCode(
+export function acdbIsDwgConverterLicenseCode(
   code: unknown
 ): code is AcDbDwgConverterLicenseCode {
   return code === 'license_expired' || code === 'license_invalid'
@@ -35,7 +35,7 @@ export function isDwgConverterLicenseCode(
  *
  * @returns The matching license code, or `undefined` when no marker matches
  */
-export function classifyDwgConverterLicenseMessage(
+export function acdbClassifyDwgConverterLicenseMessage(
   message: string
 ): AcDbDwgConverterLicenseCode | undefined {
   const lower = message.toLowerCase()
@@ -51,8 +51,8 @@ export function classifyDwgConverterLicenseMessage(
 /**
  * Classifies a known license error message, defaulting unknown text to invalid.
  */
-export function classifyDwgConverterLicenseMessageOrInvalid(
+export function acdbClassifyDwgConverterLicenseMessageOrInvalid(
   message: string
 ): AcDbDwgConverterLicenseCode {
-  return classifyDwgConverterLicenseMessage(message) ?? 'license_invalid'
+  return acdbClassifyDwgConverterLicenseMessage(message) ?? 'license_invalid'
 }

--- a/packages/data-model/src/database/AcDbOpenDatabaseError.ts
+++ b/packages/data-model/src/database/AcDbOpenDatabaseError.ts
@@ -1,6 +1,12 @@
 import { AcCmTaskError } from '@mlightcad/common'
 
 import type { AcDbWorkerErrorCode } from '../converter/worker/AcDbBaseWorker'
+import {
+  ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME,
+  classifyDwgConverterLicenseMessage,
+  classifyDwgConverterLicenseMessageOrInvalid,
+  isDwgConverterLicenseCode
+} from '../converter/worker/AcDbDwgConverterLicense'
 import { AcDbWorkerResult } from '../converter/worker/AcDbWorkerManager'
 import { AcDbConversionStage } from './AcDbDatabaseConverter'
 
@@ -63,19 +69,6 @@ export class AcDbOpenDatabaseError extends Error {
   ]
 
   /**
-   * Message markers used when a thrown license error lacks a structured `code`.
-   *
-   * Kept in sync with `@mlight-cad/dwg-converter` user-facing license messages.
-   */
-  private static readonly LICENSE_EXPIRED_MARKERS = [
-    'evaluation of @mlight-cad/dwg-converter has expired'
-  ]
-
-  private static readonly LICENSE_INVALID_MARKERS = [
-    'invalid @mlight-cad/dwg-converter license key'
-  ]
-
-  /**
    * Creates a new open-database error.
    *
    * @param message - Human-readable failure description
@@ -100,7 +93,7 @@ export class AcDbOpenDatabaseError extends Error {
   static isLicenseErrorCode(
     code: AcDbOpenDatabaseErrorCode
   ): code is 'license_expired' | 'license_invalid' {
-    return code === 'license_expired' || code === 'license_invalid'
+    return isDwgConverterLicenseCode(code)
   }
 
   /**
@@ -133,8 +126,8 @@ export class AcDbOpenDatabaseError extends Error {
         return structured
       }
 
-      if (error.name === 'DwgConverterLicenseError') {
-        return AcDbOpenDatabaseError.classifyLicenseMessage(error.message)
+      if (error.name === ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME) {
+        return classifyDwgConverterLicenseMessageOrInvalid(error.message)
       }
     }
 
@@ -154,25 +147,14 @@ export class AcDbOpenDatabaseError extends Error {
   static classifyWorkerErrorMessage(
     message: string
   ): AcDbOpenDatabaseErrorCode {
-    const lower = message.toLowerCase()
-    if (
-      AcDbOpenDatabaseError.LICENSE_EXPIRED_MARKERS.some(marker =>
-        lower.includes(marker)
-      )
-    ) {
-      return 'license_expired'
-    }
-    if (
-      AcDbOpenDatabaseError.LICENSE_INVALID_MARKERS.some(marker =>
-        lower.includes(marker)
-      )
-    ) {
-      return 'license_invalid'
+    const licenseCode = classifyDwgConverterLicenseMessage(message)
+    if (licenseCode) {
+      return licenseCode
     }
     if (AcDbOpenDatabaseError.isWorkerOutOfMemoryMessage(message)) {
       return 'worker_oom'
     }
-    if (lower.includes('timed out')) {
+    if (message.toLowerCase().includes('timed out')) {
       return 'worker_timeout'
     }
     return 'worker_error'
@@ -299,25 +281,5 @@ export class AcDbOpenDatabaseError extends Error {
       default:
         return undefined
     }
-  }
-
-  /**
-   * Classifies license failure messages into expired vs invalid.
-   *
-   * Used for `DwgConverterLicenseError` instances that omit a structured
-   * `code`. Unknown license messages default to `license_invalid`.
-   */
-  private static classifyLicenseMessage(
-    message: string
-  ): 'license_expired' | 'license_invalid' {
-    const lower = message.toLowerCase()
-    if (
-      AcDbOpenDatabaseError.LICENSE_EXPIRED_MARKERS.some(marker =>
-        lower.includes(marker)
-      )
-    ) {
-      return 'license_expired'
-    }
-    return 'license_invalid'
   }
 }

--- a/packages/data-model/src/database/AcDbOpenDatabaseError.ts
+++ b/packages/data-model/src/database/AcDbOpenDatabaseError.ts
@@ -13,6 +13,8 @@ import { AcDbConversionStage } from './AcDbDatabaseConverter'
  * - `parse_failed` — the drawing could not be parsed into an {@link AcDbDatabase}
  * - `font_load_failed` — required font files could not be downloaded or loaded
  * - `fetch_failed` — the drawing source could not be fetched from a URI
+ * - `license_expired` — DWG converter evaluation period has ended
+ * - `license_invalid` — DWG converter license key is missing, malformed, expired, or invalid
  * - `unknown` — failure reason could not be classified
  */
 export type AcDbOpenDatabaseErrorCode =
@@ -22,13 +24,15 @@ export type AcDbOpenDatabaseErrorCode =
   | 'parse_failed'
   | 'font_load_failed'
   | 'fetch_failed'
+  | 'license_expired'
+  | 'license_invalid'
   | 'unknown'
 
 /**
  * Structured error thrown when opening a drawing database fails.
  *
  * Callers can inspect {@link code} to distinguish worker out-of-memory failures
- * from parse errors, timeouts, and other failure modes.
+ * from parse errors, timeouts, license failures, and other failure modes.
  */
 export class AcDbOpenDatabaseError extends Error {
   /** Machine-readable failure category for programmatic handling. */
@@ -42,6 +46,9 @@ export class AcDbOpenDatabaseError extends Error {
    */
   readonly stage?: AcDbConversionStage
 
+  /** Original thrown value that was normalized into this error, when available. */
+  readonly cause?: unknown
+
   /**
    * Substrings matched against worker error messages to detect out-of-memory failures.
    *
@@ -53,6 +60,19 @@ export class AcDbOpenDatabaseError extends Error {
     'data cannot be cloned',
     'allocation failed',
     'memory access out of bounds'
+  ]
+
+  /**
+   * Message markers used when a thrown license error lacks a structured `code`.
+   *
+   * Kept in sync with `@mlight-cad/dwg-converter` user-facing license messages.
+   */
+  private static readonly LICENSE_EXPIRED_MARKERS = [
+    'evaluation of @mlight-cad/dwg-converter has expired'
+  ]
+
+  private static readonly LICENSE_INVALID_MARKERS = [
+    'invalid @mlight-cad/dwg-converter license key'
   ]
 
   /**
@@ -71,6 +91,16 @@ export class AcDbOpenDatabaseError extends Error {
     this.name = 'AcDbOpenDatabaseError'
     this.code = code
     this.stage = options?.stage
+    this.cause = options?.cause
+  }
+
+  /**
+   * Returns `true` when {@link code} is a license failure.
+   */
+  static isLicenseErrorCode(
+    code: AcDbOpenDatabaseErrorCode
+  ): code is 'license_expired' | 'license_invalid' {
+    return code === 'license_expired' || code === 'license_invalid'
   }
 
   /**
@@ -87,10 +117,36 @@ export class AcDbOpenDatabaseError extends Error {
   }
 
   /**
+   * Classifies a thrown value into an {@link AcDbOpenDatabaseErrorCode}.
+   *
+   * Prefers a structured `code` on the error (for example
+   * `DwgConverterLicenseError.code`), then the error `name`, then message
+   * heuristics used for worker/postMessage failures.
+   *
+   * @param error - Thrown value from an open or conversion operation
+   * @returns The inferred open-database error code
+   */
+  static classifyThrownError(error: unknown): AcDbOpenDatabaseErrorCode {
+    if (error instanceof Error) {
+      const structured = AcDbOpenDatabaseError.readStructuredCode(error)
+      if (structured) {
+        return structured
+      }
+
+      if (error.name === 'DwgConverterLicenseError') {
+        return AcDbOpenDatabaseError.classifyLicenseMessage(error.message)
+      }
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+    return AcDbOpenDatabaseError.classifyWorkerErrorMessage(message)
+  }
+
+  /**
    * Classifies a worker error message into an {@link AcDbOpenDatabaseErrorCode}.
    *
-   * Checks out-of-memory patterns first, then timeout wording, and falls back to
-   * `worker_error` for all other messages.
+   * Checks license markers, then out-of-memory patterns, then timeout wording,
+   * and falls back to `worker_error` for all other messages.
    *
    * @param message - Worker or postMessage error text to classify
    * @returns The inferred open-database error code
@@ -98,10 +154,25 @@ export class AcDbOpenDatabaseError extends Error {
   static classifyWorkerErrorMessage(
     message: string
   ): AcDbOpenDatabaseErrorCode {
+    const lower = message.toLowerCase()
+    if (
+      AcDbOpenDatabaseError.LICENSE_EXPIRED_MARKERS.some(marker =>
+        lower.includes(marker)
+      )
+    ) {
+      return 'license_expired'
+    }
+    if (
+      AcDbOpenDatabaseError.LICENSE_INVALID_MARKERS.some(marker =>
+        lower.includes(marker)
+      )
+    ) {
+      return 'license_invalid'
+    }
     if (AcDbOpenDatabaseError.isWorkerOutOfMemoryMessage(message)) {
       return 'worker_oom'
     }
-    if (message.toLowerCase().includes('timed out')) {
+    if (lower.includes('timed out')) {
       return 'worker_timeout'
     }
     return 'worker_error'
@@ -126,7 +197,7 @@ export class AcDbOpenDatabaseError extends Error {
     }
 
     const message = error instanceof Error ? error.message : String(error)
-    const code = AcDbOpenDatabaseError.classifyWorkerErrorMessage(message)
+    const code = AcDbOpenDatabaseError.classifyThrownError(error)
     return new AcDbOpenDatabaseError(message, code, { stage, cause: error })
   }
 
@@ -194,8 +265,59 @@ export class AcDbOpenDatabaseError extends Error {
         return 'worker_timeout'
       case 'worker_error':
         return 'worker_error'
+      case 'license_expired':
+        return 'license_expired'
+      case 'license_invalid':
+        return 'license_invalid'
       default:
         return AcDbOpenDatabaseError.classifyWorkerErrorMessage(message ?? '')
     }
+  }
+
+  /**
+   * Reads a structured machine-readable code from a thrown error when present.
+   */
+  private static readStructuredCode(
+    error: Error
+  ): AcDbOpenDatabaseErrorCode | undefined {
+    const code = (error as { code?: unknown }).code
+    if (typeof code !== 'string') {
+      return undefined
+    }
+
+    switch (code) {
+      case 'license_expired':
+      case 'license_invalid':
+      case 'worker_oom':
+      case 'worker_timeout':
+      case 'worker_error':
+      case 'parse_failed':
+      case 'font_load_failed':
+      case 'fetch_failed':
+      case 'unknown':
+        return code
+      default:
+        return undefined
+    }
+  }
+
+  /**
+   * Classifies license failure messages into expired vs invalid.
+   *
+   * Used for `DwgConverterLicenseError` instances that omit a structured
+   * `code`. Unknown license messages default to `license_invalid`.
+   */
+  private static classifyLicenseMessage(
+    message: string
+  ): 'license_expired' | 'license_invalid' {
+    const lower = message.toLowerCase()
+    if (
+      AcDbOpenDatabaseError.LICENSE_EXPIRED_MARKERS.some(marker =>
+        lower.includes(marker)
+      )
+    ) {
+      return 'license_expired'
+    }
+    return 'license_invalid'
   }
 }

--- a/packages/data-model/src/database/AcDbOpenDatabaseError.ts
+++ b/packages/data-model/src/database/AcDbOpenDatabaseError.ts
@@ -3,9 +3,9 @@ import { AcCmTaskError } from '@mlightcad/common'
 import type { AcDbWorkerErrorCode } from '../converter/worker/AcDbBaseWorker'
 import {
   ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME,
-  classifyDwgConverterLicenseMessage,
-  classifyDwgConverterLicenseMessageOrInvalid,
-  isDwgConverterLicenseCode
+  acdbClassifyDwgConverterLicenseMessage,
+  acdbClassifyDwgConverterLicenseMessageOrInvalid,
+  acdbIsDwgConverterLicenseCode
 } from '../converter/worker/AcDbDwgConverterLicense'
 import { AcDbWorkerResult } from '../converter/worker/AcDbWorkerManager'
 import { AcDbConversionStage } from './AcDbDatabaseConverter'
@@ -93,7 +93,7 @@ export class AcDbOpenDatabaseError extends Error {
   static isLicenseErrorCode(
     code: AcDbOpenDatabaseErrorCode
   ): code is 'license_expired' | 'license_invalid' {
-    return isDwgConverterLicenseCode(code)
+    return acdbIsDwgConverterLicenseCode(code)
   }
 
   /**
@@ -127,7 +127,7 @@ export class AcDbOpenDatabaseError extends Error {
       }
 
       if (error.name === ACDB_DWG_CONVERTER_LICENSE_ERROR_NAME) {
-        return classifyDwgConverterLicenseMessageOrInvalid(error.message)
+        return acdbClassifyDwgConverterLicenseMessageOrInvalid(error.message)
       }
     }
 
@@ -147,7 +147,7 @@ export class AcDbOpenDatabaseError extends Error {
   static classifyWorkerErrorMessage(
     message: string
   ): AcDbOpenDatabaseErrorCode {
-    const licenseCode = classifyDwgConverterLicenseMessage(message)
+    const licenseCode = acdbClassifyDwgConverterLicenseMessage(message)
     if (licenseCode) {
       return licenseCode
     }

--- a/tools/use-dwg-converter.mjs
+++ b/tools/use-dwg-converter.mjs
@@ -6,12 +6,14 @@
  * Updates packages/example:
  *   - index.html: LibreDWG → dwg-converter
  *   - package.json: dependency name
- *   - vite.config.ts: package references + dwg-codepage-*.bin static copy
+ *   - vite.config.ts: package references, drop libredwg-web.wasm, add
+ *     dwg-codepage-*.bin static copy
  *   - src/main.ts: import, class name and worker file references
  *
  * If packages/dwg-converter/package.json exists:
- *   - set @mlightcad/data-model version to link:../data-model
- *     (dwg-converter is outside the pnpm workspace / public lockfile)
+ *   - set @mlightcad/data-model in dependencies/devDependencies to
+ *     link:../data-model (dwg-converter is outside the pnpm workspace)
+ *   - fix peerDependencies if they incorrectly use link: (must be semver)
  */
 import { access, readFile, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
@@ -117,6 +119,60 @@ function ensureCodepageCopyTarget(content) {
   return { content: lines.join(nl), added: true }
 }
 
+/**
+ * Remove libredwg-web.wasm viteStaticCopy target — private dwg-converter
+ * does not ship that asset.
+ *
+ * @param {string} content
+ * @returns {{ content: string, removed: boolean }}
+ */
+function removeLibreDwgWasmCopyTarget(content) {
+  if (!content.includes('libredwg-web.wasm')) {
+    return { content, removed: false }
+  }
+
+  const nl = content.includes('\r\n') ? '\r\n' : '\n'
+  const lines = content.split(/\r?\n/)
+  const wasmLineIdx = lines.findIndex((line) =>
+    line.includes('libredwg-web.wasm')
+  )
+  if (wasmLineIdx === -1) {
+    return { content, removed: false }
+  }
+
+  // Find the enclosing `{ ... }` object for this target.
+  let startIdx = wasmLineIdx
+  while (startIdx > 0 && !/^[ \t]*\{$/.test(lines[startIdx])) {
+    startIdx--
+  }
+  let endIdx = wasmLineIdx
+  while (endIdx < lines.length && !/^[ \t]*\},?$/.test(lines[endIdx])) {
+    endIdx++
+  }
+  if (endIdx >= lines.length) {
+    return { content, removed: false }
+  }
+
+  // Drop a trailing comma on the previous target if this was the last entry.
+  const nextNonEmpty = lines
+    .slice(endIdx + 1)
+    .find((line) => line.trim() !== '')
+  const removingLast =
+    nextNonEmpty != null && /^[ \t]*\]/.test(nextNonEmpty)
+  if (removingLast) {
+    for (let i = startIdx - 1; i >= 0; i--) {
+      if (lines[i].trim() === '') continue
+      if (lines[i].endsWith(',')) {
+        lines[i] = lines[i].replace(/,$/, '')
+      }
+      break
+    }
+  }
+
+  lines.splice(startIdx, endIdx - startIdx + 1)
+  return { content: lines.join(nl), removed: true }
+}
+
 const changes = []
 
 const indexHtmlPath = path.join(exampleDir, 'index.html')
@@ -151,6 +207,8 @@ const viteConfigPath = path.join(exampleDir, 'vite.config.ts')
   const before = await readFile(viteConfigPath, { encoding: 'utf8' })
   let next = replaceConverterPkg(before)
   const renamed = next !== before
+  const wasmRemoved = removeLibreDwgWasmCopyTarget(next)
+  next = wasmRemoved.content
   const ensured = ensureCodepageCopyTarget(next)
   next = ensured.content
 
@@ -159,6 +217,9 @@ const viteConfigPath = path.join(exampleDir, 'vite.config.ts')
   }
   if (renamed) {
     changes.push(`vite.config.ts: converter package → ${TO_PKG}`)
+  }
+  if (wasmRemoved.removed) {
+    changes.push('vite.config.ts: remove libredwg-web.wasm static copy target')
   }
   if (ensured.added) {
     changes.push('vite.config.ts: add dwg-codepage-*.bin static copy target')
@@ -191,11 +252,8 @@ if (await fileExists(dwgConverterPkgPath)) {
     await updateFile(dwgConverterPkgPath, (content) => {
       const pkg = JSON.parse(content)
       let changed = false
-      for (const section of [
-        'dependencies',
-        'devDependencies',
-        'peerDependencies'
-      ]) {
+      // peerDependencies must be semver / workspace: / catalog: — not link:
+      for (const section of ['dependencies', 'devDependencies']) {
         const deps = pkg[section]
         if (
           deps?.[DATA_MODEL_PKG] != null &&
@@ -205,6 +263,13 @@ if (await fileExists(dwgConverterPkgPath)) {
           changed = true
         }
       }
+      if (
+        pkg.peerDependencies?.[DATA_MODEL_PKG] != null &&
+        pkg.peerDependencies[DATA_MODEL_PKG].startsWith('link:')
+      ) {
+        pkg.peerDependencies[DATA_MODEL_PKG] = '*'
+        changed = true
+      }
       if (!changed) {
         return content
       }
@@ -212,7 +277,7 @@ if (await fileExists(dwgConverterPkgPath)) {
     })
   ) {
     changes.push(
-      `packages/dwg-converter/package.json: ${DATA_MODEL_PKG} → link:../data-model`
+      `packages/dwg-converter/package.json: ${DATA_MODEL_PKG} → link:../data-model (peer: *)`
     )
   }
 }


### PR DESCRIPTION
## Summary
- Add `license_expired` / `license_invalid` codes to `AcDbOpenDatabaseError` and worker responses so callers can distinguish evaluation vs key failures from generic parse errors.
- Prefer structured `DwgConverterLicenseError.code`, then error name, then message markers when classifying thrown license failures.
- Harden `tools/use-dwg-converter.mjs`: drop the LibreDWG wasm static copy target and keep peerDependencies as semver (`*`) instead of `link:`.

## Test plan
- [x] `pnpm test -- packages/data-model/__tests__/AcDbOpenDatabaseError.spec.ts`
- [ ] Open a drawing with an expired evaluation / invalid license key and confirm the surfaced `AcDbOpenDatabaseError.code` is `license_expired` or `license_invalid`
- [ ] Run `pnpm use:dwg-converter` against an example vite config that still copies `libredwg-web.wasm` and confirm the target is removed