### PR TITLE
fix(libredwg-converter): map CMC RGB layer colors when colorIndex is 256

### DIFF
--- a/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
+++ b/packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts
@@ -1,10 +1,14 @@
-import { AcDbDatabase } from '@mlightcad/data-model'
+import { AcCmColorMethod, AcDbDatabase } from '@mlightcad/data-model'
 
 import { AcDbLibreDwgConverter } from '../src/AcDbLibreDwgConverter'
 
 class TestLibreDwgConverter extends AcDbLibreDwgConverter {
   processHeaderPublic(model: any, db: AcDbDatabase) {
     return this.processHeader(model, db)
+  }
+
+  processLayersPublic(model: any, db: AcDbDatabase) {
+    return this.processLayers(model, db)
   }
 }
 
@@ -23,5 +27,103 @@ describe('AcDbLibreDwgConverter', () => {
     )
 
     expect(db.thumbnailImage).toEqual(bytes)
+  })
+
+  it('keeps CMC RGB for layers when libredwg leaves colorIndex at 256', () => {
+    // libredwg-web convertLayer leaves colorIndex=256 for method 0xC2 and puts
+    // the CMC RGB in `color`. Mapping 256 to ByLayer made legend fills white.
+    const db = new AcDbDatabase()
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+
+    converter.processLayersPublic(
+      {
+        tables: {
+          LAYER: {
+            entries: [
+              {
+                name: '0道路填充',
+                handle: '1',
+                ownerHandle: '0',
+                standardFlag: 0,
+                colorIndex: 256,
+                color: 0xff7fbf,
+                lineType: 'Continuous',
+                lineweight: -1,
+                frozen: false,
+                off: false,
+                frozenInNew: false,
+                locked: false,
+                plotFlag: 1
+              },
+              {
+                name: '0草地填充',
+                handle: '2',
+                ownerHandle: '0',
+                standardFlag: 0,
+                colorIndex: 70,
+                color: 0xffffff,
+                lineType: 'Continuous',
+                lineweight: -1,
+                frozen: false,
+                off: false,
+                frozenInNew: false,
+                locked: false,
+                plotFlag: 1
+              }
+            ]
+          }
+        }
+      },
+      db
+    )
+
+    const road = db.tables.layerTable.getAt('0道路填充')
+    expect(road).toBeTruthy()
+    expect(road!.color.colorMethod).toBe(AcCmColorMethod.ByColor)
+    expect(road!.color.RGB).toBe(0xff7fbf)
+    expect(road!.color.isByLayer).toBe(false)
+
+    const grass = db.tables.layerTable.getAt('0草地填充')
+    expect(grass).toBeTruthy()
+    expect(grass!.color.colorIndex).toBe(70)
+  })
+
+  it('keeps ByBlock when colorIndex is 0 even if color defaults to white', () => {
+    // libredwg convertLayer defaults color to 0xffffff; the 0xc3/ByBlock path
+    // only sets colorIndex=0 and leaves that default rgb in place.
+    const db = new AcDbDatabase()
+    const converter = new TestLibreDwgConverter({ useWorker: false })
+
+    converter.processLayersPublic(
+      {
+        tables: {
+          LAYER: {
+            entries: [
+              {
+                name: 'ByBlockLayer',
+                handle: '1',
+                ownerHandle: '0',
+                standardFlag: 0,
+                colorIndex: 0,
+                color: 0xffffff,
+                lineType: 'Continuous',
+                lineweight: -1,
+                frozen: false,
+                off: false,
+                frozenInNew: false,
+                locked: false,
+                plotFlag: 1
+              }
+            ]
+          }
+        }
+      },
+      db
+    )
+
+    const layer = db.tables.layerTable.getAt('ByBlockLayer')
+    expect(layer).toBeTruthy()
+    expect(layer!.color.isByBlock).toBe(true)
+    expect(layer!.color.colorIndex).toBe(0)
   })
 })

--- a/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
+++ b/packages/libredwg-converter/src/AcDbLibreDwgConverter.ts
@@ -212,7 +212,7 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
     const layers = model.tables.LAYER.entries
     layers.forEach(item => {
       const color = new AcCmColor()
-      color.colorIndex = item.colorIndex
+      this.applyLibreLayerColor(color, item)
       const record = new AcDbLayerTableRecord({
         name: item.name,
         standardFlags: item.standardFlag,
@@ -225,6 +225,44 @@ export class AcDbLibreDwgConverter extends AcDbDatabaseConverter<DwgDatabase> {
       this.processCommonTableEntryAttrs(item, record)
       db.tables.layerTable.add(record)
     })
+  }
+
+  /**
+   * Maps a libredwg-web {@link DwgLayerTableEntry} colour onto {@link AcCmColor}.
+   *
+   * `libredwg-web` `convertLayer` leaves `colorIndex` at the ByLayer sentinel
+   * **256** for CMC method `0xC2` while storing the real CMC RGB in `color`.
+   * Layer colours cannot be ByLayer — treating 256 as ByLayer washes legend
+   * solid fills white (same failure mode as dwg-converter's Index/256 bug).
+   */
+  private applyLibreLayerColor(
+    target: AcCmColor,
+    item: {
+      colorIndex?: number
+      color?: number
+      colorName?: string
+    }
+  ) {
+    const aci = item.colorIndex
+    const rgb = item.color
+
+    // ACI 1–255 wins. Check ByBlock (0) before the RGB fallback: libredwg's
+    // convertLayer defaults `color` to 0xffffff even for the 0xc3/ByBlock path,
+    // so treating any finite rgb first would mis-map ByBlock layers to white.
+    if (aci != null && aci >= 1 && aci <= 255) {
+      target.colorIndex = aci
+    } else if (aci === 0) {
+      target.colorIndex = 0
+    } else if (rgb != null && Number.isFinite(rgb)) {
+      // colorIndex 256 (or absent): CMC 0xC2 left the real RGB in `color`.
+      target.setRGBValue(rgb & 0xffffff)
+    } else {
+      target.colorIndex = 256
+    }
+
+    if (item.colorName) {
+      target.colorName = item.colorName
+    }
   }
 
   protected processViewports(model: DwgDatabase, db: AcDbDatabase) {


### PR DESCRIPTION
## Summary
- Fix libredwg layer color mapping when CMC method `0xC2` leaves `colorIndex` at 256 and stores the real RGB in `color` (legend solid fills were washed white).
- Prefer ByBlock (`colorIndex === 0`) over libredwg’s default `color = 0xffffff` so ByBlock layers are not mis-mapped to white.
- Add unit coverage for the CMC RGB and ByBlock layer cases.

## Test plan
- [x] `pnpm exec jest packages/libredwg-converter/__tests__/AcDbLibreDwgConverter.spec.ts`
- [ ] Open a DWG whose layers use true-color / CMC RGB and confirm legend fills match AutoCAD
- [ ] Spot-check ACI-indexed layers still resolve by color index
